### PR TITLE
bugfix(provisioning): fix migration

### DIFF
--- a/src/provisioning/Provisioning.Migrations/Migrations/20230613120413_230629.Designer.cs
+++ b/src/provisioning/Provisioning.Migrations/Migrations/20230613120413_230629.Designer.cs
@@ -31,8 +31,8 @@ using Org.Eclipse.TractusX.Portal.Backend.Provisioning.ProvisioningEntities;
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Migrations.Migrations
 {
     [DbContext(typeof(ProvisioningDbContext))]
-    [Migration("20230613120413_CPLP-2553-AlignUsers")]
-    partial class CPLP2553AlignUsers
+    [Migration("20230613120413_230629")]
+    partial class _230629
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/src/provisioning/Provisioning.Migrations/Migrations/20230613120413_230629.cs
+++ b/src/provisioning/Provisioning.Migrations/Migrations/20230613120413_230629.cs
@@ -24,10 +24,12 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Migrations.Migrations
 {
-    public partial class CPLP2553AlignUsers : Migration
+    public partial class _230629 : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql("DELETE FROM provisioning.user_password_resets;");
+
             migrationBuilder.DropPrimaryKey(
                 name: "pk_user_password_resets",
                 schema: "provisioning",
@@ -55,6 +57,8 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Migrations.Migrations
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql("DELETE FROM provisioning.user_password_resets;");
+
             migrationBuilder.DropPrimaryKey(
                 name: "pk_user_password_resets",
                 schema: "provisioning",


### PR DESCRIPTION
## Description

- add sql to latest provisioning migration to delete contents of table user_password_resets before migrating to new identitymodel
- rename latest migration removing reference to JIRA-ticket replacing by current date.

remark: on DEV environment the entries of table __efmigrations_history_provisioning must be manually migrated by applying this sql command:
```
update __efmigrations_history_provisioning
set migration_id = '20230613120413_230629'
where migration_id = '20230613120413_CPLP-2553-AlignUsers';
```

## Why

- table provisioning.user_password_resets is being changed by latest migration in such a way that existing data is in conflict with new pk-constraint. The migration therefore fails to run in case the table does contain entries. As the entries are of low value (the table exists to track number of password-resets per user per day) the harm of deleting those entries is negligible.
- migration is being renamed before being applied to INT environment to comply with release naming scheme.

## Issue

N/A (CPLP-2553)

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
