### PR TITLE
fix(notification): fix put notification by Id endpoint

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
@@ -40,7 +40,7 @@ public interface INotificationRepository
     Notification CreateNotification(Guid receiverUserId, NotificationTypeId notificationTypeId,
         bool isRead, Action<Notification>? setOptionalParameters = null);
 
-    void AttachAndModifyNotification(Guid notificationId, Action<Notification> setOptionalParameters);
+    void AttachAndModifyNotification(Guid notificationId, Action<Notification>? initialize, Action<Notification> updateFields);
 
     void AttachAndModifyNotifications(IEnumerable<Guid> notificationIds, Action<Notification> setOptionalParameters);
 
@@ -72,8 +72,9 @@ public interface INotificationRepository
     /// </summary>
     /// <param name="notificationId">Id of the notification</param>
     /// <param name="companyUserId">Id of the receiver</param>
+    /// <param name="isRead">is Read</param>
     /// <returns><c>true</c> if the notification exists, <c>false</c> if it doesn't exist</returns>
-    Task<(bool IsUserReceiver, bool IsNotificationExisting)> CheckNotificationExistsByIdAndValidateReceiverAsync(Guid notificationId, Guid companyUserId);
+    Task<(bool IsUserReceiver, bool IsNotificationExisting, bool isRead)> CheckNotificationExistsByIdAndValidateReceiverAsync(Guid notificationId, Guid companyUserId);
 
     /// <summary>
     /// Gets the count of the notifications for the given user and optional status

--- a/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
+++ b/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
@@ -315,10 +315,11 @@ public class NotificationBusinessLogicTests
     {
         // Arrange
         var notification = new Notification(_notificationDetail.Id, Guid.NewGuid(), DateTimeOffset.Now, NotificationTypeId.INFO, !isRead);
-        A.CallTo(() => _notificationRepository.AttachAndModifyNotification(_notificationDetail.Id, A<Action<Notification>>._))
-            .Invokes((Guid _, Action<Notification> setOptionalParameters) =>
+        A.CallTo(() => _notificationRepository.AttachAndModifyNotification(_notificationDetail.Id, A<Action<Notification>>._, A<Action<Notification>>._))
+            .Invokes((Guid _, Action<Notification> initializers, Action<Notification> dbupdatedfield) =>
             {
-                setOptionalParameters.Invoke(notification);
+                initializers.Invoke(notification);
+                dbupdatedfield.Invoke(notification);
             });
         var sut = new NotificationBusinessLogic(_portalRepositories, Options.Create(new NotificationSettings
         {
@@ -443,15 +444,15 @@ public class NotificationBusinessLogicTests
 
         A.CallTo(() =>
                 _notificationRepository.CheckNotificationExistsByIdAndValidateReceiverAsync(_notificationDetail.Id, _identity.UserId))
-            .ReturnsLazily(() => (true, true));
+            .ReturnsLazily(() => (true, true, true));
         A.CallTo(() =>
                 _notificationRepository.CheckNotificationExistsByIdAndValidateReceiverAsync(
                     A<Guid>.That.Not.Matches(x => x == _notificationDetail.Id), A<Guid>._))
-            .Returns((false, false));
+            .Returns((false, false, true));
         A.CallTo(() =>
                 _notificationRepository.CheckNotificationExistsByIdAndValidateReceiverAsync(_notificationDetail.Id,
                     A<Guid>.That.Not.Matches(x => x == _identity.UserId)))
-            .Returns((false, true));
+            .Returns((false, true, true));
         A.CallTo(() => _notificationRepository.GetNotificationByIdAndValidateReceiverAsync(_notificationDetail.Id, _identity.UserId))
             .Returns((true, _unreadNotificationDetails.First()));
         A.CallTo(() => _notificationRepository.GetNotificationByIdAndValidateReceiverAsync(_notificationDetail.Id, A<Guid>.That.Not.Matches(x => x == _identity.UserId)))

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -104,7 +104,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         changedEntity.State.Should().Be(EntityState.Modified);
         changedEntity.Entity.Should().BeOfType<Notification>().Which.IsRead.Should().Be(true);
     }
-    
+
     [Fact]
     public async Task AttachAndModifyNotification_WithExistingNotification_NotUpdatesStatus()
     {

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -104,6 +104,32 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         changedEntity.State.Should().Be(EntityState.Modified);
         changedEntity.Entity.Should().BeOfType<Notification>().Which.IsRead.Should().Be(true);
     }
+    
+    [Fact]
+    public async Task AttachAndModifyNotification_WithExistingNotification_NotUpdatesStatus()
+    {
+        // Arrange
+        var (sut, dbContext) = await CreateSutWithContext().ConfigureAwait(false);
+
+        // Act
+        sut.AttachAndModifyNotification(new Guid("19AFFED7-13F0-4868-9A23-E77C23D8C889"), notification =>
+        {
+            notification.IsRead = true;
+        },
+        notification =>
+        {
+            notification.IsRead = true;
+        });
+
+        // Assert
+        var changeTracker = dbContext.ChangeTracker;
+        var changedEntries = changeTracker.Entries().ToList();
+        changeTracker.HasChanges().Should().BeFalse();
+        changedEntries.Should().NotBeEmpty();
+        changedEntries.Should().HaveCount(1);
+        var changedEntity = changedEntries.Single();
+        changedEntity.Entity.Should().BeOfType<Notification>().Which.IsRead.Should().Be(true);
+    }
 
     #endregion
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -87,6 +87,10 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Act
         sut.AttachAndModifyNotification(new Guid("19AFFED7-13F0-4868-9A23-E77C23D8C889"), notification =>
         {
+            notification.IsRead = false;
+        },
+        notification =>
+        {
             notification.IsRead = true;
         });
 


### PR DESCRIPTION
## Description

isRead flag was not updating if we update the value to false/true

## Why

isRead value first time updated to true but when updating to false it was not updating. It was due to comparison of bool value in entity framework which was set default value.

## Issue

CPLP-2916.

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
