### PR TITLE
fix(autoSetup): manual autoSetup process fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X Portal Backend.
 
+## 1.5.1
+
+### Bugfix
+* Marketplace Service:  POST: /api/apps/autoSetup fixed mailing for subscription activation
+* Services Service:  POST: /api/services/autoSetup fixed mailing for subscription activation
+
 ## 1.5.0
 
 ### Change

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.0</VersionPrefix>
+    <VersionPrefix>1.5.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/marketplace/Apps.Service/appsettings.json
+++ b/src/marketplace/Apps.Service/appsettings.json
@@ -64,7 +64,7 @@
         "Subject": "New subscription request for app {offerName}",
         "EmailTemplateType": "AppSubscriptionRequest"
       },
-      "subscription-activation": {
+      "app-subscription-activation": {
         "Subject": "Activation of app {offerName}",
         "EmailTemplateType": "AppSubscriptionActivation"
       },

--- a/src/marketplace/Services.Service/appsettings.json
+++ b/src/marketplace/Services.Service/appsettings.json
@@ -58,7 +58,7 @@
         "Subject": "New subscription request for service {offerName}",
         "EmailTemplateType": "ServiceSubscriptionRequest"
       },
-      "subscription-activation": {
+      "service-subscription-activation": {
         "Subject": "Activation of service {offerName}",
         "EmailTemplateType": "ServiceSubscriptionActivation"
       },


### PR DESCRIPTION
Refs: CPLP-2903

## Description

fixed mail sending when acivating the subscription within the manual auto setup process

## Why

when sending the mail within the manual auto setup endpoints, the template couldn't be found.

## Issue

N/A - Jira Issue: CPLP-2903

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
