### PR TITLE
bug(notification): fix get notification count endpoint

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
@@ -89,7 +89,7 @@ public interface INotificationRepository
     /// </summary>
     /// <param name="companyUserId">id of the user</param>
     /// <returns>Returns the notification count details</returns>
-    IAsyncEnumerable<(bool IsRead, bool? Done, NotificationTopicId NotificationTopicId, int Count)> GetCountDetailsForUserAsync(Guid companyUserId);
+    IAsyncEnumerable<(bool IsRead, bool? Done, NotificationTopicId? NotificationTopicId, int Count)> GetCountDetailsForUserAsync(Guid companyUserId);
 
     /// <summary>
     /// Gets the notification ids that should be updated

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
@@ -131,12 +131,12 @@ public class NotificationRepository : INotificationRepository
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public IAsyncEnumerable<(bool IsRead, bool? Done, NotificationTopicId NotificationTopicId, int Count)> GetCountDetailsForUserAsync(Guid companyUserId) =>
+    public IAsyncEnumerable<(bool IsRead, bool? Done, NotificationTopicId? NotificationTopicId, int Count)> GetCountDetailsForUserAsync(Guid companyUserId) =>
         _dbContext.Notifications
             .AsNoTracking()
             .Where(not => not.ReceiverUserId == companyUserId)
             .GroupBy(not => new { not.IsRead, not.Done, not.NotificationType!.NotificationTypeAssignedTopic!.NotificationTopicId },
-                (key, element) => new ValueTuple<bool, bool?, NotificationTopicId, int>(key.IsRead, key.Done, key.NotificationTopicId, element.Count()))
+                (key, element) => new ValueTuple<bool, bool?, NotificationTopicId?, int>(key.IsRead, key.Done, key.NotificationTopicId, element.Count()))
             .AsAsyncEnumerable();
 
     /// <inheritdoc />

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/notification_type_assigned_topic.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/notification_type_assigned_topic.json
@@ -86,5 +86,17 @@
   {
     "notification_type_id": 22,
     "notification_topic_id": 1
+  },
+  {
+    "notification_type_id": 23,
+    "notification_topic_id": 1
+  },
+  {
+    "notification_type_id": 24,
+    "notification_topic_id": 1
+  },
+  {
+    "notification_type_id": 25,
+    "notification_topic_id": 1
   }
 ]

--- a/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
+++ b/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
@@ -275,7 +275,7 @@ public class NotificationBusinessLogicTests
     public async Task GetNotificationCountDetailsAsync()
     {
         // Arrange
-        var data = new AsyncEnumerableStub<(bool IsRead, bool? Done, NotificationTopicId NotificationTopicId, int Count)>(new List<(bool IsRead, bool? Done, NotificationTopicId NotificationTopicId, int Count)>
+        var data = new AsyncEnumerableStub<(bool IsRead, bool? Done, NotificationTopicId? NotificationTopicId, int Count)>(new List<(bool IsRead, bool? Done, NotificationTopicId? NotificationTopicId, int Count)>
         {
             new (true, null, NotificationTopicId.INFO, 2),
             new (false, null, NotificationTopicId.INFO, 3),

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -437,6 +437,27 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         results.Count.Should().Be(4);
     }
 
+    [Fact]
+    public async Task GetCountDetailsForUserAsync_ReturnsExpectedCount()
+    {
+        // Arrange
+        var (sut, context) = await CreateSutWithContext().ConfigureAwait(false);
+        using var trans = await context.Database.BeginTransactionAsync().ConfigureAwait(false);
+        context.NotificationTypeAssignedTopics.Remove(new NotificationTypeAssignedTopic(NotificationTypeId.INFO, NotificationTopicId.INFO));
+        await context.SaveChangesAsync().ConfigureAwait(false);
+
+        // Act
+        var results = await sut
+            .GetCountDetailsForUserAsync(_companyUserId).ToListAsync()
+            .ConfigureAwait(false);
+
+        // Assert
+        results.Count.Should().Be(5);
+        results.Where(x => x.NotificationTopicId == null).Should().ContainSingle().And.Satisfy(x => x.Count == 1);
+
+        await trans.RollbackAsync().ConfigureAwait(false);
+    }
+
     #endregion
 
     #region CheckNotificationExistsByIdAndIamUserId


### PR DESCRIPTION
## Description

fixed 500 error for notification count.

## Why

If there is no matching notification topic id in table notification_type_assigned_topics for notificationtypeid so null was returning through query due to which nullable exception was throwing 500 error.

## Issue
CPLP--2939

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my change
