### PR TITLE
feat(seeding): add configurable path for seeding data

### DIFF
--- a/src/framework/Framework.Seeding/CustomSeederRunner.cs
+++ b/src/framework/Framework.Seeding/CustomSeederRunner.cs
@@ -20,7 +20,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding;
 
@@ -31,7 +30,6 @@ internal class CustomSeederRunner
 {
     private readonly ICustomSeeder[] _seeders;
     private readonly ILogger<CustomSeederRunner> _logger;
-    private readonly SeederSettings _settings;
 
     /// <summary>
     /// Creates a new instance of <see cref="CustomSeederRunner"/>
@@ -39,9 +37,8 @@ internal class CustomSeederRunner
     /// </summary>
     /// <param name="serviceProvider">The service provider with the CustomSeeder registrations</param>
     /// <param name="logger">Logger</param>
-    /// <param name="options">The options</param>
-    public CustomSeederRunner(IServiceProvider serviceProvider, ILogger<CustomSeederRunner> logger, IOptions<SeederSettings> options) =>
-        (_seeders, _logger, _settings) = (serviceProvider.GetServices<ICustomSeeder>().ToArray(), logger, options.Value);
+    public CustomSeederRunner(IServiceProvider serviceProvider, ILogger<CustomSeederRunner> logger) =>
+        (_seeders, _logger) = (serviceProvider.GetServices<ICustomSeeder>().ToArray(), logger);
 
     /// <summary>
     /// Executes all registered seeders in the order they have defined
@@ -50,12 +47,6 @@ internal class CustomSeederRunner
     public async Task RunSeedersAsync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Found {SeederCount} custom seeder", _seeders.Length);
-        if (!_settings.DataPaths.Any())
-        {
-            _logger.LogInformation("There a no data paths configured, therefore no seeding will be executed");
-            return;
-        }
-
         foreach (var seeder in _seeders.OrderBy(x => x.Order))
         {
             await seeder.ExecuteAsync(cancellationToken);

--- a/src/framework/Framework.Seeding/SeederHelper.cs
+++ b/src/framework/Framework.Seeding/SeederHelper.cs
@@ -45,7 +45,7 @@ public static class SeederHelper
         }
 
         var data = new ConcurrentBag<T>();
-        var results = await Task.WhenAll(dataPaths.Select(path => GetDataFromFile<T>(logger, fileName, location, path, Options, cancellationToken))).ConfigureAwait(false);
+        var results = await Task.WhenAll(dataPaths.Select(path => GetDataFromFile<T>(logger, fileName, location, path, cancellationToken))).ConfigureAwait(false);
         foreach (var entry in results.SelectMany(item => item))
         {
             data.Add(entry);
@@ -57,7 +57,7 @@ public static class SeederHelper
         };
         await Parallel.ForEachAsync(additionalEnvironments, parallelOptions, async (env, ct) =>
         {
-            var results = await Task.WhenAll(dataPaths.Select(path => GetDataFromFile<T>(logger, fileName, location, path, Options, ct, env))).ConfigureAwait(false);
+            var results = await Task.WhenAll(dataPaths.Select(path => GetDataFromFile<T>(logger, fileName, location, path, ct, env))).ConfigureAwait(false);
             foreach (var entry in results.SelectMany(item => item))
             {
                 data.Add(entry);
@@ -67,7 +67,7 @@ public static class SeederHelper
         return data.ToList();
     }
 
-    private static async Task<List<T>> GetDataFromFile<T>(ILogger logger, string fileName, string location, string dataPath, JsonSerializerOptions options, CancellationToken cancellationToken, string? env = null) where T : class
+    private static async Task<List<T>> GetDataFromFile<T>(ILogger logger, string fileName, string location, string dataPath, CancellationToken cancellationToken, string? env = null) where T : class
     {
         var envPath = env == null ? null : $".{env}";
         var path = Path.Combine(location, dataPath, $"{fileName}{envPath}.json");
@@ -76,7 +76,7 @@ public static class SeederHelper
             return new List<T>();
 
         var data = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
-        var list = JsonSerializer.Deserialize<List<T>>(data, options);
+        var list = JsonSerializer.Deserialize<List<T>>(data, Options);
         return list ?? new List<T>();
     }
 }

--- a/src/framework/Framework.Seeding/SeederSettings.cs
+++ b/src/framework/Framework.Seeding/SeederSettings.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding;
 
 public class SeederSettings
@@ -11,10 +13,12 @@ public class SeederSettings
     /// <summary>
     /// Configurable paths where to check for the seeding data
     /// </summary>
+    [Required]
     public IEnumerable<string> DataPaths { get; set; }
 
     /// <summary>
     /// Configurable environments for the testdata
     /// </summary>
+    [Required]
     public IEnumerable<string> TestDataEnvironments { get; set; }
 }

--- a/src/framework/Framework.Seeding/SeederSettings.cs
+++ b/src/framework/Framework.Seeding/SeederSettings.cs
@@ -3,6 +3,11 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding;
 public class SeederSettings
 {
     /// <summary>
+    /// Configurable paths where to check for the seeding data
+    /// </summary>
+    public List<string> DataPaths { get; set; } = new();
+
+    /// <summary>
     /// Configurable environments for the testdata
     /// </summary>
     public List<string> TestDataEnvironments { get; set; } = new();

--- a/src/framework/Framework.Seeding/SeederSettings.cs
+++ b/src/framework/Framework.Seeding/SeederSettings.cs
@@ -2,13 +2,19 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding;
 
 public class SeederSettings
 {
+    public SeederSettings()
+    {
+        TestDataEnvironments = null!;
+        DataPaths = null!;
+    }
+
     /// <summary>
     /// Configurable paths where to check for the seeding data
     /// </summary>
-    public List<string> DataPaths { get; set; } = new();
+    public IEnumerable<string> DataPaths { get; set; }
 
     /// <summary>
     /// Configurable environments for the testdata
     /// </summary>
-    public List<string> TestDataEnvironments { get; set; } = new();
+    public IEnumerable<string> TestDataEnvironments { get; set; }
 }

--- a/src/marketplace/Apps.Service/ViewModels/AppDetailResponse.cs
+++ b/src/marketplace/Apps.Service/ViewModels/AppDetailResponse.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 

--- a/src/marketplace/Apps.Service/ViewModels/InReviewAppDetails.cs
+++ b/src/marketplace/Apps.Service/ViewModels/InReviewAppDetails.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 

--- a/src/marketplace/Services.Service/ViewModels/ServiceData.cs
+++ b/src/marketplace/Services.Service/ViewModels/ServiceData.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 

--- a/src/marketplace/Services.Service/ViewModels/ServiceDetailResponse.cs
+++ b/src/marketplace/Services.Service/ViewModels/ServiceDetailResponse.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanySsiDetailsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanySsiDetailsRepository.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Microsoft.EntityFrameworkCore;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchInsertSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchInsertSeeder.cs
@@ -144,7 +144,7 @@ public class BatchInsertSeeder : ICustomSeeder
     private async Task SeedTable<T>(string fileName, Func<T, object> keySelector, CancellationToken cancellationToken) where T : class
     {
         _logger.LogInformation("Start seeding {Filename}", fileName);
-        var data = await SeederHelper.GetSeedData<T>(_logger, fileName, cancellationToken, _settings.TestDataEnvironments.ToArray()).ConfigureAwait(false);
+        var data = await SeederHelper.GetSeedData<T>(_logger, fileName, _settings.DataPaths, cancellationToken, _settings.TestDataEnvironments.ToArray()).ConfigureAwait(false);
         _logger.LogInformation("Found {ElementCount} data", data.Count);
         if (data.Any())
         {

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchInsertSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchInsertSeeder.cs
@@ -55,6 +55,12 @@ public class BatchInsertSeeder : ICustomSeeder
     /// <inheritdoc />
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
+        if (!_settings.DataPaths.Any())
+        {
+            _logger.LogInformation("There a no data paths configured, therefore the {SeederName} will be skipped", nameof(BatchUpdateSeeder));
+            return;
+        }
+
         _logger.LogInformation("Start BaseEntityBatch Seeder");
         await SeedTable<Language>("languages", x => x.ShortName, cancellationToken).ConfigureAwait(false);
         await SeedTable<LanguageLongName>("language_long_names", x => new { x.ShortName, x.LanguageShortName }, cancellationToken).ConfigureAwait(false);

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
@@ -108,7 +108,7 @@ public class BatchUpdateSeeder : ICustomSeeder
     private async Task SeedTable<T>(string fileName, Func<T, object> keySelector, Func<(T dataEntity, T dbEntity), bool> whereClause, Action<T, T> updateEntries, CancellationToken cancellationToken) where T : class
     {
         _logger.LogInformation("Start seeding {Filename}", fileName);
-        var data = await SeederHelper.GetSeedData<T>(_logger, fileName, cancellationToken, _settings.TestDataEnvironments.ToArray()).ConfigureAwait(false);
+        var data = await SeederHelper.GetSeedData<T>(_logger, fileName, _settings.DataPaths, cancellationToken, _settings.TestDataEnvironments.ToArray()).ConfigureAwait(false);
         _logger.LogInformation("Found {ElementCount} data", data.Count);
         if (data.Any())
         {

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
@@ -54,6 +54,12 @@ public class BatchUpdateSeeder : ICustomSeeder
     /// <inheritdoc />
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
+        if (!_settings.DataPaths.Any())
+        {
+            _logger.LogInformation("There a no data paths configured, therefore the {SeederName} will be skipped", nameof(BatchUpdateSeeder));
+            return;
+        }
+
         _logger.LogInformation("Start BaseEntityBatch Seeder");
         await SeedTable<LanguageLongName>(
             "language_long_names",

--- a/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditCompanySsiDetail.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditCompanySsiDetail.cs
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Auditing;
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Base;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using System.ComponentModel.DataAnnotations;
 

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/VerifiedCredentialExternalType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/VerifiedCredentialExternalType.cs
@@ -1,4 +1,3 @@
-using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Setup/TestDbFixture.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Setup/TestDbFixture.cs
@@ -101,8 +101,8 @@ public class TestDbFixture : IAsyncLifetime
 
         var seederOptions = Options.Create(new SeederSettings
         {
-            TestDataEnvironments = new List<string> { "test" },
-            DataPaths = new List<string> { "Seeder/Data" }
+            TestDataEnvironments = new [] { "test" },
+            DataPaths = new [] { "Seeder/Data" }
         });
         var insertSeeder = new BatchInsertSeeder(context,
             LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<BatchInsertSeeder>(),

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Setup/TestDbFixture.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Setup/TestDbFixture.cs
@@ -99,7 +99,11 @@ public class TestDbFixture : IAsyncLifetime
         var context = new PortalDbContext(optionsBuilder.Options);
         await context.Database.MigrateAsync();
 
-        var seederOptions = Options.Create(new SeederSettings { TestDataEnvironments = new List<string> { "test" } });
+        var seederOptions = Options.Create(new SeederSettings
+        {
+            TestDataEnvironments = new List<string> { "test" },
+            DataPaths = new List<string> { "Seeder/Data" }
+        });
         var insertSeeder = new BatchInsertSeeder(context,
             LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<BatchInsertSeeder>(),
             seederOptions);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Setup/TestDbFixture.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Setup/TestDbFixture.cs
@@ -101,8 +101,8 @@ public class TestDbFixture : IAsyncLifetime
 
         var seederOptions = Options.Create(new SeederSettings
         {
-            TestDataEnvironments = new [] { "test" },
-            DataPaths = new [] { "Seeder/Data" }
+            TestDataEnvironments = new[] { "test" },
+            DataPaths = new[] { "Seeder/Data" }
         });
         var insertSeeder = new BatchInsertSeeder(context,
             LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<BatchInsertSeeder>(),

--- a/tests/portalbackend/PortalBackend.Migrations.Tests/ConsortiaDataDbFixture.cs
+++ b/tests/portalbackend/PortalBackend.Migrations.Tests/ConsortiaDataDbFixture.cs
@@ -89,7 +89,11 @@ public class ConsortiaDataDbFixture : IAsyncLifetime
         var context = new PortalDbContext(optionsBuilder.Options);
         await context.Database.MigrateAsync();
 
-        var seederOptions = Options.Create(new SeederSettings { TestDataEnvironments = new List<string> { "consortia" } });
+        var seederOptions = Options.Create(new SeederSettings 
+        {
+            TestDataEnvironments = new [] { "consortia" },
+            DataPaths = new [] { "Seeder/Data" } 
+        });
         var insertSeeder = new BatchInsertSeeder(context,
             LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<BatchInsertSeeder>(),
             seederOptions);

--- a/tests/portalbackend/PortalBackend.Migrations.Tests/ConsortiaDataDbFixture.cs
+++ b/tests/portalbackend/PortalBackend.Migrations.Tests/ConsortiaDataDbFixture.cs
@@ -89,10 +89,10 @@ public class ConsortiaDataDbFixture : IAsyncLifetime
         var context = new PortalDbContext(optionsBuilder.Options);
         await context.Database.MigrateAsync();
 
-        var seederOptions = Options.Create(new SeederSettings 
+        var seederOptions = Options.Create(new SeederSettings
         {
-            TestDataEnvironments = new [] { "consortia" },
-            DataPaths = new [] { "Seeder/Data" } 
+            TestDataEnvironments = new[] { "consortia" },
+            DataPaths = new[] { "Seeder/Data" }
         });
         var insertSeeder = new BatchInsertSeeder(context,
             LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<BatchInsertSeeder>(),


### PR DESCRIPTION
## Description

The path of the seeding data is now configurable

## Why

To be able to seed ones own data and don't have the need to edit the json files within the Seeder/Data directory one can now mount a directory which than can be configured to be used for the seeding as well.

## Issue

N/A - Jira Issue:  CPLP-2788

## Corresponding CD PR

[#37](https://github.com/eclipse-tractusx/portal-cd/pull/37)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
