### PR TITLE
fix(registration): add missing template setting SubmitDocumentTypeIds

### DIFF
--- a/src/registration/Registration.Service/appsettings.json
+++ b/src/registration/Registration.Service/appsettings.json
@@ -16,7 +16,8 @@
     "BasePortalAddress": "https://portal.example.org/registration",
     "ApplicationStatusIds": [],
     "DocumentTypeIds": [],
-    "RegistrationDocumentTypeIds": []
+    "RegistrationDocumentTypeIds": [],
+    "SubmitDocumentTypeIds": []
   },
   "BPN_Address": "",
   "MailingService": {


### PR DESCRIPTION
## Description

Adding the new setting SubmitDocumentTypeIds as template to registration-service appsettings.json. This was forgotten when merging https://github.com/eclipse-tractusx/portal-backend/pull/56

## Why

Missing setting causes error on service-startup

## Issue

No GH Issue
CPLP-2736

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
