### PR TITLE
feat(app)!: change app subscription process

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -181,7 +181,6 @@ public class AppsBusinessLogic : IAppsBusinessLogic
         _offerSubscriptionService.AddOfferSubscriptionAsync(appId, offerAgreementConsentData, identity, OfferTypeId.APP, _settings.BasePortalAddress);
 
     /// <inheritdoc/>
-    [Obsolete("This Method is not used anymore")]
     public async Task ActivateOwnCompanyProvidedAppSubscriptionAsync(Guid subscriptionId, (Guid UserId, Guid CompanyId) identity)
     {
         var offerSubscriptionRepository = _portalRepositories.GetInstance<IOfferSubscriptionsRepository>();
@@ -255,7 +254,7 @@ public class AppsBusinessLogic : IAppsBusinessLogic
 
         if (status != OfferSubscriptionStatusId.ACTIVE && status != OfferSubscriptionStatusId.PENDING)
         {
-            throw new ArgumentException($"There is no active or pending subscription for company '{companyId}' and subscriptionId '{subscriptionId}'");
+            throw new ConflictException($"There is no active or pending subscription for company '{companyId}' and subscriptionId '{subscriptionId}'");
         }
 
         offerSubscriptionsRepository.AttachAndModifyOfferSubscription(subscriptionId, os =>

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -182,29 +182,24 @@ public class AppsBusinessLogic : IAppsBusinessLogic
 
     /// <inheritdoc/>
     [Obsolete("This Method is not used anymore")]
-    public async Task ActivateOwnCompanyProvidedAppSubscriptionAsync(Guid appId, Guid subscribingCompanyId, (Guid UserId, Guid CompanyId) identity)
+    public async Task ActivateOwnCompanyProvidedAppSubscriptionAsync(Guid subscriptionId, (Guid UserId, Guid CompanyId) identity)
     {
         var offerSubscriptionRepository = _portalRepositories.GetInstance<IOfferSubscriptionsRepository>();
-        var assignedAppData = await offerSubscriptionRepository.GetCompanyAssignedAppDataForProvidingCompanyUserAsync(appId, subscribingCompanyId, identity.CompanyId).ConfigureAwait(false);
+        var assignedAppData = await offerSubscriptionRepository.GetCompanyAssignedAppDataForProvidingCompanyUserAsync(subscriptionId, identity.CompanyId).ConfigureAwait(false);
         if (assignedAppData == default)
         {
-            throw new NotFoundException($"App {appId} does not exist.");
+            throw new NotFoundException($"Subscription {subscriptionId} does not exist.");
         }
 
-        var (subscriptionId, subscriptionStatusId, requesterId, appName, isUserOfProvider, requesterData) = assignedAppData;
+        var (subscriptionStatusId, requesterId, appId, appName, isUserOfProvider, requesterData) = assignedAppData;
         if (!isUserOfProvider)
         {
             throw new ControllerArgumentException("Missing permission: The user's company does not provide the requested app so they cannot activate it.");
         }
 
-        if (subscriptionId == Guid.Empty)
-        {
-            throw new ControllerArgumentException($"subscription for app {appId}, company {subscribingCompanyId} has not been created yet");
-        }
-
         if (subscriptionStatusId != OfferSubscriptionStatusId.PENDING)
         {
-            throw new ControllerArgumentException($"subscription for app {appId}, company {subscribingCompanyId} is not in status PENDING");
+            throw new ControllerArgumentException($"subscription {subscriptionId} is not in status PENDING");
         }
 
         if (appName is null)
@@ -242,22 +237,26 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     }
 
     /// <inheritdoc/>
-    public async Task UnsubscribeOwnCompanyAppSubscriptionAsync(Guid appId, Guid companyId)
+    public async Task UnsubscribeOwnCompanyAppSubscriptionAsync(Guid subscriptionId, Guid companyId)
     {
-        var assignedAppData = await _portalRepositories.GetInstance<IOfferSubscriptionsRepository>().GetCompanyAssignedAppDataForCompanyUserAsync(appId, companyId).ConfigureAwait(false);
-
+        var offerSubscriptionsRepository = _portalRepositories.GetInstance<IOfferSubscriptionsRepository>();
+        var assignedAppData = await offerSubscriptionsRepository.GetCompanyAssignedAppDataForCompanyUserAsync(subscriptionId, companyId).ConfigureAwait(false);
         if (assignedAppData == default)
         {
-            throw new NotFoundException($"App {appId} does not exist.");
+            throw new NotFoundException($"Subscription {subscriptionId} does not exist.");
         }
 
-        var (subscription, _) = assignedAppData;
+        var (status, _) = assignedAppData;
 
-        if (subscription == null)
+        if (status is OfferSubscriptionStatusId.ACTIVE or OfferSubscriptionStatusId.PENDING)
         {
-            throw new ArgumentException($"There is no active subscription for company '{companyId}' and app '{appId}'");
+            throw new ArgumentException($"There is no active or pending subscription for company '{companyId}' and subscriptionId '{subscriptionId}'");
         }
-        subscription.OfferSubscriptionStatusId = OfferSubscriptionStatusId.INACTIVE;
+
+        offerSubscriptionsRepository.AttachAndModifyOfferSubscription(subscriptionId, os =>
+        {
+            os.OfferSubscriptionStatusId = OfferSubscriptionStatusId.INACTIVE;
+        });
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
 

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -194,12 +194,12 @@ public class AppsBusinessLogic : IAppsBusinessLogic
         var (subscriptionStatusId, requesterId, appId, appName, isUserOfProvider, requesterData) = assignedAppData;
         if (!isUserOfProvider)
         {
-            throw new ControllerArgumentException("Missing permission: The user's company does not provide the requested app so they cannot activate it.");
+            throw new ForbiddenException("Missing permission: The user's company does not provide the requested app so they cannot activate it.");
         }
 
         if (subscriptionStatusId != OfferSubscriptionStatusId.PENDING)
         {
-            throw new ControllerArgumentException($"subscription {subscriptionId} is not in status PENDING");
+            throw new ConflictException($"subscription {subscriptionId} is not in status PENDING");
         }
 
         if (appName is null)
@@ -246,7 +246,12 @@ public class AppsBusinessLogic : IAppsBusinessLogic
             throw new NotFoundException($"Subscription {subscriptionId} does not exist.");
         }
 
-        var (status, _) = assignedAppData;
+        var (status, isSubscribingCompany, _) = assignedAppData;
+
+        if (!isSubscribingCompany)
+        {
+            throw new ForbiddenException($"the calling user does not belong to the subsribing company");
+        }
 
         if (status is OfferSubscriptionStatusId.ACTIVE or OfferSubscriptionStatusId.PENDING)
         {

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -250,10 +250,10 @@ public class AppsBusinessLogic : IAppsBusinessLogic
 
         if (!isSubscribingCompany)
         {
-            throw new ForbiddenException($"the calling user does not belong to the subsribing company");
+            throw new ForbiddenException("the calling user does not belong to the subscribing company");
         }
 
-        if (status is OfferSubscriptionStatusId.ACTIVE or OfferSubscriptionStatusId.PENDING)
+        if (status != OfferSubscriptionStatusId.ACTIVE && status != OfferSubscriptionStatusId.PENDING)
         {
             throw new ArgumentException($"There is no active or pending subscription for company '{companyId}' and subscriptionId '{subscriptionId}'");
         }

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -109,7 +109,6 @@ public interface IAppsBusinessLogic
     /// </summary>
     /// <param name="subscriptionId">ID of the pending app to be activated.</param>
     /// <param name="identity">identity of the current user.</param>
-    [Obsolete("This Method is not used anymore")]
     public Task ActivateOwnCompanyProvidedAppSubscriptionAsync(Guid subscriptionId, (Guid UserId, Guid CompanyId) identity);
 
     /// <summary>

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -115,9 +115,9 @@ public interface IAppsBusinessLogic
     /// <summary>
     /// Unsubscribes an app for the current users company.
     /// </summary>
-    /// <param name="appId">ID of the app to unsubscribe from.</param>
+    /// <param name="subscriptionId">ID of the subscription to unsubscribe from.</param>
     /// <param name="companyId">Id of the users company that initiated app unsubscription.</param>
-    public Task UnsubscribeOwnCompanyAppSubscriptionAsync(Guid appId, Guid companyId);
+    public Task UnsubscribeOwnCompanyAppSubscriptionAsync(Guid subscriptionId, Guid companyId);
 
     /// <summary>
     /// Retrieve Company Owned App Data

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -107,11 +107,10 @@ public interface IAppsBusinessLogic
     /// <summary>
     /// Activates a pending app subscription for an app provided by the current user's company.
     /// </summary>
-    /// <param name="appId">ID of the pending app to be activated.</param>
-    /// <param name="subscribingCompanyId">ID of the company subscribing the app.</param>
+    /// <param name="subscriptionId">ID of the pending app to be activated.</param>
     /// <param name="identity">identity of the current user.</param>
     [Obsolete("This Method is not used anymore")]
-    public Task ActivateOwnCompanyProvidedAppSubscriptionAsync(Guid appId, Guid subscribingCompanyId, (Guid UserId, Guid CompanyId) identity);
+    public Task ActivateOwnCompanyProvidedAppSubscriptionAsync(Guid subscriptionId, (Guid UserId, Guid CompanyId) identity);
 
     /// <summary>
     /// Unsubscribes an app for the current users company.

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -223,7 +223,7 @@ public class AppsController : ControllerBase
     /// Activates a pending app subscription.
     /// </summary>
     /// <param name="subscriptionId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">ID of the subscription to activate.</param>
-    /// <remarks>Example: PUT: /api/apps/D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645/supscription/company/74BA5AEF-1CC7-495F-ABAA-CF87840FA6E2/activate</remarks>
+    /// <remarks>Example: PUT: /api/apps/supscription/{subscriptiondId}/activate</remarks>
     /// <response code="204">App subscription was successfully activated.</response>
     /// <response code="400">If sub claim is empty/invalid or user does not exist, or any other parameters are invalid.</response>
     /// <response code="404">App does not exist.</response>
@@ -250,7 +250,7 @@ public class AppsController : ControllerBase
     /// Unsubscribes an app from the current user's company's subscriptions.
     /// </summary>
     /// <param name="subscriptionId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">ID of the subscription to unsubscribe from.</param>
-    /// <remarks>Example: PUT: /api/apps/D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645/unsubscribe</remarks>
+    /// <remarks>Example: PUT: /api/apps/{subscriptionId}/unsubscribe</remarks>
     /// <response code="204">The app was successfully unsubscribed from.</response>
     /// <response code="400">Either the sub claim is empty/invalid, user does not exist or the subscription might not have the correct status or the companyID is incorrect.</response>
     /// <response code="404">App does not exist.</response>

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -220,10 +220,9 @@ public class AppsController : ControllerBase
         _appsBusinessLogic.GetAppAgreement(appId);
 
     /// <summary>
-    /// Activates a pending app subscription for an app provided by the current user's company.
+    /// Activates a pending app subscription.
     /// </summary>
-    /// <param name="appId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">ID of the app to activate subscription for.</param>
-    /// <param name="companyId" example="74BA5AEF-1CC7-495F-ABAA-CF87840FA6E2">ID of the company to activate subscription for.</param>
+    /// <param name="subscriptionId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">ID of the subscription to activate.</param>
     /// <remarks>Example: PUT: /api/apps/D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645/supscription/company/74BA5AEF-1CC7-495F-ABAA-CF87840FA6E2/activate</remarks>
     /// <response code="204">App subscription was successfully activated.</response>
     /// <response code="400">If sub claim is empty/invalid or user does not exist, or any other parameters are invalid.</response>
@@ -232,7 +231,7 @@ public class AppsController : ControllerBase
     /// <response code="500">Internal Server Error.</response>
     [Obsolete("This endpoint is not used anymore")]
     [HttpPut]
-    [Route("{appId}/subscription/company/{companyId}/activate")]
+    [Route("/subscription/{subscriptionId}/activate")]
     [Authorize(Roles = "activate_subscription")]
     [Authorize(Policy = PolicyTypes.ValidIdentity)]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
@@ -241,30 +240,30 @@ public class AppsController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> ActivateCompanyAppSubscriptionAsync([FromRoute] Guid appId, [FromRoute] Guid companyId)
+    public async Task<IActionResult> ActivateCompanyAppSubscriptionAsync([FromRoute] Guid subscriptionId)
     {
-        await this.WithUserIdAndCompanyId(identity => _appsBusinessLogic.ActivateOwnCompanyProvidedAppSubscriptionAsync(appId, companyId, identity)).ConfigureAwait(false);
+        await this.WithUserIdAndCompanyId(identity => _appsBusinessLogic.ActivateOwnCompanyProvidedAppSubscriptionAsync(subscriptionId, identity)).ConfigureAwait(false);
         return NoContent();
     }
 
     /// <summary>
     /// Unsubscribes an app from the current user's company's subscriptions.
     /// </summary>
-    /// <param name="appId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">ID of the app to unsubscribe from.</param>
+    /// <param name="subscriptionId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">ID of the subscription to unsubscribe from.</param>
     /// <remarks>Example: PUT: /api/apps/D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645/unsubscribe</remarks>
     /// <response code="204">The app was successfully unsubscribed from.</response>
     /// <response code="400">Either the sub claim is empty/invalid, user does not exist or the subscription might not have the correct status or the companyID is incorrect.</response>
     /// <response code="404">App does not exist.</response>
     [HttpPut]
-    [Route("{appId}/unsubscribe")]
+    [Route("{subscriptionId}/unsubscribe")]
     [Authorize(Roles = "unsubscribe_apps")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> UnsubscribeCompanyAppSubscriptionAsync([FromRoute] Guid appId)
+    public async Task<IActionResult> UnsubscribeCompanyAppSubscriptionAsync([FromRoute] Guid subscriptionId)
     {
-        await this.WithCompanyId(companyId => _appsBusinessLogic.UnsubscribeOwnCompanyAppSubscriptionAsync(appId, companyId)).ConfigureAwait(false);
+        await this.WithCompanyId(companyId => _appsBusinessLogic.UnsubscribeOwnCompanyAppSubscriptionAsync(subscriptionId, companyId)).ConfigureAwait(false);
         return NoContent();
     }
 

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -229,7 +229,6 @@ public class AppsController : ControllerBase
     /// <response code="404">App does not exist.</response>
     /// <response code="409">App Name not set.</response>
     /// <response code="500">Internal Server Error.</response>
-    [Obsolete("This endpoint is not used anymore")]
     [HttpPut]
     [Route("/subscription/{subscriptionId}/activate")]
     [Authorize(Roles = "activate_subscription")]

--- a/src/marketplace/Offers.Library/Service/OfferSubscriptionService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSubscriptionService.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Flurl.Util;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;

--- a/src/marketplace/Offers.Library/Service/OfferSubscriptionService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSubscriptionService.cs
@@ -18,6 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Flurl.Util;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
@@ -56,11 +57,11 @@ public class OfferSubscriptionService : IOfferSubscriptionService
         await ValidateConsent(offerAgreementConsentData, offerId).ConfigureAwait(false);
 
         var offerSubscriptionsRepository = _portalRepositories.GetInstance<IOfferSubscriptionsRepository>();
-        var (offerSubscription, process, processSteps) = offerTypeId == OfferTypeId.APP
+        var offerSubscription = offerTypeId == OfferTypeId.APP
             ? await HandleAppSubscriptionAsync(offerId, offerSubscriptionsRepository, companyInformation, identity.UserId).ConfigureAwait(false)
-            : (offerSubscriptionsRepository.CreateOfferSubscription(offerId, companyInformation.CompanyId, OfferSubscriptionStatusId.PENDING, identity.UserId, identity.UserId), null, null);
+            : offerSubscriptionsRepository.CreateOfferSubscription(offerId, companyInformation.CompanyId, OfferSubscriptionStatusId.PENDING, identity.UserId, identity.UserId);
 
-        CreateProcessSteps(offerSubscription, process, processSteps);
+        CreateProcessSteps(offerSubscription);
         CreateConsentsForSubscription(offerSubscription.Id, offerAgreementConsentData, companyInformation.CompanyId, identity.UserId);
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
 
@@ -77,18 +78,12 @@ public class OfferSubscriptionService : IOfferSubscriptionService
         return offerSubscription.Id;
     }
 
-    private void CreateProcessSteps(OfferSubscription offerSubscription, Process? process, IEnumerable<ProcessStepTypeId>? processStepTypeIds)
+    private void CreateProcessSteps(OfferSubscription offerSubscription)
     {
         var processStepRepository = _portalRepositories.GetInstance<IProcessStepRepository>();
-        if (process == null)
-        {
-            process = processStepRepository.CreateProcess(ProcessTypeId.OFFER_SUBSCRIPTION);
-            offerSubscription.ProcessId = process.Id;
-        }
-        if (processStepTypeIds == null || !processStepTypeIds.Any())
-        {
-            processStepRepository.CreateProcessStepRange(new (ProcessStepTypeId, ProcessStepStatusId, Guid)[] { (ProcessStepTypeId.TRIGGER_PROVIDER, ProcessStepStatusId.TODO, process.Id) });
-        }
+        var process = processStepRepository.CreateProcess(ProcessTypeId.OFFER_SUBSCRIPTION);
+        offerSubscription.ProcessId = process.Id;
+        processStepRepository.CreateProcessStepRange(new (ProcessStepTypeId, ProcessStepStatusId, Guid)[] { (ProcessStepTypeId.TRIGGER_PROVIDER, ProcessStepStatusId.TODO, process.Id) });
     }
 
     private async Task<OfferProviderDetailsData> ValidateOfferProviderDetailDataAsync(Guid offerId, OfferTypeId offerTypeId)
@@ -139,36 +134,21 @@ public class OfferSubscriptionService : IOfferSubscriptionService
         return companyInformation;
     }
 
-    private static async Task<(OfferSubscription, Process?, IEnumerable<ProcessStepTypeId>?)> HandleAppSubscriptionAsync(
+    private static async Task<OfferSubscription> HandleAppSubscriptionAsync(
         Guid offerId,
         IOfferSubscriptionsRepository offerSubscriptionsRepository,
         CompanyInformationData companyInformation,
         Guid companyUserId)
     {
-        var result = await offerSubscriptionsRepository
-            .GetOfferSubscriptionStateForCompanyAsync(offerId, companyInformation.CompanyId, OfferTypeId.APP)
+        var activeOrPendingSubscriptionExists = await offerSubscriptionsRepository
+            .CheckPendingOrActiveSubscriptionExists(offerId, companyInformation.CompanyId, OfferTypeId.APP)
             .ConfigureAwait(false);
-        if (result == default)
+        if (activeOrPendingSubscriptionExists)
         {
-            return (offerSubscriptionsRepository.CreateOfferSubscription(offerId, companyInformation.CompanyId,
-                OfferSubscriptionStatusId.PENDING, companyUserId, companyUserId), null, null);
+            throw new ConflictException($"company {companyInformation.CompanyId} is already subscribed to {offerId}");
         }
 
-        if (result.OfferSubscriptionStatusId is OfferSubscriptionStatusId.ACTIVE or OfferSubscriptionStatusId.PENDING)
-        {
-            throw new ConflictException(
-                $"company {companyInformation.CompanyId} is already subscribed to {offerId}");
-        }
-
-        return (
-            offerSubscriptionsRepository.AttachAndModifyOfferSubscription(result.OfferSubscriptionId,
-                os =>
-                {
-                    os.OfferSubscriptionStatusId = OfferSubscriptionStatusId.PENDING;
-                    os.LastEditorId = companyUserId;
-                }),
-            result.Process,
-            result.ProcessStepTypeIds);
+        return offerSubscriptionsRepository.CreateOfferSubscription(offerId, companyInformation.CompanyId, OfferSubscriptionStatusId.PENDING, companyUserId, companyUserId);
     }
 
     private void CreateConsentsForSubscription(Guid offerSubscriptionId, IEnumerable<OfferAgreementConsentData> offerAgreementConsentData, Guid companyId, Guid companyUserId)

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -52,7 +52,7 @@ public interface IOfferSubscriptionsRepository
 
     Task<(OfferSubscriptionStatusId SubscriptionStatusId, Guid RequestorId, Guid AppId, string? AppName, bool IsUserOfProvider, RequesterData Requester)> GetCompanyAssignedAppDataForProvidingCompanyUserAsync(Guid subscriptionId, Guid userCompanyId);
 
-    Task<(OfferSubscriptionStatusId offerSubscriptionStatusId, bool _)> GetCompanyAssignedAppDataForCompanyUserAsync(Guid subscriptionId, Guid userCompanyId);
+    Task<(OfferSubscriptionStatusId OfferSubscriptionStatusId, bool IsSubscribingCompany, bool IsValidSubscriptionId)> GetCompanyAssignedAppDataForCompanyUserAsync(Guid subscriptionId, Guid userCompanyId);
 
     Task<(Guid companyId, OfferSubscription? offerSubscription)> GetCompanyIdWithAssignedOfferForCompanyUserAndSubscriptionAsync(Guid subscriptionId, Guid userId, OfferTypeId offerTypeId);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -50,9 +50,9 @@ public interface IOfferSubscriptionsRepository
     /// <returns>Returns a func with skip, take and the pagination of the source</returns>
     Func<int, int, Task<Pagination.Source<OfferCompanySubscriptionStatusData>?>> GetOwnCompanyProvidedOfferSubscriptionStatusesUntrackedAsync(Guid userCompanyId, OfferTypeId offerTypeId, SubscriptionStatusSorting? sorting, IEnumerable<OfferSubscriptionStatusId> statusIds, Guid? offerId);
 
-    Task<(Guid SubscriptionId, OfferSubscriptionStatusId SubscriptionStatusId, Guid RequestorId, string? AppName, bool IsUserOfProvider, RequesterData Requester)> GetCompanyAssignedAppDataForProvidingCompanyUserAsync(Guid appId, Guid companyId, Guid userCompanyId);
+    Task<(OfferSubscriptionStatusId SubscriptionStatusId, Guid RequestorId, Guid AppId, string? AppName, bool IsUserOfProvider, RequesterData Requester)> GetCompanyAssignedAppDataForProvidingCompanyUserAsync(Guid subscriptionId, Guid userCompanyId);
 
-    Task<(OfferSubscription? companyAssignedApp, bool _)> GetCompanyAssignedAppDataForCompanyUserAsync(Guid appId, Guid userCompanyId);
+    Task<(OfferSubscriptionStatusId offerSubscriptionStatusId, bool _)> GetCompanyAssignedAppDataForCompanyUserAsync(Guid subscriptionId, Guid userCompanyId);
 
     Task<(Guid companyId, OfferSubscription? offerSubscription)> GetCompanyIdWithAssignedOfferForCompanyUserAndSubscriptionAsync(Guid subscriptionId, Guid userId, OfferTypeId offerTypeId);
 
@@ -74,14 +74,14 @@ public interface IOfferSubscriptionsRepository
     /// <returns>Returns the offer details.</returns>
     Task<OfferSubscriptionTransferData?> GetOfferDetailsAndCheckProviderCompany(Guid offerSubscriptionId, Guid providerCompanyId, OfferTypeId offerTypeId);
 
-    public Task<(Guid OfferSubscriptionId, OfferSubscriptionStatusId OfferSubscriptionStatusId, Process? Process, IEnumerable<ProcessStepTypeId>? ProcessStepTypeIds)> GetOfferSubscriptionStateForCompanyAsync(Guid offerId, Guid companyId, OfferTypeId offerTypeId);
+    public Task<bool> CheckPendingOrActiveSubscriptionExists(Guid offerId, Guid companyId, OfferTypeId offerTypeId);
 
     OfferSubscription AttachAndModifyOfferSubscription(Guid offerSubscriptionId, Action<OfferSubscription> setOptionalParameters);
 
     /// <summary>
     /// Gets all business app data for the given userId
     /// </summary>
-    /// <param name="iamUserId">Id of the user to get the app data for.</param>
+    /// <param name="userId">Id of the user to get the app data for.</param>
     /// <returns>Returns an IAsyncEnumerable of app data</returns>
     IAsyncEnumerable<(Guid OfferId, Guid SubscriptionId, string? OfferName, string SubscriptionUrl, Guid LeadPictureId, string Provider)> GetAllBusinessAppDataForUserIdAsync(Guid userId);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
@@ -459,7 +459,7 @@ public class OfferRepository : IOfferRepository
                 x.SupportedLanguages.Select(sl => new ValueTuple<string, bool>(sl.ShortName, languageCodes.Any(lc => lc == sl.ShortName))),
                 x.UseCases.Select(uc => uc.Id),
                 x.OfferLicenses.Select(ol => new ValueTuple<Guid, string, bool>(ol.Id, ol.Licensetext, ol.Offers.Count > 1)).FirstOrDefault(),
-                x.OfferAssignedPrivacyPolicies.Select(x => x.PrivacyPolicyId),
+                x.OfferAssignedPrivacyPolicies.Select(oapp => oapp.PrivacyPolicyId),
                 x.Name,
                 x.Provider,
                 x.SalesManagerId,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -105,14 +105,14 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public Task<(OfferSubscriptionStatusId offerSubscriptionStatusId, bool _)> GetCompanyAssignedAppDataForCompanyUserAsync(Guid subscriptionId, Guid userCompanyId) =>
+    public Task<(OfferSubscriptionStatusId OfferSubscriptionStatusId, bool IsSubscribingCompany, bool IsValidSubscriptionId)> GetCompanyAssignedAppDataForCompanyUserAsync(Guid subscriptionId, Guid userCompanyId) =>
         _context.OfferSubscriptions
             .Where(os =>
-                os.Id == subscriptionId &&
-                os.CompanyId == userCompanyId
+                os.Id == subscriptionId
             )
-            .Select(os => new ValueTuple<OfferSubscriptionStatusId, bool>(
+            .Select(os => new ValueTuple<OfferSubscriptionStatusId, bool, bool>(
                 os.OfferSubscriptionStatusId,
+                os.CompanyId == userCompanyId,
                 true
             ))
             .SingleOrDefaultAsync();

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -91,30 +91,28 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public Task<(Guid SubscriptionId, OfferSubscriptionStatusId SubscriptionStatusId, Guid RequestorId, string? AppName, bool IsUserOfProvider, RequesterData Requester)> GetCompanyAssignedAppDataForProvidingCompanyUserAsync(Guid appId, Guid companyId, Guid userCompanyId) =>
-        _context.Offers
-            .Where(app => app.Id == appId)
-            .Select(app => new
-            {
-                App = app,
-                OfferSubscription = app.OfferSubscriptions.SingleOrDefault(subscription => subscription.CompanyId == companyId),
-            })
-            .Select(x => new ValueTuple<Guid, OfferSubscriptionStatusId, Guid, string?, bool, RequesterData>(
-                x.OfferSubscription!.Id,
-                x.OfferSubscription.OfferSubscriptionStatusId,
-                x.OfferSubscription.RequesterId,
-                x.App.Name,
-                x.App.ProviderCompanyId == userCompanyId,
-                new RequesterData(x.OfferSubscription.Requester!.Email, x.OfferSubscription.Requester.Firstname, x.OfferSubscription.Requester.Lastname)
+    public Task<(OfferSubscriptionStatusId SubscriptionStatusId, Guid RequestorId, Guid AppId, string? AppName, bool IsUserOfProvider, RequesterData Requester)> GetCompanyAssignedAppDataForProvidingCompanyUserAsync(Guid subscriptionId, Guid userCompanyId) =>
+        _context.OfferSubscriptions
+            .Where(os => os.Id == subscriptionId)
+            .Select(x => new ValueTuple<OfferSubscriptionStatusId, Guid, Guid, string?, bool, RequesterData>(
+                x.OfferSubscriptionStatusId,
+                x.RequesterId,
+                x.Offer!.Id,
+                x.Offer.Name,
+                x.Offer.ProviderCompanyId == userCompanyId,
+                new RequesterData(x.Requester!.Email, x.Requester.Firstname, x.Requester.Lastname)
             ))
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public Task<(OfferSubscription? companyAssignedApp, bool _)> GetCompanyAssignedAppDataForCompanyUserAsync(Guid appId, Guid userCompanyId) =>
-        _context.Offers
-            .Where(app => app.Id == appId)
-            .Select(app => new ValueTuple<OfferSubscription?, bool>(
-                app.OfferSubscriptions.SingleOrDefault(assignedApp => assignedApp.CompanyId == userCompanyId),
+    public Task<(OfferSubscriptionStatusId offerSubscriptionStatusId, bool _)> GetCompanyAssignedAppDataForCompanyUserAsync(Guid subscriptionId, Guid userCompanyId) =>
+        _context.OfferSubscriptions
+            .Where(os =>
+                os.Id == subscriptionId &&
+                os.CompanyId == userCompanyId
+            )
+            .Select(os => new ValueTuple<OfferSubscriptionStatusId, bool>(
+                os.OfferSubscriptionStatusId,
                 true
             ))
             .SingleOrDefaultAsync();
@@ -160,11 +158,13 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public Task<(Guid OfferSubscriptionId, OfferSubscriptionStatusId OfferSubscriptionStatusId, Process? Process, IEnumerable<ProcessStepTypeId>? ProcessStepTypeIds)> GetOfferSubscriptionStateForCompanyAsync(Guid offerId, Guid companyId, OfferTypeId offerTypeId) =>
+    public Task<bool> CheckPendingOrActiveSubscriptionExists(Guid offerId, Guid companyId, OfferTypeId offerTypeId) =>
         _context.OfferSubscriptions.AsNoTracking()
-            .Where(x => x.OfferId == offerId && x.CompanyId == companyId && x.Offer!.OfferTypeId == offerTypeId)
-            .Select(x => new ValueTuple<Guid, OfferSubscriptionStatusId, Process?, IEnumerable<ProcessStepTypeId>?>(x.Id, x.OfferSubscriptionStatusId, x.Process, x.Process!.ProcessSteps.Where(step => step.ProcessStepStatusId == ProcessStepStatusId.TODO).Select(step => step.ProcessStepTypeId)))
-            .SingleOrDefaultAsync();
+            .AnyAsync(x =>
+                x.OfferId == offerId &&
+                x.CompanyId == companyId &&
+                x.Offer!.OfferTypeId == offerTypeId &&
+                (x.OfferSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE || x.OfferSubscriptionStatusId == OfferSubscriptionStatusId.PENDING));
 
     /// <inheritdoc />
     public OfferSubscription AttachAndModifyOfferSubscription(Guid offerSubscriptionId, Action<OfferSubscription> setOptionalParameters)

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
@@ -383,7 +383,7 @@ public class AppBusinessLogicTests
         async Task Act() => await sut.ActivateOwnCompanyProvidedAppSubscriptionAsync(subscriptionId, (identity.UserId, identity.CompanyId)).ConfigureAwait(false);
 
         // Assert
-        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+        var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
         ex.Message.Should().Be("Missing permission: The user's company does not provide the requested app so they cannot activate it.");
     }
 
@@ -413,7 +413,7 @@ public class AppBusinessLogicTests
         async Task Act() => await sut.ActivateOwnCompanyProvidedAppSubscriptionAsync(offerSubscriptionId, (_identity.UserId, _identity.CompanyId)).ConfigureAwait(false);
 
         // Assert
-        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
         ex.Message.Should().Be($"subscription {offerSubscriptionId} is not in status PENDING");
     }
 

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
@@ -213,14 +213,13 @@ public class AppsControllerTests
     public async Task ActivateCompanyAppSubscriptionAsync_ReturnsNoContent()
     {
         //Arrange
-        var appId = _fixture.Create<Guid>();
-        var companyId = _fixture.Create<Guid>();
+        var subscriptionId = _fixture.Create<Guid>();
 
         //Act
-        var result = await this._controller.ActivateCompanyAppSubscriptionAsync(appId, companyId).ConfigureAwait(false);
+        var result = await this._controller.ActivateCompanyAppSubscriptionAsync(subscriptionId).ConfigureAwait(false);
 
         //Assert
-        A.CallTo(() => _logic.ActivateOwnCompanyProvidedAppSubscriptionAsync(appId, companyId, A<ValueTuple<Guid, Guid>>.That.Matches(x => x.Item1 == _identity.UserId && x.Item2 == _identity.CompanyId))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.ActivateOwnCompanyProvidedAppSubscriptionAsync(subscriptionId, A<ValueTuple<Guid, Guid>>.That.Matches(x => x.Item1 == _identity.UserId && x.Item2 == _identity.CompanyId))).MustHaveHappenedOnceExactly();
         Assert.IsType<NoContentResult>(result);
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -86,16 +86,13 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetOfferSubscriptionStateForCompanyAsync(
+        var result = await sut.CheckPendingOrActiveSubscriptionExists(
             new Guid("a16e73b9-5277-4b69-9f8d-3b227495dfea"),
             new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"),
             OfferTypeId.SERVICE).ConfigureAwait(false);
 
         // Assert
-        result.Should().NotBeNull();
-        result.Should().NotBe(default);
-        result.OfferSubscriptionStatusId.Should().Be(OfferSubscriptionStatusId.ACTIVE);
-        result.OfferSubscriptionId.Should().Be(new Guid("3DE6A31F-A5D1-4F60-AA3A-4B1A769BECBF"));
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -105,13 +102,13 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetOfferSubscriptionStateForCompanyAsync(
+        var result = await sut.CheckPendingOrActiveSubscriptionExists(
             new Guid("99C5FD12-8085-4DE2-ABFD-215E1EE4BAA4"),
             new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"),
             OfferTypeId.SERVICE).ConfigureAwait(false);
 
         // Assert
-        result.Should().Be(default);
+        result.Should().BeFalse();
     }
 
     #endregion


### PR DESCRIPTION
## Description

an inactive subscription now won't be activated, instead a new subscription will be created

the following endpoints have been changed from appId to subscriptionId:

/api/apps/supscription/{subscriptiondId}/activate
/api/apps/{subscriptionId}/unsubscribe

## Why

Since the subscription is linked to a technical user and an app instance we don't want to reactivate an inactive subscription. Instead we want to create a new one.

## Issue

N/A - Jira Issue: CPLP-2911

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
