### PR TITLE
chore: remove asp.net dependencies from process worker

### DIFF
--- a/src/externalsystems/OfferProvider.Library/OfferProvider.Library.csproj
+++ b/src/externalsystems/OfferProvider.Library/OfferProvider.Library.csproj
@@ -36,10 +36,4 @@
         <ProjectReference Include="..\..\portalbackend\PortalBackend.DBAccess\PortalBackend.DBAccess.csproj" />
         <ProjectReference Include="..\..\provisioning\Provisioning.Library\Provisioning.Library.csproj" />
     </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-        <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-    </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Nuget Packages with a reference to asp.net has been removed from dependent projects of the process worker

## Why

to use a leaner base image the process worker must not have any references to asp.net

## Issue

N/A - Jira Ticket:  CPLP-2344

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes