### PR TITLE
feat(CompanyDataBusinessLogic)! : enhanced logic to unassign the CompanyRole and Consent

### DIFF
--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -292,7 +292,7 @@ public class CompanyDataBusinessLogicTests
         }.ToAsyncEnumerable();
 
         A.CallTo(() => _companyRepository.GetCompanyRolesDataAsync(A<Guid>._, A<IEnumerable<CompanyRoleId>>._))
-            .Returns((true, true, new []{ CompanyRoleId.SERVICE_PROVIDER }, consentStatusDetails));
+            .Returns((true, true, new[] { CompanyRoleId.SERVICE_PROVIDER }, consentStatusDetails));
 
         A.CallTo(() => _companyRepository.GetAgreementAssignedRolesDataAsync(A<IEnumerable<CompanyRoleId>>._))
             .Returns(agreementData);


### PR DESCRIPTION
## Description

Enhanced the logic to unassign the CompanyRoles and Consent

## Why

Added an logic to unassign the CompanyRole and set inactive to respective agreements in Consent 

## Issue

[CPLP-2813](https://jira.catena-x.net/browse/CPLP-2813)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
