### PR TITLE
fix(config): marketplace uploadDocumentTypeIds

### DIFF
--- a/src/marketplace/Offers.Library.Web/OfferDocumentService.cs
+++ b/src/marketplace/Offers.Library.Web/OfferDocumentService.cs
@@ -63,9 +63,9 @@ public class OfferDocumentService : IOfferDocumentService
         MediaTypeId mediaTypeId;
         try
         {
-            mediaTypeId  = document.ContentType.ParseMediaTypeId();
+            mediaTypeId = document.ContentType.ParseMediaTypeId();
         }
-        catch(UnsupportedMediaTypeException e)
+        catch (UnsupportedMediaTypeException e)
         {
             throw new UnsupportedMediaTypeException($"Document type {documentTypeId}, {e.Message}. File with contentType :{string.Join(",", uploadContentTypeSettings.MediaTypes)} are allowed.");
         }

--- a/src/marketplace/Offers.Library/Models/UploadDocumentConfig.cs
+++ b/src/marketplace/Offers.Library/Models/UploadDocumentConfig.cs
@@ -18,6 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Validation;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
@@ -29,13 +30,17 @@ public class UploadDocumentConfig
         MediaTypes = null!;
     }
 
-    public UploadDocumentConfig(DocumentTypeId documentTypeId, IEnumerable<string> mediaTypes)
+    public UploadDocumentConfig(DocumentTypeId documentTypeId, IEnumerable<MediaTypeId> mediaTypes)
         : this()
     {
         DocumentTypeId = documentTypeId;
         MediaTypes = mediaTypes;
     }
 
+    [ValidateEnumValue]
     public DocumentTypeId DocumentTypeId { get; set; }
-    public IEnumerable<string> MediaTypes { get; set; }
+    
+    [EnumEnumeration]
+    [DistinctValues]
+    public IEnumerable<MediaTypeId> MediaTypes { get; set; }
 };

--- a/src/marketplace/Offers.Library/Models/UploadDocumentConfig.cs
+++ b/src/marketplace/Offers.Library/Models/UploadDocumentConfig.cs
@@ -39,7 +39,7 @@ public class UploadDocumentConfig
 
     [ValidateEnumValue]
     public DocumentTypeId DocumentTypeId { get; set; }
-    
+
     [EnumEnumeration]
     [DistinctValues]
     public IEnumerable<MediaTypeId> MediaTypes { get; set; }

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -482,7 +482,7 @@ public class AppReleaseBusinessLogicTest
         var file = FormFileHelper.GetFormFile("this is just a test", "superFile.pdf", "application/pdf");
 
         _settings.UploadAppDocumentTypeIds = new[] {
-            new UploadDocumentConfig(DocumentTypeId.ADDITIONAL_DETAILS, new []{ "application/pdf" })
+            new UploadDocumentConfig(DocumentTypeId.ADDITIONAL_DETAILS, new []{ MediaTypeId.PDF })
         };
 
         // Act

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
@@ -542,7 +542,7 @@ public class ServiceReleaseBusinessLogicTest
         {
             UploadServiceDocumentTypeIds = new[]
             {
-                new UploadDocumentConfig(DocumentTypeId.ADDITIONAL_DETAILS, new []{ "application/pdf" })
+                new UploadDocumentConfig(DocumentTypeId.ADDITIONAL_DETAILS, new []{ MediaTypeId.PDF })
             }
         };
         var sut = new ServiceReleaseBusinessLogic(_portalRepositories, _offerService, _offerDocumentService, Options.Create(settings));


### PR DESCRIPTION
* use enum-values in uploadDocumentTypeIds setting

## Description

change of uploadDocumentTypeIds settings values type from string to MediaTypeIds enum

## Why

using string-values in config is not typesafe and can be more easily be validated on startup.

## Issue

N/A (CPLP-2891)

## Link to Configuration-change PR:

https://github.com/eclipse-tractusx/portal-cd/pull/30

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
