### PR TITLE
feat(serviceaccount):- Delete  serviceaccount

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -102,7 +102,7 @@ public class ServiceAccountBusinessLogic : IServiceAccountBusinessLogic
         {
             throw new ConflictException($"serviceAccount {serviceAccountId} not found for company {companyId}");
         }
-        if(result.statusId == ConnectorStatusId.ACTIVE || result.statusId == ConnectorStatusId.PENDING)
+        if (result.statusId == ConnectorStatusId.ACTIVE || result.statusId == ConnectorStatusId.PENDING)
         {
             throw new ConflictException($"Technical User is linked to an active connector. Change the link or deactivate the connector to delete the technical user.");
         }

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -102,6 +102,10 @@ public class ServiceAccountBusinessLogic : IServiceAccountBusinessLogic
         {
             throw new ConflictException($"serviceAccount {serviceAccountId} not found for company {companyId}");
         }
+        if(result.statusId == ConnectorStatusId.ACTIVE || result.statusId == ConnectorStatusId.PENDING)
+        {
+            throw new ConflictException($"Technical User is linked to an active connector. Change the link or deactivate the connector to delete the technical user.");
+        }
 
         _portalRepositories.GetInstance<IUserRepository>().AttachAndModifyIdentity(serviceAccountId, null, i =>
         {

--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -77,12 +77,14 @@ public class ServiceAccountController : ControllerBase
     /// <remarks>Example: DELETE: api/administration/serviceaccount/owncompany/serviceaccounts/7e85a0b8-0001-ab67-10d1-0ef508201000</remarks>
     /// <response code="200">Successful if the service account was deleted.</response>
     /// <response code="404">Record was not found. Service account is either not existing or not connected to the respective company.</response>
+    /// <response code="409">Technical User is linked to an active connector. Change the link or deactivate the connector to delete the technical user.</response>
     [HttpDelete]
     [Authorize(Roles = "delete_tech_user_management")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("owncompany/serviceaccounts/{serviceAccountId}")]
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
     public Task<int> DeleteServiceAccount([FromRoute] Guid serviceAccountId) =>
         this.WithCompanyId(companyId => _logic.DeleteOwnCompanyServiceAccountAsync(serviceAccountId, companyId));
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
@@ -37,7 +37,7 @@ public interface IServiceAccountRepository
 
     void AttachAndModifyCompanyServiceAccount(Guid id, Action<CompanyServiceAccount>? initialize, Action<CompanyServiceAccount> modify);
     Task<CompanyServiceAccountWithRoleDataClientId?> GetOwnCompanyServiceAccountWithIamClientIdAsync(Guid serviceAccountId, Guid userCompanyId);
-    Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId, ConnectorStatusId statusId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId);
+    Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId, ConnectorStatusId? statusId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId);
     Task<CompanyServiceAccountDetailedData?> GetOwnCompanyServiceAccountDetailedDataUntrackedAsync(Guid serviceAccountId, Guid companyId);
     Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnCompanyServiceAccountsUntracked(Guid userCompanyId);
     Task<bool> CheckActiveServiceAccountExistsForCompanyAsync(Guid technicalUserId, Guid companyId);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
@@ -37,7 +37,7 @@ public interface IServiceAccountRepository
 
     void AttachAndModifyCompanyServiceAccount(Guid id, Action<CompanyServiceAccount>? initialize, Action<CompanyServiceAccount> modify);
     Task<CompanyServiceAccountWithRoleDataClientId?> GetOwnCompanyServiceAccountWithIamClientIdAsync(Guid serviceAccountId, Guid userCompanyId);
-    Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId);
+    Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId, ConnectorStatusId statusId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId);
     Task<CompanyServiceAccountDetailedData?> GetOwnCompanyServiceAccountDetailedDataUntrackedAsync(Guid serviceAccountId, Guid companyId);
     Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnCompanyServiceAccountsUntracked(Guid userCompanyId);
     Task<bool> CheckActiveServiceAccountExistsForCompanyAsync(Guid technicalUserId, Guid companyId);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -96,13 +96,13 @@ public class ServiceAccountRepository : IServiceAccountRepository
                             userRole.UserRoleText))))
             .SingleOrDefaultAsync();
 
-    public Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId, ConnectorStatusId statusId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId) =>
+    public Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId, ConnectorStatusId? statusId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId) =>
         _dbContext.CompanyServiceAccounts
             .Where(serviceAccount =>
                 serviceAccount.Id == serviceAccountId &&
                 serviceAccount.Identity!.UserStatusId == UserStatusId.ACTIVE &&
                 serviceAccount.Identity!.CompanyId == companyId)
-            .Select(sa => new ValueTuple<IEnumerable<Guid>, Guid?, string?, ConnectorStatusId>(
+            .Select(sa => new ValueTuple<IEnumerable<Guid>, Guid?, string?, ConnectorStatusId?>(
                 sa.Identity!.IdentityAssignedRoles.Select(r => r.UserRoleId),
                 sa.Connector!.Id,
                 sa.ClientId,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -96,16 +96,17 @@ public class ServiceAccountRepository : IServiceAccountRepository
                             userRole.UserRoleText))))
             .SingleOrDefaultAsync();
 
-    public Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId) =>
+    public Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId, ConnectorStatusId statusId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId) =>
         _dbContext.CompanyServiceAccounts
             .Where(serviceAccount =>
                 serviceAccount.Id == serviceAccountId &&
                 serviceAccount.Identity!.UserStatusId == UserStatusId.ACTIVE &&
                 serviceAccount.Identity!.CompanyId == companyId)
-            .Select(sa => new ValueTuple<IEnumerable<Guid>, Guid?, string?>(
+            .Select(sa => new ValueTuple<IEnumerable<Guid>, Guid?, string?, ConnectorStatusId>(
                 sa.Identity!.IdentityAssignedRoles.Select(r => r.UserRoleId),
                 sa.Connector!.Id,
-                sa.ClientId))
+                sa.ClientId,
+                sa.Connector!.StatusId))
             .SingleOrDefaultAsync();
 
     public Task<CompanyServiceAccountDetailedData?> GetOwnCompanyServiceAccountDetailedDataUntrackedAsync(Guid serviceAccountId, Guid companyId) =>


### PR DESCRIPTION
## Description

Map ServiceAccount Deletion to Connector and throw exception message if connectorstatus is pending or  active

## Why

To ensure that service account deletion will happen only when connector is in inactive state

## Issue
https://jira.catena-x.net/browse/CPLP-2778

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
-- [ ] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
