### PR TITLE
fix(config): extend validation to all properties

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsSettings.cs
@@ -52,12 +52,11 @@ public static class ConnectorsSettingsExtensions
 {
     public static IServiceCollection ConfigureConnectorsSettings(
         this IServiceCollection services,
-        IConfigurationSection section
-        )
+        IConfigurationSection section)
     {
         services.AddOptions<ConnectorsSettings>()
             .Bind(section)
-            .ValidateDistinctValues()
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
         return services;
     }

--- a/src/administration/Administration.Service/BusinessLogic/DocumentSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/DocumentSettings.cs
@@ -49,7 +49,7 @@ public static class DocumentSettingsExtension
             .Bind(section)
             .ValidateDataAnnotations()
             .ValidateEnumEnumeration(section)
-            .ValidateDistinctValues()
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
         return services;
     }

--- a/src/administration/Administration.Service/BusinessLogic/InvitationSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationSettings.cs
@@ -53,7 +53,7 @@ public static class InvitationSettingsExtension
         services.AddOptions<InvitationSettings>()
             .Bind(section)
             .ValidateDataAnnotations()
-            .ValidateDistinctValues()
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
         return services;
     }

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationSettings.cs
@@ -53,7 +53,7 @@ public static class RegistrationSettingsExtension
             .Bind(section)
             .ValidateDataAnnotations()
             .ValidateEnumEnumeration(section)
-            .ValidateDistinctValues()
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
         return services;
     }

--- a/src/administration/Administration.Service/BusinessLogic/UserSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserSettings.cs
@@ -86,7 +86,7 @@ public static class UserSettingsExtension
             .Bind(section)
             .ValidateDataAnnotations()
             .ValidateEnumEnumeration(section)
-            .ValidateDistinctValues()
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
         return services;
     }

--- a/src/externalsystems/OfferProvider.Library/DependencyInjection/OfferProviderServiceCollectionExtension.cs
+++ b/src/externalsystems/OfferProvider.Library/DependencyInjection/OfferProviderServiceCollectionExtension.cs
@@ -32,9 +32,10 @@ public static class OfferProviderServiceCollectionExtension
 {
     public static IServiceCollection AddOfferProviderService(this IServiceCollection services, IConfiguration configuration)
     {
+        var configSection = configuration.GetSection("OfferProvider");
         services.AddOptions<OfferProviderSettings>()
-            .Bind(configuration.GetSection("OfferProvider"))
-            .ValidateDistinctValues()
+            .Bind(configSection)
+            .ValidateDistinctValues(configSection)
             .ValidateOnStart();
         services.AddTransient<LoggingHandler<OfferProviderService>>();
 

--- a/src/framework/Framework.Models/Validation/BaseOptionEnumerableValidation.cs
+++ b/src/framework/Framework.Models/Validation/BaseOptionEnumerableValidation.cs
@@ -1,3 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Linq;

--- a/src/framework/Framework.Models/Validation/BaseOptionEnumerableValidation.cs
+++ b/src/framework/Framework.Models/Validation/BaseOptionEnumerableValidation.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Linq;
+using System.Collections;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Validation;
+
+public abstract class BaseOptionEnumerableValidation<TOptions> : IValidateOptions<TOptions> where TOptions : class
+{
+    protected ImmutableArray<Type> IgnoreTypes = new List<Type>
+    {
+        typeof(String),
+        typeof(Boolean),
+        typeof(Decimal),
+    }.ToImmutableArray();
+
+    protected readonly IConfiguration Section;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="name">The name of the option.</param>
+    /// <param name="section"></param>
+    protected BaseOptionEnumerableValidation(string name, IConfiguration section)
+    {
+        Name = name;
+        Section = section;
+    }
+
+    /// <summary>
+    /// The options name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Validates a specific named options instance (or all when <paramref name="name"/> is null).
+    /// </summary>
+    /// <param name="name">The name of the options instance being validated.</param>
+    /// <param name="options">The options instance.</param>
+    /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
+    public ValidateOptionsResult Validate(string? name, TOptions options)
+    {
+        // Null name is used to configure all named options.
+        if (name == null || name != Name)
+        {
+            return ValidateOptionsResult.Skip;
+        }
+
+        var validationErrors = GetValidationErrors(options.GetType(), Section);
+
+        return validationErrors.IfAny(
+            errors => errors.Select(r => $"DataAnnotation validation failed for members: '{string.Join(",", r.MemberNames)}' with the error: '{r.ErrorMessage}'."),
+            out var messages)
+                ? ValidateOptionsResult.Fail(messages)
+                : ValidateOptionsResult.Success;
+    }
+
+    private IEnumerable<ValidationResult> GetValidationErrors(Type type, IConfiguration configSection)
+    {
+        var validationResults = new List<ValidationResult>();
+        foreach (var property in type
+                     .GetProperties()
+                     .Where(prop =>
+                         !IgnoreTypes.Contains(prop.PropertyType) &&
+                         !prop.PropertyType.IsEnum))
+        {
+            var propertyName = property.Name;
+            validationResults.AddRange(ValidateAttribute(configSection, property, propertyName));
+            validationResults.AddRange(CheckPropertiesOfProperty(configSection, property, propertyName));
+        }
+
+        foreach (var validationResult in validationResults)
+        {
+            yield return validationResult;
+        }
+    }
+
+    protected abstract IEnumerable<ValidationResult> ValidateAttribute(IConfiguration config, PropertyInfo property, string propertyName);
+
+    private IEnumerable<ValidationResult> CheckPropertiesOfProperty(IConfiguration configSection, PropertyInfo property, string propertyName)
+    {
+        var validationResults = new List<ValidationResult>();
+        if (property.PropertyType.IsClass)
+        {
+            validationResults.AddRange(GetValidationErrors(property.PropertyType, configSection.GetSection(propertyName)));
+        }
+        else if (property.PropertyType.GetInterfaces().Contains(typeof(IEnumerable)))
+        {
+            var propertyType = property.PropertyType.GetGenericArguments().FirstOrDefault();
+            if (propertyType == null || IgnoreTypes.Contains(propertyType) || propertyType.IsEnum)
+                yield break;
+
+            // Validate each item of the enumerable
+            var listValues = (IEnumerable)configSection.GetSection(propertyName).Get(property.PropertyType);
+            if (listValues != null)
+            {
+                var errors = Enumerable.Range(0, listValues.ToIEnumerable().Count())
+                    .SelectMany(i => GetValidationErrors(propertyType, configSection.GetSection($"{propertyName}:{i}")));
+                validationResults.AddRange(errors);
+            }
+        }
+
+        foreach (var validationResult in validationResults)
+        {
+            yield return validationResult;
+        }
+    }
+}

--- a/src/framework/Framework.Models/Validation/BaseOptionEnumerableValidation.cs
+++ b/src/framework/Framework.Models/Validation/BaseOptionEnumerableValidation.cs
@@ -30,12 +30,10 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Validation;
 
 public abstract class BaseOptionEnumerableValidation<TOptions> : IValidateOptions<TOptions> where TOptions : class
 {
-    protected ImmutableArray<Type> IgnoreTypes = new List<Type>
-    {
+    protected static ImmutableArray<Type> IgnoreTypes = ImmutableArray.Create(
         typeof(String),
         typeof(Boolean),
-        typeof(Decimal),
-    }.ToImmutableArray();
+        typeof(Decimal));
 
     protected readonly IConfiguration Section;
 
@@ -82,7 +80,7 @@ public abstract class BaseOptionEnumerableValidation<TOptions> : IValidateOption
         type.GetProperties()
             .ExceptBy(IgnoreTypes, prop => prop.PropertyType)
             .Where(prop => !prop.PropertyType.IsEnum)
-            .SelectMany(property => 
+            .SelectMany(property =>
                 ValidateAttribute(configSection, property, property.Name)
                     .Concat(CheckPropertiesOfProperty(configSection, property, property.Name)));
 

--- a/src/framework/Framework.Models/Validation/BaseOptionEnumerableValidation.cs
+++ b/src/framework/Framework.Models/Validation/BaseOptionEnumerableValidation.cs
@@ -28,13 +28,16 @@ using System.Reflection;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Validation;
 
-public abstract class BaseOptionEnumerableValidation<TOptions> : IValidateOptions<TOptions> where TOptions : class
+public abstract class SharedBaseOptionEnumerableValidation
 {
-    protected static ImmutableArray<Type> IgnoreTypes = ImmutableArray.Create(
+    protected static readonly ImmutableArray<Type> IgnoreTypes = ImmutableArray.Create(
         typeof(String),
         typeof(Boolean),
         typeof(Decimal));
+}
 
+public abstract class BaseOptionEnumerableValidation<TOptions> : SharedBaseOptionEnumerableValidation, IValidateOptions<TOptions> where TOptions : class
+{
     protected readonly IConfiguration Section;
 
     /// <summary>

--- a/src/framework/Framework.Models/Validation/DistinctValuesValidation.cs
+++ b/src/framework/Framework.Models/Validation/DistinctValuesValidation.cs
@@ -18,9 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Linq;
+using System.Collections;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
@@ -30,83 +32,56 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Validation;
 /// Implementation of <see cref="IValidateOptions{TOptions}"/> that uses DataAnnotation's <see cref="Validator"/> for validation.
 /// </summary>
 /// <typeparam name="TOptions">The instance being validated.</typeparam>
-public class DistinctValuesValidation<TOptions> : IValidateOptions<TOptions> where TOptions : class
+public class DistinctValuesValidation<TOptions> : BaseOptionEnumerableValidation<TOptions> where TOptions : class
 {
     /// <summary>
     /// Constructor.
     /// </summary>
     /// <param name="name">The name of the option.</param>
-    public DistinctValuesValidation(string name)
+    /// <param name="config">The configuration</param>
+    public DistinctValuesValidation(string name, IConfiguration config)
+        : base(name, config)
     {
-        Name = name;
     }
 
-    /// <summary>
-    /// The options name.
-    /// </summary>
-    public string Name { get; }
-
-    /// <summary>
-    /// Validates a specific named options instance (or all when <paramref name="name"/> is null).
-    /// </summary>
-    /// <param name="name">The name of the options instance being validated.</param>
-    /// <param name="options">The options instance.</param>
-    /// <returns>The <see cref="ValidateOptionsResult"/> result.</returns>
-    public ValidateOptionsResult Validate(string? name, TOptions options)
+    /// <inheritdoc />
+    protected override IEnumerable<ValidationResult> ValidateAttribute(IConfiguration config, PropertyInfo property, string propertyName)
     {
-        // Null name is used to configure all named options.
-        if (name == null || name != Name)
+        if (!Attribute.IsDefined(property, typeof(DistinctValuesAttribute)))
+            yield break;
+
+        var attribute = (DistinctValuesAttribute)property.GetCustomAttributes(typeof(DistinctValuesAttribute), false).Single();
+
+        if (!property.PropertyType.GetInterfaces().Contains(typeof(IEnumerable)))
         {
-            return ValidateOptionsResult.Skip;
+            throw new UnexpectedConditionException(
+                $"Attribute DistinctValues is applied to property {property.Name} which is not an IEnumerable type ({property.PropertyType})");
+        }
+        var listValues = (IEnumerable)config.GetSection(propertyName).Get(property.PropertyType);
+        var items = listValues?.ToIEnumerable();
+
+        IEnumerable<object> duplicates;
+
+        switch (attribute.Selector, items)
+        {
+            case (null, null):
+                yield break;
+            case (null, _):
+                duplicates = items.Duplicates();
+                break;
+            case (_, null):
+                GetDelegate(attribute.Selector, property);
+                yield break;
+            default:
+                var selector = GetDelegate(attribute.Selector, property);
+                duplicates = items.DuplicatesBy(x => selector.DynamicInvoke(x));
+                break;
         }
 
-        var validationErrors = GetValidationErrors(options);
-
-        return validationErrors.IfAny(
-            errors => errors.Select(r => $"DataAnnotation validation failed for members: '{string.Join(",", r.MemberNames)}' with the error: '{r.ErrorMessage}'."),
-            out var messages)
-                ? ValidateOptionsResult.Fail(messages)
-                : ValidateOptionsResult.Success;
-    }
-
-    private static IEnumerable<ValidationResult> GetValidationErrors(TOptions options)
-    {
-        foreach (var propertyInfo in options.GetType()
-                        .GetProperties().Where(prop => Attribute.IsDefined(prop, typeof(DistinctValuesAttribute))))
+        if (duplicates.IfAny(dup => $"{string.Join(",", dup)} are duplicate values for {property.Name}.",
+                out var message))
         {
-            var attribute = (DistinctValuesAttribute)propertyInfo.GetCustomAttributes(typeof(DistinctValuesAttribute), false).Single();
-
-            if (!propertyInfo.PropertyType.GetInterfaces().Contains(typeof(System.Collections.IEnumerable)))
-            {
-                throw new UnexpectedConditionException($"Attribute DistinctValues is applied to property {propertyInfo.Name} which is not an IEnumerable type ({propertyInfo.PropertyType})");
-            }
-
-            var getter = propertyInfo.GetGetMethod() ?? throw new UnexpectedConditionException($"cannot access property getter of {propertyInfo.Name}");
-
-            var items = getter.Invoke(options, Array.Empty<object>())?.ToIEnumerable();
-
-            IEnumerable<object> duplicates;
-
-            switch (attribute.Selector, items)
-            {
-                case (null, null):
-                    continue;
-                case (null, _):
-                    duplicates = items.Duplicates();
-                    break;
-                case (_, null):
-                    GetDelegate(attribute.Selector, propertyInfo);
-                    continue;
-                default:
-                    var selector = GetDelegate(attribute.Selector, propertyInfo);
-                    duplicates = items.DuplicatesBy(x => selector.DynamicInvoke(x));
-                    break;
-            }
-
-            if (duplicates.IfAny(dup => $"{string.Join(",", dup)} are duplicate values for {propertyInfo.Name}.", out var message))
-            {
-                yield return new(message, new[] { propertyInfo.Name });
-            }
+            yield return new ValidationResult(message, new[] { property.Name });
         }
     }
 

--- a/src/framework/Framework.Models/Validation/SettingValidation.cs
+++ b/src/framework/Framework.Models/Validation/SettingValidation.cs
@@ -49,9 +49,9 @@ public static class SettingValidation
     /// <param name="optionsBuilder">The options builder to add the services to.</param>
     /// <param name="section">The current configuration section</param>
     /// <returns>The <see cref="OptionsBuilder{TOptions}"/> so that additional calls can be chained.</returns>
-    public static OptionsBuilder<TOptions> ValidateDistinctValues<TOptions>(this OptionsBuilder<TOptions> optionsBuilder) where TOptions : class
+    public static OptionsBuilder<TOptions> ValidateDistinctValues<TOptions>(this OptionsBuilder<TOptions> optionsBuilder, IConfigurationSection section) where TOptions : class
     {
-        optionsBuilder.Services.AddTransient<IValidateOptions<TOptions>>(_ => new DistinctValuesValidation<TOptions>(optionsBuilder.Name));
+        optionsBuilder.Services.AddTransient<IValidateOptions<TOptions>>(_ => new DistinctValuesValidation<TOptions>(optionsBuilder.Name, section));
         return optionsBuilder;
     }
 }

--- a/src/framework/Framework.Web/WebApplicationBuildRunner.cs
+++ b/src/framework/Framework.Web/WebApplicationBuildRunner.cs
@@ -47,10 +47,12 @@ public static class WebApplicationBuildRunner
         }
         catch (Exception ex) when (!ex.GetType().Name.Equals("StopTheHostException", StringComparison.Ordinal))
         {
+            LoggingExtensions.EnsureInitialized();
             Log.Fatal(ex, "Unhandled exception");
         }
         finally
         {
+            LoggingExtensions.EnsureInitialized();
             Log.Information("Server Shutting down");
             Log.CloseAndFlush();
         }

--- a/src/mailing/Mailing.Template/TemplateSettings.cs
+++ b/src/mailing/Mailing.Template/TemplateSettings.cs
@@ -98,7 +98,7 @@ public static class TemplateSettingsExtention
         services.AddOptions<TemplateSettings>()
             .Bind(section)
             .Validate(x => x.Validate())
-            .ValidateDistinctValues()
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
         return services;
     }

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
@@ -194,7 +194,7 @@ public static class AppsSettingsExtension
             .Bind(section)
             .ValidateDataAnnotations()
             .ValidateEnumEnumeration(section)
-            .ValidateDistinctValues()
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
         return services;
     }

--- a/src/marketplace/Services.Service/ServiceSettings.cs
+++ b/src/marketplace/Services.Service/ServiceSettings.cs
@@ -151,7 +151,7 @@ public static class ServiceSettingsExtension
             .Bind(section)
             .ValidateDataAnnotations()
             .ValidateEnumEnumeration(section)
-            .ValidateDistinctValues()
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
         return services;
     }

--- a/src/processes/OfferSubscription.Executor/DependencyInjection/OfferSubscriptionProcessCollectionExtensions.cs
+++ b/src/processes/OfferSubscription.Executor/DependencyInjection/OfferSubscriptionProcessCollectionExtensions.cs
@@ -31,9 +31,10 @@ public static class OfferSubscriptionProcessCollectionExtensions
 {
     public static IServiceCollection AddOfferSubscriptionProcessExecutor(this IServiceCollection services, IConfiguration config)
     {
+        var section = config.GetSection("OfferSubscriptionProcess");
         services.AddOptions<OfferSubscriptionsProcessSettings>()
-            .Bind(config.GetSection("OfferSubscriptionProcess"))
-            .ValidateDistinctValues()
+            .Bind(section)
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
 
         return services

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationSettings.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationSettings.cs
@@ -84,7 +84,7 @@ public static class RegistrationSettingsExtension
             .Bind(section)
             .ValidateDataAnnotations()
             .ValidateEnumEnumeration(section)
-            .ValidateDistinctValues()
+            .ValidateDistinctValues(section)
             .ValidateOnStart();
         return services;
     }

--- a/tests/framework/Framework.Models.Tests/ValidationTests.cs
+++ b/tests/framework/Framework.Models.Tests/ValidationTests.cs
@@ -61,19 +61,33 @@ public class ValidationTests
     public void DistinctValuesValidation_Distinct_ReturnsExpected()
     {
         // Arrange
-        var settings = new DistinctValuesTestSettings()
+        const string configuration = @"
         {
-            StringProperty = new[] { "foo", "bar", "baz" },
-            TypedProperty = new DistinctValuesTypedPropery[] {
-                new () { Key = "foo", Value = "value1"},
-                new () { Key = "bar", Value = "value2"},
-                new () { Key = "baz", Value = "value3"}
-            }
-        };
-
+            ""StringProperty"": [
+                ""foo"",
+                ""bar"",
+                ""baz""
+            ],
+            ""TypedProperty"": [
+                {
+                    ""Key"": ""foo"",
+                    ""Value"": ""value1""
+                },
+                {
+                    ""Key"": ""bar"",
+                    ""Value"": ""value2""
+                },
+                {
+                    ""Key"": ""baz"",
+                    ""Value"": ""value3""
+                }
+            ]
+        }";
+        var config = new ConfigurationBuilder().AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(configuration))).Build();
+        var settings = config.Get<DistinctValuesTestSettings>();
         var name = _fixture.Create<string>();
 
-        var sut = new DistinctValuesValidation<DistinctValuesTestSettings>(name);
+        var sut = new DistinctValuesValidation<DistinctValuesTestSettings>(name, config);
 
         // Act
         var result = sut.Validate(name, settings);
@@ -91,10 +105,16 @@ public class ValidationTests
     public void DistinctValuesValidation_Missing_ReturnsExpected()
     {
         // Arrange
+        const string configuration = @"
+        {
+            ""StringProperty"": [],
+            ""TypedProperty"": []
+        }";
+        var config = new ConfigurationBuilder().AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(configuration))).Build();
         var settings = new DistinctValuesTestSettings();
         var name = _fixture.Create<string>();
 
-        var sut = new DistinctValuesValidation<DistinctValuesTestSettings>(name);
+        var sut = new DistinctValuesValidation<DistinctValuesTestSettings>(name, config);
 
         // Act
         var result = sut.Validate(name, settings);
@@ -112,18 +132,33 @@ public class ValidationTests
     public void DistinctValuesValidation_Duplicates_ReturnsExpected()
     {
         // Arrange
-        var settings = new DistinctValuesTestSettings()
+        const string configuration = @"
         {
-            StringProperty = new[] { "foo", "bar", "foo" },
-            TypedProperty = new DistinctValuesTypedPropery[] {
-                new () { Key = "foo", Value = "value1"},
-                new () { Key = "bar", Value = "value2"},
-                new () { Key = "foo", Value = "value3"}
-            }
-        };
+            ""StringProperty"": [
+                ""foo"",
+                ""bar"",
+                ""foo""
+            ],
+            ""TypedProperty"": [
+                {
+                    ""Key"": ""foo"",
+                    ""Value"": ""value1""
+                },
+                {
+                    ""Key"": ""bar"",
+                    ""Value"": ""value2""
+                },
+                {
+                    ""Key"": ""foo"",
+                    ""Value"": ""value3""
+                }
+            ]
+        }";
+        var config = new ConfigurationBuilder().AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(configuration))).Build();
+        var settings = config.Get<DistinctValuesTestSettings>();
         var name = _fixture.Create<string>();
 
-        var sut = new DistinctValuesValidation<DistinctValuesTestSettings>(name);
+        var sut = new DistinctValuesValidation<DistinctValuesTestSettings>(name, config);
 
         // Act
         var result = sut.Validate(name, settings);
@@ -141,17 +176,28 @@ public class ValidationTests
     public void DistinctValuesValidation_InvalidProperty_ThrowsExpected()
     {
         // Arrange
-        var settings = new InvalidDistinctValuesTestSettings()
+        const string configuration = @"
         {
-            InvalidProperty = new DistinctValuesTypedPropery[] {
-                new () { Key = "foo", Value = "value1"},
-                new () { Key = "bar", Value = "value2"},
-                new () { Key = "foo", Value = "value3"}
-            }
-        };
+            ""InvalidProperty"": [
+                {
+                    ""Key"": ""foo"",
+                    ""Value"": ""value1""
+                },
+                {
+                    ""Key"": ""bar"",
+                    ""Value"": ""value2""
+                },
+                {
+                    ""Key"": ""foo"",
+                    ""Value"": ""value3""
+                }
+            ]
+        }";
+        var config = new ConfigurationBuilder().AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(configuration))).Build();
+        var settings = config.Get<InvalidDistinctValuesTestSettings>();
         var name = _fixture.Create<string>();
 
-        var sut = new DistinctValuesValidation<InvalidDistinctValuesTestSettings>(name);
+        var sut = new DistinctValuesValidation<InvalidDistinctValuesTestSettings>(name, config);
 
         var Act = () => sut.Validate(name, settings);
 
@@ -167,10 +213,15 @@ public class ValidationTests
     public void DistinctValuesValidation_EmptyInvalidProperty_ThrowsExpected()
     {
         // Arrange
+        const string configuration = @"
+        {
+            ""InvalidProperty"": []
+        }";
+        var config = new ConfigurationBuilder().AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(configuration))).Build();
         var settings = new InvalidDistinctValuesTestSettings();
         var name = _fixture.Create<string>();
 
-        var sut = new DistinctValuesValidation<InvalidDistinctValuesTestSettings>(name);
+        var sut = new DistinctValuesValidation<InvalidDistinctValuesTestSettings>(name, config);
 
         var Act = () => sut.Validate(name, settings);
 
@@ -270,7 +321,7 @@ public class ValidationTests
             !r.Skipped &&
             !r.Succeeded &&
             r.Failed &&
-            r.FailureMessage == "DataAnnotation validation failed for members: 'EnumProperty' with the error: 'Extra is not a valid value for Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Tests.ValidationTests+TestEnum. Valid values are: Foo, Bar, Baz'."
+            r.FailureMessage == "DataAnnotation validation failed for members: 'EnumProperty' with the error: 'Extra is not a valid value for Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Tests.ValidationTests+TestEnum in section EnumProperty. Valid values are: Foo, Bar, Baz'."
         );
     }
 
@@ -301,33 +352,6 @@ public class ValidationTests
         // Assert
         result.Should().NotBeNull().And.Match<UnexpectedConditionException>(r =>
             r.Message == "InvalidProperty must be of type IEnumerable<Enum> but is IEnumerable<System.String>"
-        );
-    }
-
-    [Fact]
-    public void EnumEnumerableValidation_NonEnumerable_ThrowsExpected()
-    {
-        // Arrange
-        var appSettings = @"
-        {
-            ""InvalidProperty"": ""Foo""
-        }";
-
-        var config = new ConfigurationBuilder().AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(appSettings))).Build();
-        var name = _fixture.Create<string>();
-
-        var sut = new EnumEnumerableValidation<InvalidNonEnumerableTestSettings>(name, config);
-
-        var settings = config.Get<InvalidNonEnumerableTestSettings>();
-
-        var Act = () => sut.Validate(name, settings);
-
-        // Act
-        var result = Assert.Throws<UnexpectedConditionException>(Act);
-
-        // Assert
-        result.Should().NotBeNull().And.Match<UnexpectedConditionException>(r =>
-            r.Message == "Attribute EnumEnumeration is applied to property InvalidProperty which is not an IEnumerable type (Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Tests.ValidationTests+TestEnum)"
         );
     }
 


### PR DESCRIPTION
## Description

validation for custom attributes EnumEnumerable and DistinctValues extended to validate Properties of properties as well added base implementation for custom enumerable validators

## Why

The current validatio implmentation only validates properties within the given class, but doesn't validate properties of properties.

## Issue

N/A - Jira Issue: CPLP-2698

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
