### PR TITLE
fix(app & services):- get technical user profile

### DIFF
--- a/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
@@ -484,7 +484,7 @@ public class AppReleaseProcessController : ControllerBase
     }
 
     /// <summary>
-    /// Retrieve the technical user profile information
+    /// Retrieve app specific stored technical user profile configured to get created if a related app subscription is getting activated.
     /// </summary>
     /// <param name="appId">id of the app to receive the technical user profiles for</param>
     /// <remarks>Example: GET: /api/apps/{appId}/appreleaseprocess/technical-user-profiles</remarks>
@@ -494,7 +494,7 @@ public class AppReleaseProcessController : ControllerBase
     [Route("{appId}/technical-user-profiles")]
     [Authorize(Roles = "add_apps")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
-    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(IEnumerable<TechnicalUserProfileInformation>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfiles([FromRoute] Guid appId) =>
         this.WithCompanyId(companyId => _appReleaseBusinessLogic.GetTechnicalUserProfilesForOffer(appId, companyId));

--- a/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
@@ -348,17 +348,17 @@ public class ServiceReleaseController : ControllerBase
     }
 
     /// <summary>
-    /// Retrieve the technical user profile information
+    /// Retrieve service specific stored technical user profile configured to get created if a related service subscription is getting activated.
     /// </summary>
     /// <param name="serviceId">id of the service to receive the technical user profiles for</param>
     /// <remarks>Example: GET: /api/services/servicerelease/{serviceId}/technical-user-profiles</remarks>
-    /// <response code="200">Returns a list of profiles</response>
+    /// <response code="200">Returns a list of Technical User profiles</response>
     /// <response code="403">Requesting user is not part of the providing company for the service.</response>
     [HttpGet]
     [Route("{serviceId}/technical-user-profiles")]
     [Authorize(Roles = "add_service_offering")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
-    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(IEnumerable<TechnicalUserProfileInformation>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfiles([FromRoute] Guid serviceId) =>
         this.WithCompanyId(companyId => _serviceReleaseBusinessLogic.GetTechnicalUserProfilesForOffer(serviceId, companyId));


### PR DESCRIPTION
## Description

Swagger clean up of technical user profile endpoint for app and services.

## Why
swagger documentation was missing the response body.

## Issue

https://jira.catena-x.net/browse/CPLP-2809.

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

