### PR TITLE
chore(Invitation): refactor user-validation-query

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
@@ -37,7 +37,7 @@ public interface IUserRepository
     IQueryable<CompanyUser> GetOwnCompanyUserQuery(Guid companyId, Guid? companyUserId = null, string? userEntityId = null, string? firstName = null, string? lastName = null, string? email = null, IEnumerable<UserStatusId>? statusIds = null);
     Task<(string UserEntityId, string? FirstName, string? LastName, string? Email)> GetUserEntityDataAsync(Guid companyUserId, Guid companyId);
     IAsyncEnumerable<(string? UserEntityId, Guid CompanyUserId)> GetMatchingCompanyIamUsersByNameEmail(string firstName, string lastName, string email, Guid companyId, IEnumerable<UserStatusId> companyUserStatusIds);
-    Task<bool> IsOwnCompanyUserWithEmailExisting(string email, Guid companyUserId);
+    Task<bool> IsOwnCompanyUserWithEmailExisting(string email, Guid companyId);
     Task<CompanyUserDetails?> GetOwnCompanyUserDetailsUntrackedAsync(Guid companyUserId, Guid companyId);
     Task<CompanyUserBusinessPartners?> GetOwnCompanyUserWithAssignedBusinessPartnerNumbersUntrackedAsync(Guid companyUserId, Guid companyId);
     Task<CompanyOwnUserDetails?> GetUserDetailsUntrackedAsync(Guid companyUserId, IEnumerable<Guid> userRoleIds);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -131,11 +131,9 @@ public class UserRepository : IUserRepository
                     : Guid.Empty))
             .AsAsyncEnumerable();
 
-    public Task<bool> IsOwnCompanyUserWithEmailExisting(string email, Guid companyUserId) =>
+    public Task<bool> IsOwnCompanyUserWithEmailExisting(string email, Guid companyId) =>
         _dbContext.CompanyUsers
-            .Where(user => user.Id == companyUserId)
-            .SelectMany(user => user.Identity!.Company!.Identities.Where(i => i.IdentityTypeId == IdentityTypeId.COMPANY_USER).Select(x => x.CompanyUser!))
-            .AnyAsync(companyUser => companyUser!.Email == email);
+            .AnyAsync(companyUser => companyUser.Identity!.CompanyId == companyId && companyUser.Email == email);
 
     public Task<CompanyUserDetails?> GetOwnCompanyUserDetailsUntrackedAsync(Guid companyUserId, Guid companyId) =>
         _dbContext.CompanyUsers

--- a/src/registration/Registration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
@@ -46,7 +45,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.BusinessLogic
         IAsyncEnumerable<CompanyApplicationData> GetAllApplicationsForUserWithStatus(Guid companyId);
         Task<CompanyDetailData> GetCompanyDetailData(Guid applicationId, Guid companyId);
         Task SetCompanyDetailDataAsync(Guid applicationId, CompanyDetailData companyDetails, Guid companyId);
-        Task<int> InviteNewUserAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo, Guid userId);
+        Task<int> InviteNewUserAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo, (Guid UserId, Guid CompanyId) identity);
         Task<int> SetOwnCompanyApplicationStatusAsync(Guid applicationId, CompanyApplicationStatusId status, Guid companyId);
         Task<CompanyApplicationStatusId> GetOwnCompanyApplicationStatusAsync(Guid applicationId, Guid companyId);
         Task<int> SubmitRoleConsentAsync(Guid applicationId, CompanyRoleAgreementConsents roleAgreementConsentStatuses, Guid userId, Guid companyId);

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -447,23 +447,23 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
                 c.AddressId = addressId;
             });
 
-    public Task<int> InviteNewUserAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo, Guid userId)
+    public Task<int> InviteNewUserAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo, (Guid UserId, Guid CompanyId) identity)
     {
         if (string.IsNullOrEmpty(userCreationInfo.eMail))
         {
             throw new ControllerArgumentException($"email must not be empty");
         }
-        return InviteNewUserInternalAsync(applicationId, userCreationInfo, userId);
+        return InviteNewUserInternalAsync(applicationId, userCreationInfo, identity);
     }
 
-    private async Task<int> InviteNewUserInternalAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo, Guid userId)
+    private async Task<int> InviteNewUserInternalAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo, (Guid UserId, Guid CompanyId) identity)
     {
-        if (await _portalRepositories.GetInstance<IUserRepository>().IsOwnCompanyUserWithEmailExisting(userCreationInfo.eMail, userId))
+        if (await _portalRepositories.GetInstance<IUserRepository>().IsOwnCompanyUserWithEmailExisting(userCreationInfo.eMail, identity.CompanyId))
         {
             throw new ControllerArgumentException($"user with email {userCreationInfo.eMail} does already exist");
         }
 
-        var (companyNameIdpAliasData, createdByName) = await _userProvisioningService.GetCompanyNameSharedIdpAliasData(userId, applicationId).ConfigureAwait(false);
+        var (companyNameIdpAliasData, createdByName) = await _userProvisioningService.GetCompanyNameSharedIdpAliasData(identity.UserId, applicationId).ConfigureAwait(false);
 
         IEnumerable<UserRoleData>? userRoleDatas = null;
 

--- a/src/registration/Registration.Service/Controllers/RegistrationController.cs
+++ b/src/registration/Registration.Service/Controllers/RegistrationController.cs
@@ -286,6 +286,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Controllers
         /// <response code="502">Service Unavailable.</response>
         [HttpPost]
         [Authorize(Roles = "invite_user")]
+        [Authorize(Policy = PolicyTypes.ValidCompany)]
         [Authorize(Policy = PolicyTypes.ValidIdentity)]
         [Route("application/{applicationId}/inviteNewUser")]
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
@@ -293,7 +294,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Controllers
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status502BadGateway)]
         public Task<int> InviteNewUserAsync([FromRoute] Guid applicationId, [FromBody] UserCreationInfoWithMessage userCreationInfo) =>
-            this.WithUserId(userId => _registrationBusinessLogic.InviteNewUserAsync(applicationId, userCreationInfo, userId));
+            this.WithUserIdAndCompanyId(identity => _registrationBusinessLogic.InviteNewUserAsync(applicationId, userCreationInfo, identity));
 
         /// <summary>
         /// Post the agreement consent status for the given application.

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -1257,7 +1257,7 @@ public class RegistrationBusinessLogicTest
             _portalRepositories,
             null!);
 
-        await sut.InviteNewUserAsync(_existingApplicationId, userCreationInfo, _identity.UserId).ConfigureAwait(false);
+        await sut.InviteNewUserAsync(_existingApplicationId, userCreationInfo, (_identity.UserId, _identity.CompanyId)).ConfigureAwait(false);
 
         A.CallTo(() => _userProvisioningService.CreateOwnCompanyIdpUsersAsync(A<CompanyNameIdpAliasData>._, A<IAsyncEnumerable<UserCreationRoleDataIdpInfo>>._, A<CancellationToken>._)).MustHaveHappened();
         A.CallTo(() => _applicationRepository.CreateInvitation(A<Guid>.That.IsEqualTo(_existingApplicationId), A<Guid>._)).MustHaveHappened();
@@ -1286,7 +1286,7 @@ public class RegistrationBusinessLogicTest
             _portalRepositories,
             null!);
 
-        Task Act() => sut.InviteNewUserAsync(_existingApplicationId, userCreationInfo, _identity.UserId);
+        Task Act() => sut.InviteNewUserAsync(_existingApplicationId, userCreationInfo, (_identity.UserId, _identity.CompanyId));
 
         var error = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
         error.Message.Should().Be("email must not be empty");
@@ -1314,11 +1314,12 @@ public class RegistrationBusinessLogicTest
             _portalRepositories,
             null!);
 
-        Task Act() => sut.InviteNewUserAsync(_existingApplicationId, userCreationInfo, _identity.UserId);
+        Task Act() => sut.InviteNewUserAsync(_existingApplicationId, userCreationInfo, (_identity.UserId, _identity.CompanyId));
 
         var error = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
         error.Message.Should().Be($"user with email {userCreationInfo.eMail} does already exist");
 
+        A.CallTo(() => _userRepository.IsOwnCompanyUserWithEmailExisting(userCreationInfo.eMail, _identity.CompanyId)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
         A.CallTo(() => _mailingService.SendMails(A<string>._, A<IDictionary<string, string>>._, A<List<string>>._)).MustNotHaveHappened();
     }
@@ -1346,7 +1347,7 @@ public class RegistrationBusinessLogicTest
             _portalRepositories,
             null!);
 
-        Task Act() => sut.InviteNewUserAsync(_existingApplicationId, userCreationInfo, _identity.UserId);
+        Task Act() => sut.InviteNewUserAsync(_existingApplicationId, userCreationInfo, (_identity.UserId, _identity.CompanyId));
 
         var error = await Assert.ThrowsAsync<TestException>(Act).ConfigureAwait(false);
         error.Message.Should().Be(_error.Message);

--- a/tests/registration/Registration.Service.Tests/Controller/RegistrationControllerTest.cs
+++ b/tests/registration/Registration.Service.Tests/Controller/RegistrationControllerTest.cs
@@ -190,14 +190,16 @@ public class RegistrationControllerTest
     {
         // Arrange
         var applicationId = _fixture.Create<Guid>();
-        A.CallTo(() => _registrationBusinessLogicFake.InviteNewUserAsync(applicationId, A<UserCreationInfoWithMessage>._, _identity.UserId))
+        var creationInfo = _fixture.Create<UserCreationInfoWithMessage>();
+
+        A.CallTo(() => _registrationBusinessLogicFake.InviteNewUserAsync(A<Guid>._, A<UserCreationInfoWithMessage>._, A<(Guid, Guid)>._))
             .Returns(1);
 
         //Act
-        var result = await this._controller.InviteNewUserAsync(applicationId, _fixture.Create<UserCreationInfoWithMessage>()).ConfigureAwait(false);
+        var result = await this._controller.InviteNewUserAsync(applicationId, creationInfo).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _registrationBusinessLogicFake.InviteNewUserAsync(applicationId, A<UserCreationInfoWithMessage>._, _identity.UserId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _registrationBusinessLogicFake.InviteNewUserAsync(applicationId, creationInfo, new(_identity.UserId, _identity.CompanyId))).MustHaveHappenedOnceExactly();
         result.Should().Be(1);
     }
 }


### PR DESCRIPTION
## Description

The query that is used to check for an existing user email-address in the calling users company has been refactored to make use of the calling users identity companyId instead of identityId.

## Why

The preexisting-query did a complex join as it was required when using the iamUserId. The refactored query is now both more efficient and more easy to understand.

## Issue

https://jira.catena-x.net/browse/CPLP-2873

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
