### PR TITLE
fix(identity): add policy handler registration

### DIFF
--- a/src/framework/Framework.Web/StartupServiceExtensions.cs
+++ b/src/framework/Framework.Web/StartupServiceExtensions.cs
@@ -20,6 +20,7 @@
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Authorization;
@@ -69,7 +70,8 @@ public static class StartupServiceExtensions
                 };
             }
         });
-
+        services.AddTransient<IAuthorizationHandler, MandatoryClaimHandler>();
+        services.AddTransient<IAuthorizationHandler, MandatoryEnumTypeClaimHandler>();
         services.AddAuthorization(options =>
         {
             options.AddPolicy(PolicyTypes.ValidIdentity, policy => policy.Requirements.Add(new MandatoryGuidClaimRequirement(PortalClaimTypes.IdentityId)));


### PR DESCRIPTION
## Description

registration added for newly introduced auth handlers

## Why

the newly created enumTypeClaimHandler and GuidClaimHandler were not registered correctly, thus a user will always get a 403.

## Issue

N/A - Jira Issue: CPLP-2553


## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
