### PR TITLE
chore: add workflow to check dependencies

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  check-dependencies:
 
     runs-on: ubuntu-latest
     strategy:
@@ -41,7 +41,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - uses: actions/checkout@v3
 
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v2

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -91,4 +91,3 @@ jobs:
           echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
           exit 1
         if: steps.dependencies-changed.outputs.changed == 'true'
-        

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,95 @@
+###############################################################
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+name: Update & check Dependencies
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['6.0']
+
+    steps:
+  
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: dotnet restore src
+
+      - name: List packages
+        run: dotnet list src package --include-transitive --interactive | grep ">" | grep -Pv "\s(Org|Microsoft|NuGet|System|runtime|docker|Docker|NETStandard)" | sed -E -e "s/\s+> ([a-zA-Z\.\-]+).+\s([0-9]+\.[0-9]+\.[0-9]+)\s*/nuget\/nuget\/\-\/\1\/\2/g" | awk '!seen[$0]++' > PACKAGES
+
+      - name: Generate Dependencies file
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar PACKAGES -project automotive.tractusx -summary DEPENDENCIES
+
+      - name: Check if dependencies were changed
+        id: dependencies-changed
+        run: |
+          changed=$(git diff DEPENDENCIES)
+          if [[ -n "$changed" ]]; then
+            echo "dependencies changed"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "dependencies not changed"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for restricted dependencies
+        run: |
+          restricted=$(grep ' restricted,' DEPENDENCIES || true)
+          if [[ -n "$restricted" ]]; then
+            echo "The following dependencies are restricted: $restricted"
+            exit 1
+          fi
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Upload DEPENDENCIES file
+        uses: actions/upload-artifact@v3
+        with:
+          path: DEPENDENCIES
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Signal need to update DEPENDENCIES
+        run: |
+          echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
+          exit 1
+        if: steps.dependencies-changed.outputs.changed == 'true'
+        

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-name: Update & check Dependencies
+name: Check Dependencies
 
 on:
   push:

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,53 +1,54 @@
-nuget/nuget/-/PasswordGenerator/2.1.0
-nuget/nuget/-/EFCore.NamingConventions/6.0.0
-nuget/nuget/-/Flurl.Http.Signed/3.2.4
-nuget/nuget/-/Flurl.Signed/3.0.6
-nuget/nuget/-/Humanizer.Core/2.8.26
-nuget/nuget/-/Laraue.EfCoreTriggers.Common/6.3.6
-nuget/nuget/-/Laraue.EfCoreTriggers.PostgreSql/6.3.6
-nuget/nuget/-/MailKit/2.15.0
-nuget/nuget/-/MimeKit/2.15.1
-nuget/nuget/-/Newtonsoft.Json/13.0.2
-nuget/nuget/-/Npgsql/6.0.7
-nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL/6.0.7
-nuget/nuget/-/Portable.BouncyCastle/1.8.10
-nuget/nuget/-/Serilog/2.12.0
-nuget/nuget/-/Serilog.AspNetCore/6.1.0
-nuget/nuget/-/Serilog.Enrichers.Environment/2.2.0
-nuget/nuget/-/Serilog.Enrichers.Process/2.0.2
-nuget/nuget/-/Serilog.Enrichers.Thread/3.1.0
-nuget/nuget/-/Serilog.Extensions.Hosting/5.0.1
-nuget/nuget/-/Serilog.Extensions.Logging/3.1.0
-nuget/nuget/-/Serilog.Formatting.Compact/1.1.0
-nuget/nuget/-/Serilog.Settings.Configuration/3.4.0
-nuget/nuget/-/Serilog.Sinks.Console/4.1.0
-nuget/nuget/-/Serilog.Sinks.Debug/2.0.0
-nuget/nuget/-/Serilog.Sinks.File/5.0.0
-nuget/nuget/-/Swashbuckle.AspNetCore/6.5.0
-nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/6.5.0
-nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/6.5.0
-nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/6.5.0
-nuget/nuget/-/SwashBuckle.AspNetCore/6.5.0
-nuget/nuget/-/Newtonsoft.Json/12.0.2
-nuget/nuget/-/AutoFixture/4.17.0
-nuget/nuget/-/AutoFixture.AutoFakeItEasy/4.17.0
-nuget/nuget/-/AutoFixture.Xunit/4.17.0
-nuget/nuget/-/coverlet.collector/3.1.0
-nuget/nuget/-/FakeItEasy/7.3.1
-nuget/nuget/-/FluentAssertions/6.7.0
-nuget/nuget/-/xunit.runner.visualstudio/2.4.5
-nuget/nuget/-/Castle.Core/4.3.1
-nuget/nuget/-/Fare/2.1.1
-nuget/nuget/-/SharpZipLib/1.3.3
-nuget/nuget/-/Testcontainers/2.1.0
-nuget/nuget/-/xunit/2.4.1
-nuget/nuget/-/xunit.abstractions/2.0.3
-nuget/nuget/-/xunit.analyzers/0.10.0
-nuget/nuget/-/xunit.assert/2.4.1
-nuget/nuget/-/xunit.core/2.4.1
-nuget/nuget/-/xunit.extensibility.core/2.4.1
-nuget/nuget/-/xunit.extensibility.execution/2.4.1
-nuget/nuget/-/coverlet.collector/3.1.2
-nuget/nuget/-/xunit.runner.visualstudio/2.4.3
-nuget/nuget/-/Newtonsoft.Json/9.0.1
-nuget/nuget/-/Xunit.Extensions.AssemblyFixture/2.4.1
+nuget/nuget/-/AutoFixture.AutoFakeItEasy/4.17.0, MIT, approved, #3193
+nuget/nuget/-/AutoFixture.Xunit/4.17.0, MIT, approved, #3188
+nuget/nuget/-/AutoFixture/4.17.0, MIT, approved, clearlydefined
+nuget/nuget/-/Castle.Core/4.3.1, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/EFCore.NamingConventions/6.0.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/FakeItEasy/7.3.1, MIT, approved, #3200
+nuget/nuget/-/Fare/2.1.1, MIT, approved, clearlydefined
+nuget/nuget/-/FluentAssertions/6.7.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Flurl.Http.Signed/3.2.4, MIT, approved, #3503
+nuget/nuget/-/Flurl.Signed/3.0.6, MIT, approved, #3501
+nuget/nuget/-/Humanizer.Core/2.8.26, MIT, approved, clearlydefined
+nuget/nuget/-/Laraue.EfCoreTriggers.Common/6.3.6, MIT, approved, #5910
+nuget/nuget/-/Laraue.EfCoreTriggers.PostgreSql/6.3.6, MIT, approved, #5911
+nuget/nuget/-/MailKit/2.15.0, MIT, approved, clearlydefined
+nuget/nuget/-/MimeKit/2.15.1, MIT, approved, clearlydefined
+nuget/nuget/-/Newtonsoft.Json/12.0.2, MIT, approved, clearlydefined
+nuget/nuget/-/Newtonsoft.Json/13.0.2, MIT AND BSD-3-Clause, approved, #3266
+nuget/nuget/-/Newtonsoft.Json/9.0.1, MIT, approved, clearlydefined
+nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL/6.0.7, PostgreSQL AND MIT AND Apache-2.0, approved, #5912
+nuget/nuget/-/Npgsql/6.0.7, LicenseRef-BSD-style, approved, #5913
+nuget/nuget/-/PasswordGenerator/2.1.0, MIT, approved, #3192
+nuget/nuget/-/Portable.BouncyCastle/1.8.10, MIT, approved, clearlydefined
+nuget/nuget/-/Serilog.AspNetCore/6.1.0, Apache-2.0 AND MIT, approved, #8437
+nuget/nuget/-/Serilog.Enrichers.CorrelationId/3.0.1, MIT, approved, clearlydefined
+nuget/nuget/-/Serilog.Enrichers.Environment/2.2.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Serilog.Enrichers.Process/2.0.2, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Serilog.Enrichers.Thread/3.1.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Serilog.Extensions.Hosting/5.0.1, Apache-2.0, approved, #8436
+nuget/nuget/-/Serilog.Extensions.Logging/3.1.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Serilog.Formatting.Compact/1.1.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Serilog.Settings.Configuration/3.4.0, Apache-2.0, approved, #8433
+nuget/nuget/-/Serilog.Sinks.Console/4.1.0, Apache-2.0, approved, #8434
+nuget/nuget/-/Serilog.Sinks.Debug/2.0.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Serilog.Sinks.File/5.0.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Serilog/2.12.0, Apache-2.0, approved, #8435
+nuget/nuget/-/SharpZipLib/1.3.3, GFDL-1.3-or-later AND Apache-2.0 AND BSD-3-Clause AND MIT AND WTFPL AND bzip2-1.0.6, approved, #3264
+nuget/nuget/-/SwashBuckle.AspNetCore/6.5.0, MIT AND Apache-2.0, approved, #7159
+nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/6.5.0, MIT AND Apache-2.0, approved, #7160
+nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/6.5.0, MIT AND Apache-2.0, approved, #7156
+nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/6.5.0, MIT AND Apache-2.0, approved, #7158
+nuget/nuget/-/Swashbuckle.AspNetCore/6.5.0, MIT AND Apache-2.0, approved, #7159
+nuget/nuget/-/Testcontainers/2.1.0, MIT, approved, clearlydefined
+nuget/nuget/-/Xunit.Extensions.AssemblyFixture/2.4.1, MIT, approved, #3502
+nuget/nuget/-/coverlet.collector/3.1.0, MIT, approved, #3187
+nuget/nuget/-/coverlet.collector/3.1.2, MIT, approved, #3187
+nuget/nuget/-/xunit.abstractions/2.0.3, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/xunit.analyzers/0.10.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/xunit.assert/2.4.1, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/xunit.core/2.4.1, MIT AND Apache-2.0, approved, #5914
+nuget/nuget/-/xunit.extensibility.core/2.4.1, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/xunit.extensibility.execution/2.4.1, Apache-2.0 AND MIT, approved, #3199
+nuget/nuget/-/xunit.runner.visualstudio/2.4.3, Apache-2.0 AND MIT, approved, #3265
+nuget/nuget/-/xunit.runner.visualstudio/2.4.5, Apache-2.0 AND MIT, approved, #3265
+nuget/nuget/-/xunit/2.4.1, Apache-2.0 AND MIT, approved, #8438

--- a/scripts/check-dependencies.md
+++ b/scripts/check-dependencies.md
@@ -1,0 +1,9 @@
+# Check dependencies
+
+Dependencies are checked by the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses) with a GitHub workflow (dependencies.yaml).
+
+This workflow uses the executable jar in the download directory.
+
+In order to update the executable jar run the following command from the root directory:
+
+    curl -L --output ./scripts/download/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=0.0.1-SNAPSHOT'


### PR DESCRIPTION
## Description

- add workflow to check 3rd party dependencies with the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses)
run with  dependencies file not changed: https://github.com/eclipse-tractusx/portal-backend/actions/runs/5375054212/jobs/9751059140
example run with dependencies file changed (repurposed unit testing und formatting workflow for testing): https://github.com/eclipse-tractusx/portal-backend/actions/runs/5374531262/jobs/9749999098
- change dependencies file to '-summary' format from Dash Tool

**Due to the new format in the dependencies file: once this PR is merged into dev, all open feature branches should be rebased to dev, as the dependencies check will fail otherwise.**

## Why

Dependencies check should be automated.

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own changes
- [x] I have successfully tested my changes locally
