### PR TITLE
bugfix(password template): space issue fix

### DIFF
--- a/src/mailing/Mailing.Template/EmailTemplates/password.html
+++ b/src/mailing/Mailing.Template/EmailTemplates/password.html
@@ -137,10 +137,10 @@
                                             <td
                                                 style="color: #0D61AE; font-family: sans-serif; font-size: 12px; padding: 10px;"
                                                 valign="top" align="center">
-                                                <span class="footer-span"
-                                                      style="color: #0D61AE; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; font-size: 16px;">
+                                                <p class="footer-span"
+                                                      style="color: #0D61AE; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; font-size: 16px;margin: 0px;">
                                                       {password}
-                                                </span>
+                                        </p>
                                             </td>
                                         </tr>
                                         <!--[if mso]>

--- a/src/mailing/Mailing.Template/EmailTemplates/password.html
+++ b/src/mailing/Mailing.Template/EmailTemplates/password.html
@@ -138,7 +138,7 @@
                                                 style="color: #0D61AE; font-family: sans-serif; font-size: 12px; padding: 10px;"
                                                 valign="top" align="center">
                                                 <p class="footer-span"
-                                                      style="color: #0D61AE; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; font-size: 16px;margin: 0px;">
+                                                      style="color: #0D61AE; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; font-size: 16px; margin: 0px;">
                                                       {password}
                                         </p>
                                             </td>


### PR DESCRIPTION

## Description

change from span to p tag to remove extra space issue

## Why

password filed having extra space in some email client

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally