### PR TITLE
fix(invitation): fix application association check

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -300,10 +300,10 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
         switch ((dapsRegistrationSuccess ?? false, connectorStatus))
         {
             case (true, ConnectorStatusId.ACTIVE) when selfDescriptionDocumentId == null:
-                await DeleteUpdateConnectorDetail(connectorId, userId, cancellationToken, dapsClientId, connectorsRepository);
+                await DeleteUpdateConnectorDetail(connectorId, userId, dapsClientId, connectorsRepository, cancellationToken);
                 break;
             case (true, ConnectorStatusId.ACTIVE) when selfDescriptionDocumentId != null && documentStatus != null:
-                await DeleteConnector(connectorId, userId, cancellationToken, dapsClientId, selfDescriptionDocumentId.Value, documentStatus.Value, connectorsRepository);
+                await DeleteConnector(connectorId, userId, dapsClientId, selfDescriptionDocumentId.Value, documentStatus.Value, connectorsRepository, cancellationToken);
                 break;
             case (false, ConnectorStatusId.PENDING) when selfDescriptionDocumentId == null:
                 await DeleteConnectorWithoutDocuments(connectorId, connectorsRepository);
@@ -318,17 +318,17 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
         }
     }
 
-    private async Task DeleteConnector(Guid connectorId, Guid userId, CancellationToken cancellationToken, string? dapsClientId, Guid selfDescriptionDocumentId, DocumentStatusId documentStatus, IConnectorsRepository connectorsRepository)
+    private async Task DeleteConnector(Guid connectorId, Guid userId, string? dapsClientId, Guid selfDescriptionDocumentId, DocumentStatusId documentStatus, IConnectorsRepository connectorsRepository, CancellationToken cancellationToken)
     {
         _portalRepositories.GetInstance<IDocumentRepository>().AttachAndModifyDocument(
             selfDescriptionDocumentId,
             a => { a.DocumentStatusId = documentStatus; },
             a => { a.DocumentStatusId = DocumentStatusId.INACTIVE; });
 
-        await DeleteUpdateConnectorDetail(connectorId, userId, cancellationToken, dapsClientId, connectorsRepository);
+        await DeleteUpdateConnectorDetail(connectorId, userId, dapsClientId, connectorsRepository, cancellationToken);
     }
 
-    private async Task DeleteUpdateConnectorDetail(Guid connectorId, Guid userId, CancellationToken cancellationToken, string? dapsClientId, IConnectorsRepository connectorsRepository)
+    private async Task DeleteUpdateConnectorDetail(Guid connectorId, Guid userId, string? dapsClientId, IConnectorsRepository connectorsRepository, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(dapsClientId))
         {

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -455,14 +455,14 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
         return InviteNewUserInternalAsync(applicationId, userCreationInfo, userId);
     }
 
-    private async Task<int> InviteNewUserInternalAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo, Guid companyUserId)
+    private async Task<int> InviteNewUserInternalAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo, Guid userId)
     {
-        if (await _portalRepositories.GetInstance<IUserRepository>().IsOwnCompanyUserWithEmailExisting(userCreationInfo.eMail, companyUserId))
+        if (await _portalRepositories.GetInstance<IUserRepository>().IsOwnCompanyUserWithEmailExisting(userCreationInfo.eMail, userId))
         {
             throw new ControllerArgumentException($"user with email {userCreationInfo.eMail} does already exist");
         }
 
-        var (companyNameIdpAliasData, createdByName) = await _userProvisioningService.GetCompanyNameSharedIdpAliasData(companyUserId, applicationId).ConfigureAwait(false);
+        var (companyNameIdpAliasData, createdByName) = await _userProvisioningService.GetCompanyNameSharedIdpAliasData(userId, applicationId).ConfigureAwait(false);
 
         IEnumerable<UserRoleData>? userRoleDatas = null;
 

--- a/src/registration/Registration.Service/Controllers/RegistrationController.cs
+++ b/src/registration/Registration.Service/Controllers/RegistrationController.cs
@@ -286,15 +286,14 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Controllers
         /// <response code="502">Service Unavailable.</response>
         [HttpPost]
         [Authorize(Roles = "invite_user")]
-        [Authorize(Policy = PolicyTypes.ValidCompany)]
+        [Authorize(Policy = PolicyTypes.ValidIdentity)]
         [Route("application/{applicationId}/inviteNewUser")]
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status502BadGateway)]
         public Task<int> InviteNewUserAsync([FromRoute] Guid applicationId, [FromBody] UserCreationInfoWithMessage userCreationInfo) =>
-            this.WithCompanyId(companyId =>
-                _registrationBusinessLogic.InviteNewUserAsync(applicationId, userCreationInfo, companyId));
+            this.WithUserId(userId => _registrationBusinessLogic.InviteNewUserAsync(applicationId, userCreationInfo, userId));
 
         /// <summary>
         /// Post the agreement consent status for the given application.

--- a/tests/registration/Registration.Service.Tests/Controller/RegistrationControllerTest.cs
+++ b/tests/registration/Registration.Service.Tests/Controller/RegistrationControllerTest.cs
@@ -184,8 +184,7 @@ public class RegistrationControllerTest
         A.CallTo(() => _registrationBusinessLogicFake.GetRegistrationDocumentAsync(documentId)).MustHaveHappenedOnceExactly();
         result.Should().NotBeNull();
     }
-    
-    
+
     [Fact]
     public async Task InviteNewUserAsync_WithValidData_ReturnsExpected()
     {

--- a/tests/registration/Registration.Service.Tests/Controller/RegistrationControllerTest.cs
+++ b/tests/registration/Registration.Service.Tests/Controller/RegistrationControllerTest.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Registration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Controllers;
 using Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Model;
@@ -116,7 +117,7 @@ public class RegistrationControllerTest
         var applicationId = _fixture.Create<Guid>();
         var data = _fixture.Create<CompanyRoleAgreementConsents>();
         A.CallTo(() => _registrationBusinessLogicFake.SubmitRoleConsentAsync(applicationId, data, _identity.UserId, _identity.CompanyId))
-            .ReturnsLazily(() => 1);
+            .Returns(1);
 
         //Act
         var result = await this._controller.SubmitCompanyRoleConsentToAgreementsAsync(applicationId, data).ConfigureAwait(false);
@@ -133,7 +134,7 @@ public class RegistrationControllerTest
         var applicationId = _fixture.Create<Guid>();
         var data = _fixture.CreateMany<UniqueIdentifierData>(1);
         A.CallTo(() => _registrationBusinessLogicFake.GetCompanyIdentifiers("DE"))
-            .ReturnsLazily(() => data);
+            .Returns(data);
 
         //Act
         var result = await this._controller.GetCompanyIdentifiers("DE").ConfigureAwait(false);
@@ -156,7 +157,7 @@ public class RegistrationControllerTest
         var id = Guid.NewGuid();
         var content = Encoding.UTF8.GetBytes("This is just test content");
         A.CallTo(() => _registrationBusinessLogicFake.GetDocumentContentAsync(id, _identity.UserId))
-            .ReturnsLazily(() => (fileName, content, contentType));
+            .Returns((fileName, content, contentType));
 
         //Act
         var result = await this._controller.GetDocumentContentFileAsync(id).ConfigureAwait(false);
@@ -174,7 +175,7 @@ public class RegistrationControllerTest
         var documentId = _fixture.Create<Guid>();
         var content = new byte[7];
         A.CallTo(() => _registrationBusinessLogicFake.GetRegistrationDocumentAsync(documentId))
-            .ReturnsLazily(() => new ValueTuple<string, byte[], string>("test.json", content, "application/json"));
+            .Returns(new ValueTuple<string, byte[], string>("test.json", content, "application/json"));
 
         //Act
         var result = await this._controller.GetRegistrationDocumentAsync(documentId).ConfigureAwait(false);
@@ -182,5 +183,22 @@ public class RegistrationControllerTest
         // Assert
         A.CallTo(() => _registrationBusinessLogicFake.GetRegistrationDocumentAsync(documentId)).MustHaveHappenedOnceExactly();
         result.Should().NotBeNull();
+    }
+    
+    
+    [Fact]
+    public async Task InviteNewUserAsync_WithValidData_ReturnsExpected()
+    {
+        // Arrange
+        var applicationId = _fixture.Create<Guid>();
+        A.CallTo(() => _registrationBusinessLogicFake.InviteNewUserAsync(applicationId, A<UserCreationInfoWithMessage>._, _identity.UserId))
+            .Returns(1);
+
+        //Act
+        var result = await this._controller.InviteNewUserAsync(applicationId, _fixture.Create<UserCreationInfoWithMessage>()).ConfigureAwait(false);
+
+        // Assert
+        A.CallTo(() => _registrationBusinessLogicFake.InviteNewUserAsync(applicationId, A<UserCreationInfoWithMessage>._, _identity.UserId)).MustHaveHappenedOnceExactly();
+        result.Should().Be(1);
     }
 }


### PR DESCRIPTION
## Description

Passing the userId instead of the companyId to check the application association

## Why

The current implementation will always fail because the check for the application association is executed with the companyId, but the check will validates the user

## Issue

N/A - Jira Ticket: CPLP-2873

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
