### PR TITLE
fix (Migrations) add dependeny Framework.Models to dockerfile

### DIFF
--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -25,6 +25,8 @@ COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/portalbackend /src/portalbackend
 COPY /src/framework/Framework.DBAccess /src/framework/Framework.DBAccess
 COPY /src/framework/Framework.Logging /src/framework/Framework.Logging
+COPY /src/framework/Framework.Models /src/framework/Framework.Models
+COPY /src/framework/Framework.Linq /src/framework/Framework.Linq
 COPY /src/framework/Framework.ErrorHandling.Library /src/framework/Framework.ErrorHandling.Library
 COPY /src/framework/Framework.BaseDependencies /src/framework/Framework.BaseDependencies
 COPY /src/framework/Framework.Seeding /src/framework/Framework.Seeding


### PR DESCRIPTION
## Description

add copy of module Framework.Models and Framework.Linq to dockerfile of Module Portal.Migrations

## Why

PR #84 for CPLP-2853 does add a new dependency to module Framework.Models and Framework.Linq to module Portal.Migrations. Copying those dependencies was not added to the respective dockerfile. The image of portal.migrations therefore fails to build and thus the required migration is not applied to the database.

## Issue

N/A (CPLP-2853)

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
