### PR TITLE
Fix(notification): get notification details

### DIFF
--- a/src/notifications/Notifications.Service/BusinessLogic/NotificationBusinessLogic.cs
+++ b/src/notifications/Notifications.Service/BusinessLogic/NotificationBusinessLogic.cs
@@ -49,7 +49,7 @@ public class NotificationBusinessLogic : INotificationBusinessLogic
     /// <inheritdoc />
     public Task<Pagination.Response<NotificationDetailData>> GetNotificationsAsync(int page, int size, Guid receiverUserId, NotificationFilters filters) =>
         Pagination.CreateResponseAsync(page, size, _settings.MaxPageSize, _portalRepositories.GetInstance<INotificationRepository>()
-                .GetAllNotificationDetailsByReceiver(receiverUserId, filters.IsRead, filters.TypeId, filters.TopicId, filters.OnlyDueDate, filters.Sorting ?? NotificationSorting.DateDesc));
+                .GetAllNotificationDetailsByReceiver(receiverUserId, filters.IsRead, filters.TypeId, filters.TopicId, filters.OnlyDueDate, filters.Sorting ?? NotificationSorting.DateDesc, filters.DoneState));
 
     /// <inheritdoc />
     public async Task<NotificationDetailData> GetNotificationDetailDataAsync(Guid userId, Guid notificationId)

--- a/src/notifications/Notifications.Service/Controllers/NotificationController.cs
+++ b/src/notifications/Notifications.Service/Controllers/NotificationController.cs
@@ -61,6 +61,7 @@ public class NotificationController : ControllerBase
     /// <param name="notificationTopicId">OPTIONAL: Topic of the notifications</param>
     /// <param name="onlyDueDate">OPTIONAL: If true only notifications with a due date will be returned</param>
     /// <param name="sorting">Defines the sorting of the list</param>
+    /// <param name="doneState">Defines the done state</param>
     /// <response code="200">Collection of the unread notifications for the user.</response>
     /// <response code="400">NotificationType or NotificationStatus don't exist.</response>
     [HttpGet]
@@ -76,8 +77,9 @@ public class NotificationController : ControllerBase
         [FromQuery] NotificationTypeId? notificationTypeId = null,
         [FromQuery] NotificationTopicId? notificationTopicId = null,
         [FromQuery] bool onlyDueDate = false,
-        [FromQuery] NotificationSorting? sorting = null) =>
-        this.WithUserId(userId => _logic.GetNotificationsAsync(page, size, userId, new NotificationFilters(isRead, notificationTypeId, notificationTopicId, onlyDueDate, sorting)));
+        [FromQuery] NotificationSorting? sorting = null,
+        [FromQuery] bool? doneState = null) =>
+        this.WithUserId(userId => _logic.GetNotificationsAsync(page, size, userId, new NotificationFilters(isRead, notificationTypeId, notificationTopicId, onlyDueDate, sorting, doneState)));
 
     /// <summary>
     ///     Gets a notification for the logged in user

--- a/src/notifications/Notifications.Service/Models/NotificationFilters.cs
+++ b/src/notifications/Notifications.Service/Models/NotificationFilters.cs
@@ -31,10 +31,12 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Notifications.Service.Models;
 /// <param name="TopicId">OPTIONAL: The topic of the notifications</param>
 /// <param name="OnlyDueDate">OPTIONAL: If true only notifications with a due date will be returned</param>
 /// <param name="Sorting">Kind of sorting for the notifications</param>
+/// <param name="DoneState">Kind of sorting for the notifications</param>
 public record NotificationFilters(
     bool? IsRead,
     NotificationTypeId? TypeId,
     NotificationTopicId? TopicId,
     bool OnlyDueDate,
-    NotificationSorting? Sorting
+    NotificationSorting? Sorting,
+    bool? DoneState
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
@@ -55,8 +55,9 @@ public interface INotificationRepository
     /// <param name="topicId">OPTIONAL: The topic of the notifications</param>
     /// <param name="onlyDueDate">OPTIONAL: If true only notifications with a due date will be returned</param>
     /// <param name="sorting"></param>
+    /// <param name="doneState"></param>
     /// <returns>Returns a collection of NotificationDetailData</returns>
-    Func<int, int, Task<Pagination.Source<NotificationDetailData>?>> GetAllNotificationDetailsByReceiver(Guid receiverUserId, bool? isRead, NotificationTypeId? typeId, NotificationTopicId? topicId, bool onlyDueDate, NotificationSorting? sorting);
+    Func<int, int, Task<Pagination.Source<NotificationDetailData>?>> GetAllNotificationDetailsByReceiver(Guid receiverUserId, bool? isRead, NotificationTypeId? typeId, NotificationTopicId? topicId, bool onlyDueDate, NotificationSorting? sorting, bool? doneState);
 
     /// <summary>
     ///     Returns a notification for the given id and given user if it exists in the persistence layer, otherwise null

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
@@ -70,7 +70,7 @@ public class NotificationRepository : INotificationRepository
         _dbContext.Remove(new Notification(notificationId, Guid.Empty, default, default, default)).Entity;
 
     /// <inheritdoc />
-    public Func<int, int, Task<Pagination.Source<NotificationDetailData>?>> GetAllNotificationDetailsByReceiver(Guid receiverUserId, bool? isRead, NotificationTypeId? typeId, NotificationTopicId? topicId, bool onlyDueDate, NotificationSorting? sorting) =>
+    public Func<int, int, Task<Pagination.Source<NotificationDetailData>?>> GetAllNotificationDetailsByReceiver(Guid receiverUserId, bool? isRead, NotificationTypeId? typeId, NotificationTopicId? topicId, bool onlyDueDate, NotificationSorting? sorting, bool? doneState) =>
         (skip, take) => Pagination.CreateSourceQueryAsync(
             skip,
             take,
@@ -80,7 +80,8 @@ public class NotificationRepository : INotificationRepository
                     (!isRead.HasValue || notification.IsRead == isRead.Value) &&
                     (!typeId.HasValue || notification.NotificationTypeId == typeId.Value) &&
                     (!topicId.HasValue || notification.NotificationType!.NotificationTypeAssignedTopic!.NotificationTopicId == topicId.Value) &&
-                    (!onlyDueDate || notification.DueDate.HasValue))
+                    (!onlyDueDate || notification.DueDate.HasValue) &&
+                    (!doneState.HasValue || notification.Done == doneState.Value))
                 .GroupBy(notification => notification.ReceiverUserId),
             sorting switch
             {

--- a/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
+++ b/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
@@ -170,6 +170,26 @@ public class NotificationBusinessLogicTests
         await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
     }
 
+    [Fact]
+    public async Task GetNotifications_WithFilters_CallsExpected()
+    {
+        // Arrange
+        var sut = new NotificationBusinessLogic(_portalRepositories, Options.Create(new NotificationSettings
+        {
+            MaxPageSize = 20
+        }));
+
+        var userId = Guid.NewGuid();
+        var filter = _fixture.Create<NotificationFilters>();
+
+        // Act
+        var result = await sut.GetNotificationsAsync(0, 20, userId, filter).ConfigureAwait(false);
+
+        // Assert
+        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(userId, filter.IsRead, filter.TypeId, filter.TopicId, filter.OnlyDueDate, filter.Sorting, filter.DoneState))
+            .MustHaveHappenedOnceExactly();
+    }
+
     #endregion
 
     #region Get Notification Details

--- a/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
+++ b/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
@@ -86,7 +86,7 @@ public class NotificationBusinessLogicTests
         }));
 
         // Act
-        var result = await sut.GetNotificationsAsync(0, 15, _identity.UserId, new NotificationFilters(status, null, null, false, null)).ConfigureAwait(false);
+        var result = await sut.GetNotificationsAsync(0, 15, _identity.UserId, new NotificationFilters(status, null, null, false, null, null)).ConfigureAwait(false);
 
         // Assert
         var expectedCount = status ?
@@ -109,7 +109,7 @@ public class NotificationBusinessLogicTests
         }));
 
         // Act
-        var result = await sut.GetNotificationsAsync(0, 15, _identity.UserId, new NotificationFilters(null, null, null, false, sorting)).ConfigureAwait(false);
+        var result = await sut.GetNotificationsAsync(0, 15, _identity.UserId, new NotificationFilters(null, null, null, false, sorting, null)).ConfigureAwait(false);
 
         // Assert
         result.Meta.NumberOfElements.Should().Be(_notificationDetails.Count());
@@ -129,7 +129,7 @@ public class NotificationBusinessLogicTests
         }));
 
         // Act
-        var results = await sut.GetNotificationsAsync(1, 3, _identity.UserId, new NotificationFilters(null, null, null, false, null)).ConfigureAwait(false);
+        var results = await sut.GetNotificationsAsync(1, 3, _identity.UserId, new NotificationFilters(null, null, null, false, null, null)).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -149,7 +149,7 @@ public class NotificationBusinessLogicTests
             MaxPageSize = 15
         }));
 
-        var Act = () => sut.GetNotificationsAsync(0, 20, _identity.UserId, new NotificationFilters(null, null, null, false, null));
+        var Act = () => sut.GetNotificationsAsync(0, 20, _identity.UserId, new NotificationFilters(null, null, null, false, null, null));
 
         // Act & Assert
         await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
@@ -164,7 +164,7 @@ public class NotificationBusinessLogicTests
             MaxPageSize = 15
         }));
 
-        var Act = () => sut.GetNotificationsAsync(-1, 15, _identity.UserId, new NotificationFilters(null, null, null, false, null));
+        var Act = () => sut.GetNotificationsAsync(-1, 15, _identity.UserId, new NotificationFilters(null, null, null, false, null, null));
 
         // Act & Assert
         await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
@@ -452,11 +452,11 @@ public class NotificationBusinessLogicTests
         var readPaging = (int skip, int take) => Task.FromResult(new Pagination.Source<NotificationDetailData>(_readNotificationDetails.Count(), _readNotificationDetails.Skip(skip).Take(take)));
         var notificationsPaging = (int skip, int take) => Task.FromResult(new Pagination.Source<NotificationDetailData>(_notificationDetails.Count(), _notificationDetails.Skip(skip).Take(take)));
 
-        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identity.UserId, false, null, null, false, A<NotificationSorting>._))
+        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identity.UserId, false, null, null, false, A<NotificationSorting>._, null))
             .Returns(unreadPaging);
-        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identity.UserId, true, null, null, false, A<NotificationSorting>._))
+        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identity.UserId, true, null, null, false, A<NotificationSorting>._, null))
             .Returns(readPaging);
-        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identity.UserId, null, null, null, false, A<NotificationSorting>._))
+        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identity.UserId, null, null, null, false, A<NotificationSorting>._, null))
             .Returns(notificationsPaging);
     }
 

--- a/tests/notifications/Notifications.Service.Tests/Controllers/NotificationControllerTest.cs
+++ b/tests/notifications/Notifications.Service.Tests/Controllers/NotificationControllerTest.cs
@@ -57,15 +57,16 @@ public class NotificationControllerTest
         var topicId = _fixture.Create<NotificationTopicId?>();
         var onlyDueDate = _fixture.Create<bool>();
         var sorting = _fixture.Create<NotificationSorting?>();
+        var doneState = _fixture.Create<bool?>();
         var paginationResponse = new Pagination.Response<NotificationDetailData>(new Pagination.Metadata(15, 1, 1, 15), _fixture.CreateMany<NotificationDetailData>(5));
         A.CallTo(() => _logic.GetNotificationsAsync(A<int>._, A<int>._, A<Guid>._, A<NotificationFilters>._))
             .ReturnsLazily(() => paginationResponse);
 
         //Act
-        var result = await this._controller.GetNotifications(isRead: isRead, notificationTypeId: typeId, notificationTopicId: topicId, onlyDueDate: onlyDueDate, sorting: sorting).ConfigureAwait(false);
+        var result = await this._controller.GetNotifications(isRead: isRead, notificationTypeId: typeId, notificationTopicId: topicId, onlyDueDate: onlyDueDate, sorting: sorting, doneState: doneState).ConfigureAwait(false);
 
         //Assert
-        A.CallTo(() => _logic.GetNotificationsAsync(0, 15, A<Guid>._, A<NotificationFilters>.That.Matches(x => x.IsRead == isRead && x.TypeId == typeId && x.TopicId == topicId && x.OnlyDueDate == onlyDueDate && x.Sorting == sorting))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetNotificationsAsync(0, 15, A<Guid>._, A<NotificationFilters>.That.Matches(x => x.IsRead == isRead && x.TypeId == typeId && x.TopicId == topicId && x.OnlyDueDate == onlyDueDate && x.Sorting == sorting && x.DoneState == doneState))).MustHaveHappenedOnceExactly();
         Assert.IsType<Pagination.Response<NotificationDetailData>>(result);
         result.Content.Should().HaveCount(5);
     }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -312,6 +312,27 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         results.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x => x.NotificationTopic == NotificationTopicId.INFO));
     }
 
+    [Theory]
+    [InlineData(null, 6)]
+    [InlineData(true, 3)]
+    [InlineData(false, 2)]
+    public async Task GetAllAsDetailsByUserIdUntracked_WithDoneState_ReturnsExpectedNotificationDetailData(bool? doneState, int count)
+    {
+        // Arrange
+        var sut = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, null, doneState)(0, 15).ConfigureAwait(false);
+
+        // Assert
+        results.Should().NotBeNull();
+        results!.Data.Should().HaveCount(count);
+        if (doneState.HasValue)
+        {
+            results!.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x => x.Done == doneState.Value));
+        }
+    }
+
     #endregion
 
     #region GetNotificationByIdAndIamUserId

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -164,7 +164,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, null, null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -180,7 +180,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.DateAsc)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.DateAsc, null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -195,7 +195,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.DateDesc)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.DateDesc, null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -210,7 +210,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.ReadStatusAsc)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.ReadStatusAsc, null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -225,7 +225,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.ReadStatusDesc)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.ReadStatusDesc, null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -241,7 +241,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var results = await sut
-            .GetAllNotificationDetailsByReceiver(_companyUserId, false, null, null, false, null)(0, 15)
+            .GetAllNotificationDetailsByReceiver(_companyUserId, false, null, null, false, null, null)(0, 15)
             .ConfigureAwait(false);
 
         // Assert
@@ -258,7 +258,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var results = await sut
-            .GetAllNotificationDetailsByReceiver(_companyUserId, true, null, null, false, null)(0, 15)
+            .GetAllNotificationDetailsByReceiver(_companyUserId, true, null, null, false, null, null)(0, 15)
             .ConfigureAwait(false);
 
         // Assert
@@ -274,7 +274,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, true, NotificationTypeId.INFO, null, false, NotificationSorting.ReadStatusDesc)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, true, NotificationTypeId.INFO, null, false, NotificationSorting.ReadStatusDesc, null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -289,7 +289,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, true, NotificationTypeId.ACTION, null, false, NotificationSorting.ReadStatusAsc)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, true, NotificationTypeId.ACTION, null, false, NotificationSorting.ReadStatusAsc, null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -304,7 +304,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, NotificationTopicId.INFO, false, NotificationSorting.ReadStatusAsc)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, NotificationTopicId.INFO, false, NotificationSorting.ReadStatusAsc, null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/notifications.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/notifications.test.json
@@ -7,7 +7,8 @@
     "notification_type_id": 1,
     "is_read": true,
     "due_date": "2022-09-10 18:01:33.570000 +00:00",
-    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001"
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
+    "done": true
   },
   {
     "id": "1450F1B2-FCE6-473E-865A-62D6DC0F5A5A",
@@ -17,7 +18,8 @@
     "notification_type_id": 2,
     "is_read": true,
     "due_date": "2022-09-10 18:01:33.570000 +00:00",
-    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001"
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
+    "done": true
   },
   {
     "id": "0AC17754-4317-4612-BBA3-D5FD4AED2683",
@@ -27,7 +29,8 @@
     "notification_type_id": 4,
     "is_read": true,
     "due_date": "2022-09-10 18:01:33.570000 +00:00",
-    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001"
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
+    "done": true
   },
   {
     "id": "351422E4-9B18-4296-9DE1-A625C6D4AF5C",
@@ -37,7 +40,8 @@
     "notification_type_id": 5,
     "is_read": false,
     "due_date": "2022-09-10 18:01:33.570000 +00:00",
-    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001"
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
+    "done": false
   },
   {
     "id": "2D6E87BD-D61E-46AC-BEA9-5508D65A89EB",
@@ -47,7 +51,8 @@
     "notification_type_id": 6,
     "is_read": false,
     "due_date": "2022-09-10 18:01:33.570000 +00:00",
-    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001"
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
+    "done": false
   },
   {
     "id": "1836bbf6-b067-4126-9745-a22a098d3486",
@@ -57,6 +62,7 @@
     "notification_type_id": 11,
     "is_read": false,
     "due_date": "2022-09-10 18:01:33.570000 +00:00",
-    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001"
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
+    "done": null
   }
 ]


### PR DESCRIPTION
## Description

Added done state filter for notification detail endpoint

## Why

To filter the record based on done state value like null, true and false

## Issue

CPLP-2837

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
