### PR TITLE
fix: add missing dependencies for maintenance service

### DIFF
--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -26,6 +26,8 @@ COPY src/maintenance/Maintenance.App/ src/maintenance/Maintenance.App/
 COPY src/portalbackend/PortalBackend.PortalEntities/ src/portalbackend/PortalBackend.PortalEntities/
 COPY src/framework/Framework.BaseDependencies/ src/framework/Framework.BaseDependencies/
 COPY src/framework/Framework.DBAccess/ src/framework/Framework.DBAccess/
+COPY src/framework/Framework.Linq/ src/framework/Framework.Linq/
+COPY src/framework/Framework.Models/ src/framework/Framework.Models/
 COPY src/framework/Framework.ErrorHandling.Library/ src/framework/Framework.ErrorHandling.Library/
 RUN dotnet restore "src/maintenance/Maintenance.App/Maintenance.App.csproj"
 WORKDIR /src/maintenance/Maintenance.App


### PR DESCRIPTION
## Description

ADding missing dependencies to build the docker image of the maintenance service

## Why

Currently the docker image action is failing for the maintenance service

## Issue

N/A - Jira Issue: CPLP-2930

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
