### PR TITLE
bugfix(migrations): fix dockerfile for portal-migrations

### DIFF
--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -22,7 +22,8 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
 FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /
 COPY /src/portalbackend /src/portalbackend
-COPY src/framework/Framework.DBAccess/ src/framework/Framework.DBAccess
+COPY /src/framework/Framework.DBAccess /src/framework/Framework.DBAccess
+COPY /src/framework/Framework.Logging /src/framework/Framework.Logging
 COPY /src/framework/Framework.ErrorHandling.Library /src/framework/Framework.ErrorHandling.Library
 COPY /src/framework/Framework.BaseDependencies /src/framework/Framework.BaseDependencies
 COPY /src/framework/Framework.Seeding /src/framework/Framework.Seeding


### PR DESCRIPTION
## Description

fix dockerfile of portal.migrations not including dependency on framework.logging

## Why

implementation of CPLP-1849 structured logging was lacking adaption of portal.migrations dockerfile. That causes the build of the respective image to fail.

## Issue

N/A (CPLP-1849)

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X ] I have checked that new and existing tests pass locally with my changes
