### PR TITLE
feat(selfDescription)!: selfDescriptionDocument can be send as json

### DIFF
--- a/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
+++ b/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
@@ -106,7 +106,7 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
 
         if (confirm)
         {
-            var documentId = await ProcessDocument(SdFactoryResponseModelTitle.LegalPerson, data, cancellationToken).ConfigureAwait(false);
+            var documentId = await ProcessDocument(SdFactoryResponseModelTitle.LegalPerson, data.Content!, cancellationToken).ConfigureAwait(false);
             _portalRepositories.GetInstance<ICompanyRepository>().AttachAndModifyCompany(companyId, null,
                 c => { c.SelfDescriptionDocumentId = documentId; });
         }
@@ -131,7 +131,7 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
         Guid? documentId = null;
         if (confirm)
         {
-            documentId = await ProcessDocument(SdFactoryResponseModelTitle.Connector, data, cancellationToken).ConfigureAwait(false);
+            documentId = await ProcessDocument(SdFactoryResponseModelTitle.Connector, data.Content!, cancellationToken).ConfigureAwait(false);
         }
         _portalRepositories.GetInstance<IConnectorsRepository>().AttachAndModifyConnector(data.ExternalId, null, con =>
         {
@@ -164,12 +164,12 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
         return confirm;
     }
 
-    private async Task<Guid> ProcessDocument(SdFactoryResponseModelTitle title, SelfDescriptionResponseData data, CancellationToken cancellationToken)
+    private async Task<Guid> ProcessDocument(SdFactoryResponseModelTitle title, JsonDocument content, CancellationToken cancellationToken)
     {
         using var sha512Hash = SHA512.Create();
         using var ms = new MemoryStream();
         using var writer = new Utf8JsonWriter(ms, new JsonWriterOptions { Indented = true });
-        data.Content!.WriteTo(writer);
+        content.WriteTo(writer);
 
         await writer.FlushAsync(cancellationToken);
         var documentContent = ms.ToArray();

--- a/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
+++ b/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
@@ -169,8 +169,7 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
         using var sha512Hash = SHA512.Create();
         using var ms = new MemoryStream();
         using var writer = new Utf8JsonWriter(ms, new JsonWriterOptions { Indented = true });
-        var jsonDocument = JsonDocument.Parse(data.Content!);
-        jsonDocument.WriteTo(writer);
+        data.Content!.WriteTo(writer);
 
         await writer.FlushAsync(cancellationToken);
         var documentContent = ms.ToArray();

--- a/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
+++ b/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
@@ -94,7 +94,7 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
 
     public async Task ProcessFinishSelfDescriptionLpForApplication(SelfDescriptionResponseData data, Guid companyId, CancellationToken cancellationToken)
     {
-        var confirm = ValidateData(data);
+        var confirm = ValidateData(data, out var validated);
         var context = await _checklistService
             .VerifyChecklistEntryAndProcessSteps(
                 data.ExternalId,
@@ -106,7 +106,7 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
 
         if (confirm)
         {
-            var documentId = await ProcessDocument(SdFactoryResponseModelTitle.LegalPerson, data.Content!, cancellationToken).ConfigureAwait(false);
+            var documentId = await ProcessDocument(SdFactoryResponseModelTitle.LegalPerson, validated.Content, cancellationToken).ConfigureAwait(false);
             _portalRepositories.GetInstance<ICompanyRepository>().AttachAndModifyCompany(companyId, null,
                 c => { c.SelfDescriptionDocumentId = documentId; });
         }
@@ -127,11 +127,11 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
     /// <inheritdoc />
     public async Task ProcessFinishSelfDescriptionLpForConnector(SelfDescriptionResponseData data, Guid companyUserId, CancellationToken cancellationToken)
     {
-        var confirm = ValidateData(data);
+        var confirm = ValidateData(data, out var validated);
         Guid? documentId = null;
         if (confirm)
         {
-            documentId = await ProcessDocument(SdFactoryResponseModelTitle.Connector, data.Content!, cancellationToken).ConfigureAwait(false);
+            documentId = await ProcessDocument(SdFactoryResponseModelTitle.Connector, validated.Content, cancellationToken).ConfigureAwait(false);
         }
         _portalRepositories.GetInstance<IConnectorsRepository>().AttachAndModifyConnector(data.ExternalId, null, con =>
         {
@@ -142,7 +142,7 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
 
             if (!confirm)
             {
-                con.SelfDescriptionMessage = data.Message!;
+                con.SelfDescriptionMessage = validated.Message;
             }
 
             con.LastEditorId = companyUserId;
@@ -150,18 +150,48 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
         });
     }
 
-    private static bool ValidateData(SelfDescriptionResponseData data)
+    private sealed class ValidatedResponseData
     {
-        var confirm = data.Status == SelfDescriptionStatus.Confirm;
-        switch (confirm)
+        private readonly bool _confirm;
+        private readonly SelfDescriptionResponseData _data;
+
+        public ValidatedResponseData(SelfDescriptionResponseData data)
         {
-            case false when string.IsNullOrEmpty(data.Message):
-                throw new ConflictException("Please provide a messsage");
-            case true when data.Content == null:
-                throw new ConflictException("Please provide a selfDescriptionDocument");
+            _confirm = data.Status == SelfDescriptionStatus.Confirm;
+            switch (_confirm)
+            {
+                case false when string.IsNullOrEmpty(data.Message):
+                    throw new ConflictException("Please provide a messsage");
+                case true when data.Content == null:
+                    throw new ConflictException("Please provide a selfDescriptionDocument");
+            }
+            _data = data;
         }
 
-        return confirm;
+        public bool Confirm
+        {
+            get => _confirm;
+        }
+
+        public string Message
+        {
+            get => _data.Message == null || _confirm
+                ? throw new InvalidOperationException("Message may only be called when Confirm is false")
+                : _data.Message;
+        }
+
+        public JsonDocument Content
+        {
+            get => _data.Content == null || !_confirm
+                ? throw new InvalidOperationException("Content may only be called when Confirm is true")
+                : _data.Content;
+        }
+    }
+
+    private static bool ValidateData(SelfDescriptionResponseData data, out ValidatedResponseData validated)
+    {
+        validated = new(data);
+        return validated.Confirm;
     }
 
     private async Task<Guid> ProcessDocument(SdFactoryResponseModelTitle title, JsonDocument content, CancellationToken cancellationToken)

--- a/src/externalsystems/SdFactory.Library/Models/SelfDescriptionResponseData.cs
+++ b/src/externalsystems/SdFactory.Library/Models/SelfDescriptionResponseData.cs
@@ -18,6 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
@@ -26,4 +28,4 @@ public record SelfDescriptionResponseData(
     [property: JsonPropertyName("externalId")] Guid ExternalId,
     [property: JsonPropertyName("status")] SelfDescriptionStatus Status,
     [property: JsonPropertyName("message")] string? Message,
-    [property: JsonPropertyName("selfDescriptionDocument")] string? Content);
+    [property: JsonPropertyName("selfDescriptionDocument")] JsonDocument? Content);

--- a/src/externalsystems/SdFactory.Library/Models/SelfDescriptionResponseData.cs
+++ b/src/externalsystems/SdFactory.Library/Models/SelfDescriptionResponseData.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -35,6 +35,7 @@ using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
 using System.Collections.Immutable;
+using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.BusinessLogic;
 
@@ -515,7 +516,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var connectorId = Guid.NewGuid();
-        var data = new SelfDescriptionResponseData(connectorId, SelfDescriptionStatus.Confirm, null, "{ \"test\": true }");
+        var data = new SelfDescriptionResponseData(connectorId, SelfDescriptionStatus.Confirm, null, JsonDocument.Parse("{ \"test\": true }"));
         A.CallTo(() => _connectorsRepository.GetConnectorDataById(A<Guid>._))
             .Returns((connectorId, (Guid?)null));
 
@@ -534,7 +535,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var connectorId = Guid.NewGuid();
-        var data = new SelfDescriptionResponseData(connectorId, SelfDescriptionStatus.Confirm, null, "{ \"test\": true }");
+        var data = new SelfDescriptionResponseData(connectorId, SelfDescriptionStatus.Confirm, null, JsonDocument.Parse("{ \"test\": true }"));
         A.CallTo(() => _connectorsRepository.GetConnectorDataById(A<Guid>._))
             .Returns(((Guid, Guid?))default);
 
@@ -552,7 +553,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var connectorId = Guid.NewGuid();
-        var data = new SelfDescriptionResponseData(connectorId, SelfDescriptionStatus.Confirm, null, "{ \"test\": true }");
+        var data = new SelfDescriptionResponseData(connectorId, SelfDescriptionStatus.Confirm, null, JsonDocument.Parse("{ \"test\": true }"));
         A.CallTo(() => _connectorsRepository.GetConnectorDataById(A<Guid>._))
             .Returns((connectorId, Guid.NewGuid()));
 

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -36,6 +36,7 @@ using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
 using System.Collections.Immutable;
+using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.BusinessLogic;
 
@@ -598,7 +599,7 @@ public class RegistrationBusinessLogicTest
     public async Task ProcessClearinghouseSelfDescription_WithValidData_CallsExpected()
     {
         // Arrange
-        var data = new SelfDescriptionResponseData(ApplicationId, SelfDescriptionStatus.Confirm, null, "{ \"test\": true }");
+        var data = new SelfDescriptionResponseData(ApplicationId, SelfDescriptionStatus.Confirm, null, JsonDocument.Parse("{ \"test\": true }"));
         var companyId = Guid.NewGuid();
         A.CallTo(() => _applicationRepository.GetCompanyIdSubmissionStatusForApplication(ApplicationId))
             .Returns((true, companyId, true));
@@ -616,7 +617,7 @@ public class RegistrationBusinessLogicTest
     public async Task ProcessClearinghouseSelfDescription_WithNotExistingApplication_ThrowsNotFoundException()
     {
         // Arrange
-        var data = new SelfDescriptionResponseData(ApplicationId, SelfDescriptionStatus.Confirm, null, "{ \"test\": true }");
+        var data = new SelfDescriptionResponseData(ApplicationId, SelfDescriptionStatus.Confirm, null, JsonDocument.Parse("{ \"test\": true }"));
         A.CallTo(() => _applicationRepository.GetCompanyIdSubmissionStatusForApplication(ApplicationId))
             .Returns(((bool, Guid, bool))default);
 
@@ -632,7 +633,7 @@ public class RegistrationBusinessLogicTest
     public async Task ProcessClearinghouseSelfDescription_WithNotSubmittedApplication_ThrowsConflictException()
     {
         // Arrange
-        var data = new SelfDescriptionResponseData(ApplicationId, SelfDescriptionStatus.Confirm, null, "{ \"test\": true }");
+        var data = new SelfDescriptionResponseData(ApplicationId, SelfDescriptionStatus.Confirm, null, JsonDocument.Parse("{ \"test\": true }"));
         A.CallTo(() => _applicationRepository.GetCompanyIdSubmissionStatusForApplication(ApplicationId))
             .Returns((true, Guid.NewGuid(), false));
 

--- a/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
@@ -28,6 +28,7 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
+using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Controllers;
 
@@ -199,8 +200,7 @@ public class ConnectorsControllerTests
     public async Task ProcessClearinghouseSelfDescription_ReturnsExpectedResult()
     {
         // Arrange
-        var data = new SelfDescriptionResponseData(Guid.NewGuid(), SelfDescriptionStatus.Confirm, null, "{ \"test\": true }");
-
+        var data = new SelfDescriptionResponseData(Guid.NewGuid(), SelfDescriptionStatus.Confirm, null, JsonDocument.Parse("{ \"test\": true }"));
         // Act
         var result = await this._controller.ProcessClearinghouseSelfDescription(data, CancellationToken.None);
 

--- a/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
@@ -28,6 +28,7 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
 using System.Text;
+using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Controllers;
 
@@ -243,7 +244,7 @@ public class RegistrationControllerTest
     public async Task ProcessClearinghouseSelfDescription_ReturnsExpectedResult()
     {
         // Arrange
-        var data = new SelfDescriptionResponseData(Guid.NewGuid(), SelfDescriptionStatus.Confirm, null, "{ \"test\": true }");
+        var data = new SelfDescriptionResponseData(Guid.NewGuid(), SelfDescriptionStatus.Confirm, null, JsonDocument.Parse("{ \"test\": true }"));
         A.CallTo(() => _logic.ProcessClearinghouseSelfDescription(data, A<CancellationToken>._))
             .ReturnsLazily(() => Task.CompletedTask);
 

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
@@ -28,6 +28,7 @@ using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
 using System.Collections.Immutable;
+using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Tests;
 
@@ -203,7 +204,7 @@ public class SdFactoryBusinessLogicTests
             .With(x => x.SelfDescriptionDocumentId, (Guid?)null)
             .Create();
         const string contentJson = "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://github.com/catenax-ng/tx-sd-factory/raw/clearing-house/src/main/resources/verifiablecredentials.jsonld/sd-document-v22.10.jsonld\",\"https://w3id.org/vc/status-list/2021/v1\"],\"type\":[\"VerifiableCredential\",\"LegalPerson\"],\"issuer\":\"did:sov:12345\",\"issuanceDate\":\"2023-02-18T23:03:16Z\",\"expirationDate\":\"2023-05-19T23:03:16Z\",\"credentialSubject\":{\"bpn\":\"BPNL000000000000\",\"registrationNumber\":[{\"type\":\"local\",\"value\":\"o12345678\"}],\"headquarterAddress\":{\"countryCode\":\"DE\"},\"type\":\"LegalPerson\",\"legalAddress\":{\"countryCode\":\"DE\"},\"id\":\"did:sov:12345\"},\"credentialStatus\":{\"id\":\"https://managed-identity-wallets.int.demo.catena-x.net/api/credentials/status/123\",\"type\":\"StatusList2021Entry\",\"statusPurpose\":\"revocation\",\"statusListIndex\":\"58\",\"statusListCredential\":\"https://managed-identity-wallets.int.demo.catena-x.net/api/credentials/status/123\"},\"proof\":{\"type\":\"Ed25519Signature2018\",\"created\":\"2023-02-18T23:03:18Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:sov:12345#key-1\",\"jws\":\"test\"}}";
-        var data = new SelfDescriptionResponseData(ApplicationId, SelfDescriptionStatus.Confirm, null, contentJson);
+        var data = new SelfDescriptionResponseData(ApplicationId, SelfDescriptionStatus.Confirm, null, JsonDocument.Parse(contentJson));
         SetupForProcessFinish(company, applicationChecklistEntry);
 
         // Act
@@ -339,7 +340,7 @@ public class SdFactoryBusinessLogicTests
         // Arrange
         var connector = new Connector(Guid.NewGuid(), "con-air", "de", "https://one-url.com");
         const string contentJson = "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://github.com/catenax-ng/tx-sd-factory/raw/clearing-house/src/main/resources/verifiablecredentials.jsonld/sd-document-v22.10.jsonld\",\"https://w3id.org/vc/status-list/2021/v1\"],\"type\":[\"VerifiableCredential\",\"LegalPerson\"],\"issuer\":\"did:sov:12345\",\"issuanceDate\":\"2023-02-18T23:03:16Z\",\"expirationDate\":\"2023-05-19T23:03:16Z\",\"credentialSubject\":{\"bpn\":\"BPNL000000000000\",\"registrationNumber\":[{\"type\":\"local\",\"value\":\"o12345678\"}],\"headquarterAddress\":{\"countryCode\":\"DE\"},\"type\":\"LegalPerson\",\"legalAddress\":{\"countryCode\":\"DE\"},\"id\":\"did:sov:12345\"},\"credentialStatus\":{\"id\":\"https://managed-identity-wallets.int.demo.catena-x.net/api/credentials/status/123\",\"type\":\"StatusList2021Entry\",\"statusPurpose\":\"revocation\",\"statusListIndex\":\"58\",\"statusListCredential\":\"https://managed-identity-wallets.int.demo.catena-x.net/api/credentials/status/123\"},\"proof\":{\"type\":\"Ed25519Signature2018\",\"created\":\"2023-02-18T23:03:18Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:sov:12345#key-1\",\"jws\":\"test\"}}";
-        var data = new SelfDescriptionResponseData(connector.Id, SelfDescriptionStatus.Confirm, null, contentJson);
+        var data = new SelfDescriptionResponseData(connector.Id, SelfDescriptionStatus.Confirm, null, JsonDocument.Parse(contentJson));
         SetupForProcessFinishForConnector(connector);
 
         // Act


### PR DESCRIPTION
## Description

the data structure for the endpoints

/api/administration/connectors/clearinghouse/selfDescription 
/api/administration/registration/clearinghouse/selfDescription

have been changed for selfDescriptionDocument from string to JsonDocument

BREAKING CHANGE: data structure for endpoints changed

## Why

The external requests are sending the selfDescription document as json, it's easier to take it as it is and don't have the external services convert the json to a string

## Issue

N/A - Jira Issue: CPLP-2847

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
