### PR TITLE
feat!: move offer technical user profile endpoints

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -593,4 +593,12 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
 
         return appInstanceData.Single();
     }
+        
+    /// <inheritdoc />
+    public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, string iamUserId) =>
+        _offerService.GetTechnicalUserProfilesForOffer(offerId, iamUserId, OfferTypeId.APP);
+
+    /// <inheritdoc />
+    public Task UpdateTechnicalUserProfiles(Guid appId, IEnumerable<TechnicalUserProfileData> data, string iamUserId) =>
+        _offerService.UpdateTechnicalUserProfiles(appId, OfferTypeId.APP, data, iamUserId, _settings.TechnicalUserProfileClient);
 }

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -289,14 +289,6 @@ public class AppsBusinessLogic : IAppsBusinessLogic
         _offerService.GetOfferDocumentContentAsync(appId, documentId, _settings.AppImageDocumentTypeIds, OfferTypeId.APP, cancellationToken);
 
     /// <inheritdoc />
-    public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, string iamUserId) =>
-        _offerService.GetTechnicalUserProfilesForOffer(offerId, iamUserId, OfferTypeId.APP);
-    
-    /// <inheritdoc />
-    public Task UpdateTechnicalUserProfiles(Guid appId, IEnumerable<TechnicalUserProfileData> data, string iamUserId) =>
-        _offerService.UpdateTechnicalUserProfiles(appId, OfferTypeId.APP, data, iamUserId, _settings.TechnicalUserProfileClient);
-
-    /// <inheritdoc />
     public Task<ProviderSubscriptionDetailData> GetSubscriptionDetailForProvider(Guid appId, Guid subscriptionId, string iamUserId) =>
         _offerService.GetSubscriptionDetailsForProviderAsync(appId, subscriptionId, iamUserId, OfferTypeId.APP, _settings.CompanyAdminRoles);
     

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppReleaseBusinessLogic.cs
@@ -189,4 +189,20 @@ public interface IAppReleaseBusinessLogic
     /// <param name="data">the data for the app instance</param>
     /// <param name="iamUserId">the current user</param>
     Task SetInstanceType(Guid appId, AppInstanceSetupData data, string iamUserId);
+        
+    /// <summary>
+    /// Get technical user profiles for a specific offer
+    /// </summary>
+    /// <param name="offerId">Id of the offer</param>
+    /// <param name="iamUserId">Id of the iam user</param>
+    /// <returns>AsyncEnumerable with the technical user profile information</returns>
+    Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, string iamUserId);
+
+    /// <summary>
+    /// Creates or updates the technical user profiles
+    /// </summary>
+    /// <param name="appId">Id of the app</param>
+    /// <param name="data">The technical user profiles</param>
+    /// <param name="iamUserId">Id of the iam user</param>
+    Task UpdateTechnicalUserProfiles(Guid appId, IEnumerable<TechnicalUserProfileData> data, string iamUserId);
 }

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -148,22 +148,6 @@ public interface IAppsBusinessLogic
     /// <param name="cancellationToken"></param>
     /// <returns>byte Array Content</returns>
     Task<(byte[] Content, string ContentType, string FileName)> GetAppDocumentContentAsync(Guid appId, Guid documentId, CancellationToken cancellationToken);
-    
-    /// <summary>
-    /// Get technical user profiles for a specific offer
-    /// </summary>
-    /// <param name="offerId">Id of the offer</param>
-    /// <param name="iamUserId">Id of the iam user</param>
-    /// <returns>AsyncEnumerable with the technical user profile information</returns>
-    Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, string iamUserId);
-    
-    /// <summary>
-    /// Creates or updates the technical user profiles
-    /// </summary>
-    /// <param name="appId">Id of the app</param>
-    /// <param name="data">The technical user profiles</param>
-    /// <param name="iamUserId">Id of the iam user</param>
-    Task UpdateTechnicalUserProfiles(Guid appId, IEnumerable<TechnicalUserProfileData> data, string iamUserId);
 
     /// <summary>
     /// Gets the information for the subscription

--- a/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
@@ -463,4 +463,40 @@ public class AppReleaseProcessController : ControllerBase
         await this.WithIamUserId(iamUserId => _appReleaseBusinessLogic.SetInstanceType(appId, data, iamUserId)).ConfigureAwait(false);
         return NoContent();
     }
+    
+    /// <summary>
+    /// Retrieve the technical user profile information
+    /// </summary>
+    /// <param name="appId">id of the app to receive the technical user profiles for</param>
+    /// <remarks>Example: GET: /api/apps/{appId}/appreleaseprocess/technical-user-profiles</remarks>
+    /// <response code="200">Returns a list of profiles</response>
+    /// <response code="403">Requesting user is not part of the providing company for the service.</response>
+    [HttpGet]
+    [Route("{appId}/technical-user-profiles")]
+    [Authorize(Roles = "add_apps")]
+    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
+    public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfiles([FromRoute] Guid appId) =>
+        this.WithIamUserId(iamUserId => _appReleaseBusinessLogic.GetTechnicalUserProfilesForOffer(appId, iamUserId));
+
+    /// <summary>
+    /// Creates and updates the technical user profiles
+    /// </summary>
+    /// <param name="appId">id of the app to receive the technical user profiles for</param>
+    /// <param name="data">The data for the update of the technical user profile</param>
+    /// <remarks>Example: PUT: /api/apps/appreleaseprocess/{appId}/technical-user-profiles</remarks>
+    /// <response code="200">Returns a list of profiles</response>
+    /// <response code="403">Requesting user is not part of the providing company for the service.</response>
+    [HttpPut]
+    [Route("{appId}/technical-user-profiles")]
+    [Authorize(Roles = "add_apps")]
+    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
+    public async Task<NoContentResult> CreateAndUpdateTechnicalUserProfiles([FromRoute] Guid appId, [FromBody] IEnumerable<TechnicalUserProfileData> data)
+    {
+        await this.WithIamUserId(iamUserId => _appReleaseBusinessLogic.UpdateTechnicalUserProfiles(appId, data, iamUserId)).ConfigureAwait(false);
+        return NoContent();
+    }
 }

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -307,42 +307,6 @@ public class AppsController : ControllerBase
         var (content, contentType, fileName) = await _appsBusinessLogic.GetAppDocumentContentAsync(appId, documentId, cancellationToken).ConfigureAwait(false);
         return File(content, contentType, fileName);
     }
- 
-    /// <summary>
-    /// Retrieve the technical user profile information
-    /// </summary>
-    /// <param name="appId">id of the app to receive the technical user profiles for</param>
-    /// <remarks>Example: GET: /api/apps/{appId}/technical-user-profiles</remarks>
-    /// <response code="200">Returns a list of profiles</response>
-    /// <response code="403">Requesting user is not part of the providing company for the service.</response>
-    [HttpGet]
-    [Route("{appId}/technical-user-profiles")]
-    [Authorize(Roles = "add_apps")]
-    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
-    public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfiles([FromRoute] Guid appId) =>
-        this.WithIamUserId(iamUserId => _appsBusinessLogic.GetTechnicalUserProfilesForOffer(appId, iamUserId));
-
-    /// <summary>
-    /// Creates and updates the technical user profiles
-    /// </summary>
-    /// <param name="appId">id of the app to receive the technical user profiles for</param>
-    /// <param name="data">The data for the update of the technical user profile</param>
-    /// <remarks>Example: GET: /api/apps/{appId}/technical-user-profiles</remarks>
-    /// <response code="200">Returns a list of profiles</response>
-    /// <response code="403">Requesting user is not part of the providing company for the service.</response>
-    [HttpPut]
-    [Route("{appId}/technical-user-profiles")]
-    [Authorize(Roles = "add_apps")]
-    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status204NoContent)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
-    public async Task<NoContentResult> CreateAndUpdateTechnicalUserProfiles([FromRoute] Guid appId, [FromBody] IEnumerable<TechnicalUserProfileData> data)
-    {
-        await this.WithIamUserId(iamUserId => _appsBusinessLogic.UpdateTechnicalUserProfiles(appId, data, iamUserId)).ConfigureAwait(false);
-        return NoContent();
-    }
 
     /// <summary>
     /// Retrieves the details of a subscription

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
@@ -119,22 +119,6 @@ public interface IServiceBusinessLogic
     Task<Pagination.Response<AllOfferStatusData>> GetCompanyProvidedServiceStatusDataAsync(int page, int size, string userId, OfferSorting? sorting, string? offerName, ServiceStatusIdFilter? statusId);
 
     /// <summary>
-    /// Get technical user profiles for a specific offer
-    /// </summary>
-    /// <param name="offerId">Id of the offer</param>
-    /// <param name="iamUserId">Id of the iam user</param>
-    /// <returns>AsyncEnumerable with the technical user profile information</returns>
-    Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, string iamUserId);
-    
-    /// <summary>
-    /// Creates or updates the technical user profiles
-    /// </summary>
-    /// <param name="serviceId">Id of the service</param>
-    /// <param name="data">The technical user profiles</param>
-    /// <param name="iamUserId">Id of the iam user</param>
-    Task UpdateTechnicalUserProfiles(Guid serviceId, IEnumerable<TechnicalUserProfileData> data, string iamUserId);
-
-    /// <summary>
     /// Gets the information for the subscription
     /// </summary>
     /// <param name="serviceId">Id of the app</param>

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceReleaseBusinessLogic.cs
@@ -142,4 +142,20 @@ public interface IServiceReleaseBusinessLogic
     /// <param name="iamUserId"></param>
     /// <returns></returns>
     Task DeleteServiceDocumentsAsync(Guid documentId, string iamUserId);
+
+    /// <summary>
+    /// Get technical user profiles for a specific offer
+    /// </summary>
+    /// <param name="offerId">Id of the offer</param>
+    /// <param name="iamUserId">Id of the iam user</param>
+    /// <returns>AsyncEnumerable with the technical user profile information</returns>
+    Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, string iamUserId);
+    
+    /// <summary>
+    /// Creates or updates the technical user profiles
+    /// </summary>
+    /// <param name="serviceId">Id of the service</param>
+    /// <param name="data">The technical user profiles</param>
+    /// <param name="iamUserId">Id of the iam user</param>
+    Task UpdateTechnicalUserProfiles(Guid serviceId, IEnumerable<TechnicalUserProfileData> data, string iamUserId);
 }

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -203,14 +203,6 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
     }
 
     /// <inheritdoc />
-    public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, string iamUserId) =>
-        _offerService.GetTechnicalUserProfilesForOffer(offerId, iamUserId, OfferTypeId.SERVICE);
-    
-    /// <inheritdoc />
-    public Task UpdateTechnicalUserProfiles(Guid serviceId, IEnumerable<TechnicalUserProfileData> data, string iamUserId) =>
-        _offerService.UpdateTechnicalUserProfiles(serviceId, OfferTypeId.SERVICE, data, iamUserId, _settings.TechnicalUserProfileClient);
-
-    /// <inheritdoc />
     public Task<ProviderSubscriptionDetailData> GetSubscriptionDetailForProvider(Guid serviceId, Guid subscriptionId, string iamUserId) =>
         _offerService.GetSubscriptionDetailsForProviderAsync(serviceId, subscriptionId, iamUserId, OfferTypeId.SERVICE, _settings.CompanyAdminRoles);
 

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
@@ -245,4 +245,12 @@ public class ServiceReleaseBusinessLogic : IServiceReleaseBusinessLogic
     /// <inheritdoc/>
     public Task DeleteServiceDocumentsAsync(Guid documentId, string iamUserId) =>
         _offerService.DeleteDocumentsAsync(documentId, iamUserId, _settings.DeleteDocumentTypeIds, OfferTypeId.SERVICE);
+    
+    /// <inheritdoc />
+    public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, string iamUserId) =>
+        _offerService.GetTechnicalUserProfilesForOffer(offerId, iamUserId, OfferTypeId.SERVICE);
+    
+    /// <inheritdoc />
+    public Task UpdateTechnicalUserProfiles(Guid serviceId, IEnumerable<TechnicalUserProfileData> data, string iamUserId) =>
+        _offerService.UpdateTechnicalUserProfiles(serviceId, OfferTypeId.SERVICE, data, iamUserId, _settings.TechnicalUserProfileClient);
 }

--- a/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
@@ -334,4 +334,40 @@ public class ServiceReleaseController : ControllerBase
         await this.WithIamUserId(iamUserId => _serviceReleaseBusinessLogic.CreateServiceDocumentAsync(serviceId, documentTypeId, document, iamUserId, cancellationToken));
         return NoContent();
     }
+    
+    /// <summary>
+    /// Retrieve the technical user profile information
+    /// </summary>
+    /// <param name="serviceId">id of the service to receive the technical user profiles for</param>
+    /// <remarks>Example: GET: /api/services/servicerelease/{serviceId}/technical-user-profiles</remarks>
+    /// <response code="200">Returns a list of profiles</response>
+    /// <response code="403">Requesting user is not part of the providing company for the service.</response>
+    [HttpGet]
+    [Route("{serviceId}/technical-user-profiles")]
+    [Authorize(Roles = "add_service_offering")]
+    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
+    public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfiles([FromRoute] Guid serviceId) =>
+        this.WithIamUserId(iamUserId => _serviceReleaseBusinessLogic.GetTechnicalUserProfilesForOffer(serviceId, iamUserId));
+
+    /// <summary>
+    /// Creates and updates the technical user profiles
+    /// </summary>
+    /// <param name="serviceId">id of the service to receive the technical user profiles for</param>
+    /// <param name="data">The data for the update of the technical user profile</param>
+    /// <remarks>Example: PUT: /api/services/servicerelease/{serviceId}/technical-user-profiles</remarks>
+    /// <response code="200">Returns a list of profiles</response>
+    /// <response code="403">Requesting user is not part of the providing company for the service.</response>
+    [HttpPut]
+    [Route("{serviceId}/technical-user-profiles")]
+    [Authorize(Roles = "add_service_offering")]
+    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
+    public async Task<NoContentResult> CreateAndUpdateTechnicalUserProfiles([FromRoute] Guid serviceId, [FromBody] IEnumerable<TechnicalUserProfileData> data)
+    {
+        await this.WithIamUserId(iamUserId => _serviceReleaseBusinessLogic.UpdateTechnicalUserProfiles(serviceId, data, iamUserId)).ConfigureAwait(false);
+        return NoContent();
+    }
 }

--- a/src/marketplace/Services.Service/Controllers/ServicesController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServicesController.cs
@@ -222,42 +222,6 @@ public class ServicesController : ControllerBase
         this.WithIamUserId(userId =>_serviceBusinessLogic.GetCompanyProvidedServiceStatusDataAsync(page, size, userId, sorting, offerName, statusId));
 
     /// <summary>
-    /// Retrieve the technical user profile information
-    /// </summary>
-    /// <param name="serviceId">id of the service to receive the technical user profiles for</param>
-    /// <remarks>Example: GET: /api/services/{serviceId}/technical-user-profiles</remarks>
-    /// <response code="200">Returns a list of profiles</response>
-    /// <response code="403">Requesting user is not part of the providing company for the service.</response>
-    [HttpGet]
-    [Route("{serviceId}/technical-user-profiles")]
-    [Authorize(Roles = "add_service_offering")]
-    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
-    public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfiles([FromRoute] Guid serviceId) =>
-        this.WithIamUserId(iamUserId => _serviceBusinessLogic.GetTechnicalUserProfilesForOffer(serviceId, iamUserId));
-
-    /// <summary>
-    /// Creates and updates the technical user profiles
-    /// </summary>
-    /// <param name="serviceId">id of the service to receive the technical user profiles for</param>
-    /// <param name="data">The data for the update of the technical user profile</param>
-    /// <remarks>Example: GET: /api/services/{serviceId}/technical-user-profiles</remarks>
-    /// <response code="200">Returns a list of profiles</response>
-    /// <response code="403">Requesting user is not part of the providing company for the service.</response>
-    [HttpPut]
-    [Route("{serviceId}/technical-user-profiles")]
-    [Authorize(Roles = "add_service_offering")]
-    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status204NoContent)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
-    public async Task<NoContentResult> CreateAndUpdateTechnicalUserProfiles([FromRoute] Guid serviceId, [FromBody] IEnumerable<TechnicalUserProfileData> data)
-    {
-        await this.WithIamUserId(iamUserId => _serviceBusinessLogic.UpdateTechnicalUserProfiles(serviceId, data, iamUserId)).ConfigureAwait(false);
-        return NoContent();
-    }
-    
-    /// <summary>
     /// Retrieves the details of a subscription
     /// </summary>
     /// <param name="serviceId">id of the service to receive the details for</param>

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
@@ -553,49 +553,6 @@ public class AppBusinessLogicTests
 
     #endregion
 
-    #region GetTechnicalUserProfilesForOffer
-
-    [Fact]
-    public async Task GetTechnicalUserProfilesForOffer_ReturnsExpected()
-    {
-        // Arrange
-        var appId = Guid.NewGuid();
-        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(appId, IamUserId, OfferTypeId.APP))
-            .Returns(_fixture.CreateMany<TechnicalUserProfileInformation>(5));
-        var sut = new AppsBusinessLogic(null!, null!, _offerService, null!, Options.Create(new AppsSettings()), null!);
-
-        // Act
-        var result = await sut.GetTechnicalUserProfilesForOffer(appId, IamUserId)
-            .ConfigureAwait(false);
-
-        result.Should().HaveCount(5);
-    }
-
-    #endregion
-
-    #region UpdateTechnicalUserProfiles
-
-    [Fact]
-    public async Task UpdateTechnicalUserProfiles_ReturnsExpected()
-    {
-        // Arrange
-        const string clientProfile = "cl";
-        var appId = Guid.NewGuid();
-        var data = _fixture.CreateMany<TechnicalUserProfileData>(5);
-        var sut = new AppsBusinessLogic(null!, null!, _offerService, null!, Options.Create(new AppsSettings{TechnicalUserProfileClient = clientProfile}), null!);
-
-        // Act
-        await sut
-            .UpdateTechnicalUserProfiles(appId, data, IamUserId)
-            .ConfigureAwait(false);
-
-        A.CallTo(() => _offerService.UpdateTechnicalUserProfiles(appId, OfferTypeId.APP,
-                A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5), IamUserId, clientProfile))
-            .MustHaveHappenedOnceExactly();
-    }
-
-    #endregion
-
     #region GetSubscriptionDetailForProvider
 
     [Fact]

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -1119,6 +1119,49 @@ public class AppReleaseBusinessLogicTest
 
     #endregion
 
+    #region UpdateTechnicalUserProfiles
+
+    [Fact]
+    public async Task UpdateTechnicalUserProfiles_ReturnsExpected()
+    {
+        // Arrange
+        const string clientProfile = "cl";
+        var appId = Guid.NewGuid();
+        var data = _fixture.CreateMany<TechnicalUserProfileData>(5);
+        var sut = new AppReleaseBusinessLogic(null!,  Options.Create(new AppsSettings{TechnicalUserProfileClient = clientProfile}), _offerService, null!);
+
+        // Act
+        await sut
+            .UpdateTechnicalUserProfiles(appId, data, IamUserId)
+            .ConfigureAwait(false);
+
+        A.CallTo(() => _offerService.UpdateTechnicalUserProfiles(appId, OfferTypeId.APP,
+                A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5), IamUserId, clientProfile))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    #endregion
+
+    #region GetTechnicalUserProfilesForOffer
+
+    [Fact]
+    public async Task GetTechnicalUserProfilesForOffer_ReturnsExpected()
+    {
+        // Arrange
+        var appId = Guid.NewGuid();
+        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(appId, IamUserId, OfferTypeId.APP))
+            .Returns(_fixture.CreateMany<TechnicalUserProfileInformation>(5));
+        var sut = new AppReleaseBusinessLogic(null!, Options.Create(new AppsSettings()), _offerService, null!);
+
+        // Act
+        var result = await sut.GetTechnicalUserProfilesForOffer(appId, IamUserId)
+            .ConfigureAwait(false);
+
+        result.Should().HaveCount(5);
+    }
+
+    #endregion
+
     #region Setup
 
     private void SetupUpdateApp()

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppReleaseProcessControllerTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppReleaseProcessControllerTest.cs
@@ -410,4 +410,37 @@ public class AppReleaseProcessControllerTest
         A.CallTo(() => _logic.SetInstanceType(appId, data, IamUserId))
             .MustHaveHappenedOnceExactly();
     }
+    
+    [Fact]
+    public async Task GetTechnicalUserProfiles_ReturnsExpectedCount()
+    {
+        //Arrange
+        var offerId = Guid.NewGuid();
+        
+        var data = _fixture.CreateMany<TechnicalUserProfileInformation>(5);
+        A.CallTo(() => _logic.GetTechnicalUserProfilesForOffer(offerId, IamUserId))
+            .Returns(data);
+
+        //Act
+        var result = await this._controller.GetTechnicalUserProfiles(offerId).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.GetTechnicalUserProfilesForOffer(offerId, IamUserId)).MustHaveHappenedOnceExactly();
+        result.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task UpdateTechnicalUserProfiles_ReturnsExpectedCount()
+    {
+        //Arrange
+        var offerId = Guid.NewGuid();
+        var data = _fixture.CreateMany<TechnicalUserProfileData>(5);
+
+        //Act
+        var result = await this._controller.CreateAndUpdateTechnicalUserProfiles(offerId, data).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.UpdateTechnicalUserProfiles(offerId, A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5),IamUserId)).MustHaveHappenedOnceExactly();
+        result.Should().BeOfType<NoContentResult>();
+    }
 }

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
@@ -329,39 +329,6 @@ public class AppsControllerTests
         //Assert
         A.CallTo(() => _logic.GetAppDocumentContentAsync(A<Guid>._, A<Guid>._, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
     }
-  
-    [Fact]
-    public async Task GetTechnicalUserProfiles_ReturnsExpectedCount()
-    {
-        //Arrange
-        var offerId = Guid.NewGuid();
-        
-        var data = _fixture.CreateMany<TechnicalUserProfileInformation>(5);
-        A.CallTo(() => _logic.GetTechnicalUserProfilesForOffer(offerId, IamUserId))
-            .Returns(data);
-
-        //Act
-        var result = await this._controller.GetTechnicalUserProfiles(offerId).ConfigureAwait(false);
-
-        //Assert
-        A.CallTo(() => _logic.GetTechnicalUserProfilesForOffer(offerId, IamUserId)).MustHaveHappenedOnceExactly();
-        result.Should().HaveCount(5);
-    }
-    
-    [Fact]
-    public async Task UpdateTechnicalUserProfiles_ReturnsExpectedCount()
-    {
-        //Arrange
-        var offerId = Guid.NewGuid();
-        var data = _fixture.CreateMany<TechnicalUserProfileData>(5);
-
-        //Act
-        var result = await this._controller.CreateAndUpdateTechnicalUserProfiles(offerId, data).ConfigureAwait(false);
-
-        //Assert
-        A.CallTo(() => _logic.UpdateTechnicalUserProfiles(offerId, A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5),IamUserId)).MustHaveHappenedOnceExactly();
-        result.Should().BeOfType<NoContentResult>();
-    }
 
     [Fact]
     public async Task GetSubscriptionDetailForProvider_ReturnsExpected()

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
@@ -580,47 +580,6 @@ public class ServiceBusinessLogicTests
 
     #endregion
 
-    #region GetTechnicalUserProfilesForOffer
-
-    [Fact]
-    public async Task GetTechnicalUserProfilesForOffer_ReturnsExpected()
-    {
-        // Arrange
-        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(_existingServiceId, _iamUser.UserEntityId, OfferTypeId.SERVICE))
-            .Returns(_fixture.CreateMany<TechnicalUserProfileInformation>(5));
-        var sut = new ServiceBusinessLogic(null!, _offerService, null!, null!, Options.Create(new ServiceSettings()));
-
-        // Act
-        var result = await sut.GetTechnicalUserProfilesForOffer(_existingServiceId, _iamUser.UserEntityId)
-            .ConfigureAwait(false);
-
-        result.Should().HaveCount(5);
-    }
-
-    #endregion
-
-    #region UpdateTechnicalUserProfiles
-
-    [Fact]
-    public async Task UpdateTechnicalUserProfiles_ReturnsExpected()
-    {
-        // Arrange
-        const string clientProfile = "cl";
-        var data = _fixture.CreateMany<TechnicalUserProfileData>(5);
-        var sut = new ServiceBusinessLogic(null!, _offerService, null!, null!, Options.Create(new ServiceSettings{TechnicalUserProfileClient = clientProfile}));
-
-        // Act
-        await sut
-            .UpdateTechnicalUserProfiles(_existingServiceId, data, _iamUser.UserEntityId)
-            .ConfigureAwait(false);
-
-        A.CallTo(() => _offerService.UpdateTechnicalUserProfiles(_existingServiceId, OfferTypeId.SERVICE,
-                A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5), _iamUser.UserEntityId, clientProfile))
-            .MustHaveHappenedOnceExactly();
-    }
-
-    #endregion
-    
     #region GetSubscriptionDetailForProvider
 
     [Fact]

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
@@ -567,6 +567,47 @@ public class ServiceReleaseBusinessLogicTest
 
     #endregion
 
+    #region GetTechnicalUserProfilesForOffer
+
+    [Fact]
+    public async Task GetTechnicalUserProfilesForOffer_ReturnsExpected()
+    {
+        // Arrange
+        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(_existingServiceId, _iamUserId, OfferTypeId.SERVICE))
+            .Returns(_fixture.CreateMany<TechnicalUserProfileInformation>(5));
+        var sut = new ServiceReleaseBusinessLogic(null!, _offerService, Options.Create(new ServiceSettings()));
+
+        // Act
+        var result = await sut.GetTechnicalUserProfilesForOffer(_existingServiceId, _iamUserId)
+            .ConfigureAwait(false);
+
+        result.Should().HaveCount(5);
+    }
+
+    #endregion
+
+    #region UpdateTechnicalUserProfiles
+
+    [Fact]
+    public async Task UpdateTechnicalUserProfiles_ReturnsExpected()
+    {
+        // Arrange
+        const string clientProfile = "cl";
+        var data = _fixture.CreateMany<TechnicalUserProfileData>(5);
+        var sut = new ServiceReleaseBusinessLogic(null!, _offerService, Options.Create(new ServiceSettings{TechnicalUserProfileClient = clientProfile}));
+
+        // Act
+        await sut
+            .UpdateTechnicalUserProfiles(_existingServiceId, data, _iamUserId)
+            .ConfigureAwait(false);
+
+        A.CallTo(() => _offerService.UpdateTechnicalUserProfiles(_existingServiceId, OfferTypeId.SERVICE,
+                A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5), _iamUserId, clientProfile))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    #endregion
+
     private void SetupUpdateService()
     {
         A.CallTo(() => _offerRepository.GetServiceUpdateData(_notExistingServiceId, A<IEnumerable<ServiceTypeId>>._, _iamUserId))

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
@@ -238,39 +238,6 @@ public class ServiceControllerTest
         A.CallTo(() => _logic.GetCompanyProvidedServiceStatusDataAsync(0, 15,IamUserId, null, null,null)).MustHaveHappenedOnceExactly();
         result.Content.Should().HaveCount(5);
     }
-    
-    [Fact]
-    public async Task GetTechnicalUserProfiles_ReturnsExpectedCount()
-    {
-        //Arrange
-        var offerId = Guid.NewGuid();
-        
-        var data = _fixture.CreateMany<TechnicalUserProfileInformation>(5);
-        A.CallTo(() => _logic.GetTechnicalUserProfilesForOffer(offerId, IamUserId))
-            .Returns(data);
-
-        //Act
-        var result = await this._controller.GetTechnicalUserProfiles(offerId).ConfigureAwait(false);
-
-        //Assert
-        A.CallTo(() => _logic.GetTechnicalUserProfilesForOffer(offerId, IamUserId)).MustHaveHappenedOnceExactly();
-        result.Should().HaveCount(5);
-    }
-    
-    [Fact]
-    public async Task UpdateTechnicalUserProfiles_ReturnsExpectedCount()
-    {
-        //Arrange
-        var offerId = Guid.NewGuid();
-        var data = _fixture.CreateMany<TechnicalUserProfileData>(5);
-
-        //Act
-        var result = await this._controller.CreateAndUpdateTechnicalUserProfiles(offerId, data).ConfigureAwait(false);
-
-        //Assert
-        A.CallTo(() => _logic.UpdateTechnicalUserProfiles(offerId, A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5),IamUserId)).MustHaveHappenedOnceExactly();
-        result.Should().BeOfType<NoContentResult>();
-    }
 
     [Fact]
     public async Task GetSubscriptionDetailForProvider_ReturnsExpected()

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceReleaseControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceReleaseControllerTest.cs
@@ -288,4 +288,37 @@ public class ServiceReleaseControllerTest
         A.CallTo(() => _logic.CreateServiceDocumentAsync(serviceId,
             DocumentTypeId.ADDITIONAL_DETAILS, file, IamUserId, CancellationToken.None)).MustHaveHappened();
     }
+    
+    [Fact]
+    public async Task GetTechnicalUserProfiles_ReturnsExpectedCount()
+    {
+        //Arrange
+        var offerId = Guid.NewGuid();
+        
+        var data = _fixture.CreateMany<TechnicalUserProfileInformation>(5);
+        A.CallTo(() => _logic.GetTechnicalUserProfilesForOffer(offerId, IamUserId))
+            .Returns(data);
+
+        //Act
+        var result = await this._controller.GetTechnicalUserProfiles(offerId).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.GetTechnicalUserProfilesForOffer(offerId, IamUserId)).MustHaveHappenedOnceExactly();
+        result.Should().HaveCount(5);
+    }
+    
+    [Fact]
+    public async Task UpdateTechnicalUserProfiles_ReturnsExpectedCount()
+    {
+        //Arrange
+        var offerId = Guid.NewGuid();
+        var data = _fixture.CreateMany<TechnicalUserProfileData>(5);
+
+        //Act
+        var result = await this._controller.CreateAndUpdateTechnicalUserProfiles(offerId, data).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.UpdateTechnicalUserProfiles(offerId, A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5),IamUserId)).MustHaveHappenedOnceExactly();
+        result.Should().BeOfType<NoContentResult>();
+    }
 }


### PR DESCRIPTION
## Description

the following endpoints have been moved from /api/apps/ to:
- GET: /api/apps/appreleaseprocess/{appId}/technical-user-profiles
- PUT: /api/apps/appreleaseprocess/{appId}/technical-user-profiles the following endpoints have been moved from /api/services/ to:
- GET: /api/services/servicerelease/{serviceId}/technical-user-profiles
- PUT: /api/services/servicerelease/{serviceId}/technical-user-profiles fix: swagger documentation edited for put endpoints

## Why

endpoints were located in incorrect controller not belonging to the the app creation process

## Issue

Jira-ticket CPLP-2719 (no Github issue yet).

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
