### PR TITLE
Fix(offerService) : setting documentStatus to Pending Status

### DIFF
--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -562,7 +562,7 @@ public class OfferService : IOfferService
                     declineData.ActiveDocumentStatusDatas.Select(x => new ValueTuple<Guid, Action<Document>?, Action<Document>>(
                         x.DocumentId,
                         document => document.DocumentStatusId = x.StatusId,
-                        document => document.DocumentStatusId = DocumentStatusId.INACTIVE)));
+                        document => document.DocumentStatusId = DocumentStatusId.PENDING)));
         }
         var requesterId = await _portalRepositories.GetInstance<IUserRepository>()
             .GetCompanyUserIdForIamUserUntrackedAsync(iamUserId).ConfigureAwait(false);

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -1231,8 +1231,8 @@ public class OfferServiceTests
             x => x.Id == documentStatusDatas.ElementAt(0).DocumentId && x.DocumentStatusId == DocumentStatusId.LOCKED,
             x => x.Id == documentStatusDatas.ElementAt(1).DocumentId && x.DocumentStatusId == DocumentStatusId.PENDING);
         modified.Should().HaveCount(2).And.Satisfy(
-            x => x.Id == documentStatusDatas.ElementAt(0).DocumentId && x.DocumentStatusId == DocumentStatusId.INACTIVE,
-            x => x.Id == documentStatusDatas.ElementAt(1).DocumentId && x.DocumentStatusId == DocumentStatusId.INACTIVE);
+            x => x.Id == documentStatusDatas.ElementAt(0).DocumentId && x.DocumentStatusId == DocumentStatusId.PENDING,
+            x => x.Id == documentStatusDatas.ElementAt(1).DocumentId && x.DocumentStatusId == DocumentStatusId.PENDING);
     }
 
     #endregion


### PR DESCRIPTION
Ref: CPLP-2799

## Description

Fix(offerService) : setting documentStatus to Pending Status

## Why

when the declineService or declineApp endpoint triggered the documentStatus set to INACTIVE, instead to PENDING.
 

## Issue

[CPLP-2799](https://jira.catena-x.net/browse/CPLP-2799)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
