### PR TITLE
chore: adding validation for seeder settings

### DIFF
--- a/docker/Dockerfile-provisioning-migrations
+++ b/docker/Dockerfile-provisioning-migrations
@@ -26,6 +26,8 @@ COPY /src/provisioning /src/provisioning
 COPY /src/framework/Framework.ErrorHandling.Library /src/framework/Framework.ErrorHandling.Library
 COPY /src/framework/Framework.BaseDependencies /src/framework/Framework.BaseDependencies
 COPY /src/framework/Framework.Seeding /src/framework/Framework.Seeding
+COPY /src/framework/Framework.Models /src/framework/Framework.Models
+COPY /src/framework/Framework.Linq /src/framework/Framework.Linq
 WORKDIR /src/provisioning/Provisioning.Migrations
 RUN dotnet build "Provisioning.Migrations.csproj" -c Release -o /migrations/build
 

--- a/src/framework/Framework.Seeding/DependencyInjection/DatabaseInitializerExtensions.cs
+++ b/src/framework/Framework.Seeding/DependencyInjection/DatabaseInitializerExtensions.cs
@@ -35,18 +35,14 @@ public static class DatabaseInitializerExtensions
             .InitializeDatabasesAsync(cancellationToken);
     }
 
-    public static IServiceCollection AddDatabaseInitializer<TDbContext>(this IServiceCollection services, IConfigurationSection section) where TDbContext : DbContext
-    {
-        services.AddOptions<SeederSettings>()
-            .Bind(section);
-
-        return services
+    public static IServiceCollection AddDatabaseInitializer<TDbContext>(this IServiceCollection services, IConfigurationSection section) where TDbContext : DbContext =>
+        services
+            .ConfigureSeederSettings(section)
             .AddTransient<IDatabaseInitializer, DatabaseInitializer<TDbContext>>()
             .AddTransient<DbInitializer<TDbContext>>()
             .AddTransient<DbSeeder>()
             .AddServices(typeof(ICustomSeeder), ServiceLifetime.Transient)
             .AddTransient<CustomSeederRunner>();
-    }
 
     private static IServiceCollection AddServices(this IServiceCollection services, Type interfaceType, ServiceLifetime lifetime)
     {

--- a/src/framework/Framework.Seeding/Framework.Seeding.csproj
+++ b/src/framework/Framework.Seeding/Framework.Seeding.csproj
@@ -35,12 +35,15 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.7" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.7" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Framework.ErrorHandling.Library\Framework.ErrorHandling.Library.csproj" />
+        <ProjectReference Include="..\Framework.Models\Framework.Models.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/framework/Framework.Seeding/SeederSettings.cs
+++ b/src/framework/Framework.Seeding/SeederSettings.cs
@@ -1,3 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Validation;
 using System.ComponentModel.DataAnnotations;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding;
@@ -21,4 +44,20 @@ public class SeederSettings
     /// </summary>
     [Required]
     public IEnumerable<string> TestDataEnvironments { get; set; }
+}
+
+public static class SeederSettingsExtensions
+{
+    public static IServiceCollection ConfigureSeederSettings(
+        this IServiceCollection services,
+        IConfigurationSection section)
+    {
+        services.AddOptions<SeederSettings>()
+            .Bind(section)
+            .ValidateDataAnnotations()
+            .ValidateEnumEnumeration(section)
+            .ValidateDistinctValues(section)
+            .ValidateOnStart();
+        return services;
+    }
 }

--- a/src/portalbackend/PortalBackend.Migrations/appsettings.json
+++ b/src/portalbackend/PortalBackend.Migrations/appsettings.json
@@ -26,6 +26,7 @@
   },
   "DeleteIntervalInDays": 80,
   "Seeding":{
+    "DataPaths":[],
     "TestDataEnvironments": []
   }
 }


### PR DESCRIPTION
## Description

adding validation on application startup for the seeder settings

## Why

Currently we're receiving an NullReferenceExecption when for example forgetting the DataPaths configuration for the seeder settings, to check if the settings are configured correctly the validation happens on startup to receive a more descriptive error message.

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
