### PR TITLE
feat(offerSubscription): add get endpoint to get offerSubscriptions

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -524,4 +524,9 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
 
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<OfferSubscriptionConnectorData> GetConnectorOfferSubscriptionData(bool? connectorIdSet, Guid companyId) =>
+        _portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
+            .GetConnectorOfferSubscriptionData(connectorIdSet, companyId);
 }

--- a/src/administration/Administration.Service/BusinessLogic/IConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IConnectorsBusinessLogic.cs
@@ -109,4 +109,15 @@ public interface IConnectorsBusinessLogic
     /// <param name="identity">identity (userId and companyId) of the user</param>
     /// <param name="cancellationToken">CancellationToken</param>
     Task UpdateConnectorUrl(Guid connectorId, ConnectorUpdateRequest data, (Guid UserId, Guid CompanyId) identity, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the offer subscription data
+    /// </summary>
+    /// <param name="connectorIdSet" example="false">
+    /// Optional: if <c>true</c> only respond with subscriptions where a link to a connector is given,
+    /// if <c>false</c> it will only return subscriptions where no link to an connector exists.
+    /// </param>
+    /// <param name="companyId">Id of the company to get the subscriptions for</param>
+    /// <returns>Returns an IAsyncEnumerable of <see cref="OfferSubscriptionConnectorData"/></returns>
+    IAsyncEnumerable<OfferSubscriptionConnectorData> GetConnectorOfferSubscriptionData(bool? connectorIdSet, Guid companyId);
 }

--- a/src/administration/Administration.Service/Controllers/ConnectorsController.cs
+++ b/src/administration/Administration.Service/Controllers/ConnectorsController.cs
@@ -276,7 +276,7 @@ public class ConnectorsController : ControllerBase
     /// </param>
     /// <remarks>Example: GET: /api/administration/connectors/offerSubscriptions</remarks>
     /// <response code="200">Returns list of the offer subscriptions for the company.</response>
-    [HttpPost]
+    [HttpGet]
     [Route("offerSubscriptions")]
     [Authorize(Roles = "view_connectors")]
     [ProducesResponseType(typeof(IAsyncEnumerable<ConnectorEndPointData>), StatusCodes.Status200OK)]

--- a/src/administration/Administration.Service/Controllers/ConnectorsController.cs
+++ b/src/administration/Administration.Service/Controllers/ConnectorsController.cs
@@ -266,4 +266,20 @@ public class ConnectorsController : ControllerBase
             .ConfigureAwait(false);
         return NoContent();
     }
+
+    /// <summary>
+    /// Retrieve the offer subscriptions for the company with the linked connectorIds.
+    /// </summary>
+    /// <param name="connectorIdSet" example="false">
+    /// Optional: if <c>true</c> only respond with subscriptions where a link to a connector is given,
+    /// if <c>false</c> it will only return subscriptions where no link to an connector exists.
+    /// </param>
+    /// <remarks>Example: GET: /api/administration/connectors/offerSubscriptions</remarks>
+    /// <response code="200">Returns list of the offer subscriptions for the company.</response>
+    [HttpPost]
+    [Route("offerSubscriptions")]
+    [Authorize(Roles = "view_connectors")]
+    [ProducesResponseType(typeof(IAsyncEnumerable<ConnectorEndPointData>), StatusCodes.Status200OK)]
+    public IAsyncEnumerable<OfferSubscriptionConnectorData> GetConnectorOfferSubscriptionData([FromQuery] bool? connectorIdSet) =>
+        this.WithCompanyId(companyId => _businessLogic.GetConnectorOfferSubscriptionData(connectorIdSet, companyId));
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionConnectorData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionConnectorData.cs
@@ -18,20 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
+namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
-public class ConnectorAssignedOfferSubscription
-{
-    public ConnectorAssignedOfferSubscription(Guid connectorId, Guid offerSubscriptionId)
-    {
-        ConnectorId = connectorId;
-        OfferSubscriptionId = offerSubscriptionId;
-    }
-
-    public Guid ConnectorId { get; set; }
-    public Guid OfferSubscriptionId { get; set; }
-
-    // Navigation properties
-    public virtual Connector? Connector { get; set; }
-    public virtual OfferSubscription? OfferSubscription { get; set; }
-}
+public record OfferSubscriptionConnectorData(
+    Guid SubscriptionId,
+    string CustomerName,
+    string? OfferName,
+    IEnumerable<Guid> ConnectorIds
+);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -163,4 +163,5 @@ public interface IOfferSubscriptionsRepository
     void RemoveOfferSubscriptionProcessData(Guid offerSubscriptionId);
     IAsyncEnumerable<ProcessStepData> GetProcessStepsForSubscription(Guid offerSubscriptionId);
     Task<(bool Exists, bool IsOfferProvider, bool OfferSubscriptionAlreadyLinked, OfferSubscriptionStatusId OfferSubscriptionStatus, Guid? SelfDescriptionDocumentId, Guid CompanyId, string? ProviderBpn)> CheckOfferSubscriptionWithOfferProvider(Guid subscriptionId, Guid offerProvidingCompanyId);
+    IAsyncEnumerable<OfferSubscriptionConnectorData> GetConnectorOfferSubscriptionData(bool? connectorIdSet, Guid companyId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -483,4 +483,19 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                 os.Company.BusinessPartnerNumber
             ))
             .SingleOrDefaultAsync();
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<OfferSubscriptionConnectorData> GetConnectorOfferSubscriptionData(bool? connectorIdSet, Guid companyId) =>
+        _context.OfferSubscriptions
+            .Where(os =>
+                os.Offer!.ProviderCompanyId == companyId &&
+                (os.OfferSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE || os.OfferSubscriptionStatusId == OfferSubscriptionStatusId.PENDING) &&
+                (!connectorIdSet.HasValue || (connectorIdSet.Value ? os.ConnectorAssignedOfferSubscriptions.Any() : !os.ConnectorAssignedOfferSubscriptions.Any())))
+            .Select(os => new OfferSubscriptionConnectorData(
+                os.Id,
+                os.Company!.Name,
+                os.Offer!.Name,
+                os.ConnectorAssignedOfferSubscriptions.Select(c => c.ConnectorId)
+            ))
+            .ToAsyncEnumerable();
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -490,7 +490,7 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
             .Where(os =>
                 os.Offer!.ProviderCompanyId == companyId &&
                 (os.OfferSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE || os.OfferSubscriptionStatusId == OfferSubscriptionStatusId.PENDING) &&
-                (!connectorIdSet.HasValue || (connectorIdSet.Value ? os.ConnectorAssignedOfferSubscriptions.Any() : !os.ConnectorAssignedOfferSubscriptions.Any())))
+                (connectorIdSet == null || (connectorIdSet.Value ? os.ConnectorAssignedOfferSubscriptions.Any() : !os.ConnectorAssignedOfferSubscriptions.Any())))
             .Select(os => new OfferSubscriptionConnectorData(
                 os.Id,
                 os.Company!.Name,

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ConnectorAssignedOfferSubscription.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ConnectorAssignedOfferSubscription.cs
@@ -28,10 +28,10 @@ public class ConnectorAssignedOfferSubscription
         OfferSubscriptionId = offerSubscriptionId;
     }
 
-    public Guid ConnectorId { get; set; }
-    public Guid OfferSubscriptionId { get; set; }
+    public Guid ConnectorId { get; private set; }
+    public Guid OfferSubscriptionId { get; private set; }
 
     // Navigation properties
-    public virtual Connector? Connector { get; set; }
-    public virtual OfferSubscription? OfferSubscription { get; set; }
+    public virtual Connector? Connector { get; private set; }
+    public virtual OfferSubscription? OfferSubscription { get; private set; }
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -973,6 +973,25 @@ public class ConnectorsBusinessLogicTests
         ex.Message.Should().Be($"Incorrect BPN [{bpns[0]}] attribute value");
     }
 
+    #region GetConnectorOfferSubscriptionData
+
+    [Fact]
+    public async Task GetConnectorOfferSubscriptionData_ReturnsList()
+    {
+        // Arrange
+        var data = _fixture.CreateMany<OfferSubscriptionConnectorData>(5);
+        A.CallTo(() => _offerSubscriptionRepository.GetConnectorOfferSubscriptionData(null, _identity.CompanyId))!
+            .Returns(data.ToAsyncEnumerable());
+
+        // Act
+        var result = await _logic.GetConnectorOfferSubscriptionData(null, _identity.CompanyId).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().HaveCount(data.Count());
+    }
+
+    #endregion
+
     #region Setup
 
     private void SetupRepositoryMethods()

--- a/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
@@ -223,4 +223,19 @@ public class ConnectorsControllerTests
         A.CallTo(() => _logic.UpdateConnectorUrl(connectorId, data, new(_identity.UserId, _identity.CompanyId), A<CancellationToken>._)).MustHaveHappenedOnceExactly();
         result.Should().BeOfType<NoContentResult>();
     }
+
+    [Fact]
+    public async Task GetConnectorOfferSubscriptionData_ReturnsExpectedResult()
+    {
+        // Arrange
+        var offerSubscriptionData = _fixture.CreateMany<OfferSubscriptionConnectorData>(5);
+        A.CallTo(() => _logic.GetConnectorOfferSubscriptionData(null, _identity.CompanyId))
+            .Returns(offerSubscriptionData.ToAsyncEnumerable());
+
+        // Act
+        var result = await this._controller.GetConnectorOfferSubscriptionData(null).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().HaveCount(5);
+    }
 }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferRepositoryTests.cs
@@ -136,13 +136,14 @@ public class OfferRepositoryTests : IAssemblyFixture<TestDbFixture>
         var offers = await sut.GetAllActiveAppsAsync(null!, Constants.DefaultLanguage).ToListAsync().ConfigureAwait(false);
 
         // Assert
-        offers.Should().HaveCount(6).And.Satisfy(
+        offers.Should().HaveCount(7).And.Satisfy(
+            x => x.Name == "Test App",
+            x => x.Name == "Test App 3",
             x => x.Name == "Trace-X",
             x => x.Name == "Project Implementation: Earth Commerce",
             x => x.Name == "Top App",
             x => x.Name == "Test App 1",
-            x => x.Name == "Test App 2",
-            x => x.Name == "Test App 3"
+            x => x.Name == "Test App 2"
         );
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -926,6 +926,53 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
+    #region GetConnectorOfferSubscriptionData
+
+    [Fact]
+    public async Task GetConnectorOfferSubscriptionData_WithoutFilter_ReturnsExpected()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetConnectorOfferSubscriptionData(null, new Guid("41fd2ab8-7123-4546-9bef-a388d91b2999")).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().HaveCount(3)
+            .And.Satisfy(
+                x => x.SubscriptionId == new Guid("014afd09-e51a-4ecf-83ab-a5380d9af832"),
+                x => x.SubscriptionId == new Guid("92be9d79-4064-422c-bdc8-a12ca7d26e5d"),
+                x => x.SubscriptionId == new Guid("ed6065b1-0902-4d5e-9470-33a716022a1a"));
+    }
+
+    [Fact]
+    public async Task GetConnectorOfferSubscriptionData_WithConnectorIdSet_ReturnsExpected()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetConnectorOfferSubscriptionData(true, new Guid("41fd2ab8-7123-4546-9bef-a388d91b2999")).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().HaveCount(2).And.AllSatisfy(x => x.ConnectorIds.Should().NotBeNullOrEmpty());
+    }
+
+    [Fact]
+    public async Task GetConnectorOfferSubscriptionData_WithoutConnectorIdSet_ReturnsExpected()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetConnectorOfferSubscriptionData(false, new Guid("41fd2ab8-7123-4546-9bef-a388d91b2999")).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().HaveCount(1).And.AllSatisfy(x => x.ConnectorIds.Should().BeEmpty());
+    }
+
+    #endregion
+
     #region Setup
 
     private async Task<(IOfferSubscriptionsRepository, PortalDbContext)> CreateSut()

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionViewTests.cs
@@ -50,7 +50,7 @@ public class OfferSubscriptionViewTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var result = await sut.OfferSubscriptionView.ToListAsync().ConfigureAwait(false);
-        result.Should().HaveCount(8);
+        result.Should().HaveCount(11);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/addresses.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/addresses.test.json
@@ -58,5 +58,17 @@
     "streetnumber": "6",
     "zipcode": "00001",
     "country_alpha2code": "DE"
+  },
+  {
+    "id": "86da3e1c-a634-1234-ad44-988074612999",
+    "date_created": "2022-03-24 18:01:33.435000 +00:00",
+    "date_last_changed": "2022-03-24 18:01:33.435000 +00:00",
+    "city": "Munich",
+    "region": null,
+    "streetadditional": null,
+    "streetname": "Street",
+    "streetnumber": "6",
+    "zipcode": "00001",
+    "country_alpha2code": "DE"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/companies.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/companies.test.json
@@ -48,5 +48,15 @@
     "company_status_id": 1,
     "address_id": "86da3e1c-a634-41a6-ad44-9880746123e4",
     "self_description_document_id": null
+  },
+  {
+    "id": "41fd2ab8-7123-4546-9bef-a388d91b2999",
+    "date_created": "2022-03-24 18:01:33.438000 +00:00",
+    "business_partner_number": "BPNL00000001TEST",
+    "name": "Test Company",
+    "shortname": "Test Company",
+    "company_status_id": 2,
+    "address_id": "86da3e1c-a634-1234-ad44-988074612999",
+    "self_description_document_id": null
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connector_assigned_offer_subscriptions.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connector_assigned_offer_subscriptions.test.json
@@ -1,0 +1,10 @@
+﻿[
+  {
+    "connector_id": "4618c650-709c-4580-956a-85b76eecd4b8",
+    "offer_subscription_id": "014afd09-e51a-4ecf-83ab-a5380d9af832" 
+  },
+  {
+    "connector_id": "bd644d9c-ca12-4488-ae38-6eb902c9bec0",
+    "offer_subscription_id": "ed6065b1-0902-4d5e-9470-33a716022a1a"
+  }
+]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connectors.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connectors.test.json
@@ -83,5 +83,29 @@
     "self_description_document_id": null,
     "daps_registration_successful": null,
     "company_service_account_id": "d0c8ae19-d4f3-49cc-9cb4-6c766d4680f4"
+  },
+  {
+    "id": "4618c650-709c-4580-956a-85b76eecd4b8",
+    "name": "Test Connector 666",
+    "connector_url": "www.google.de",
+    "type_id": 2,
+    "status_id": 1,
+    "provider_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
+    "host_id": "41fd2ab8-7123-4546-9bef-a388d91b2999",
+    "location_id": "DE",
+    "self_description_document_id": null,
+    "daps_registration_successful": null
+  },
+  {
+    "id": "bd644d9c-ca12-4488-ae38-6eb902c9bec0",
+    "name": "Test Connector 123",
+    "connector_url": "www.google.de",
+    "type_id": 2,
+    "status_id": 1,
+    "provider_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f88",
+    "host_id": "41fd2ab8-7123-4546-9bef-a388d91b2999",
+    "location_id": "DE",
+    "self_description_document_id": null,
+    "daps_registration_successful": null
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offer_subscriptions.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offer_subscriptions.test.json
@@ -79,5 +79,35 @@
     "last_editor_id": null,
     "display_name": null,
     "description": null
+  },
+  {
+    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
+    "offer_id": "19e05734-9b1f-1234-b961-8ffa1d7b6999",
+    "offer_subscription_status_id": 1,
+    "requester_id": "ac1cf001-7fbc-1f2f-817f-bce058019992",
+    "id": "014afd09-e51a-4ecf-83ab-a5380d9af832",
+    "last_editor_id": null,
+    "display_name": null,
+    "description": null
+  },
+  {
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f88",
+    "offer_id": "19e05734-9b1f-1234-b961-8ffa1d7b6999",
+    "offer_subscription_status_id": 2,
+    "requester_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
+    "id": "ed6065b1-0902-4d5e-9470-33a716022a1a",
+    "last_editor_id": null,
+    "display_name": null,
+    "description": null
+  },
+  {
+    "company_id": "0dcd8209-85e2-4073-b130-ac094fb47106",
+    "offer_id": "19e05734-9b1f-1234-b961-8ffa1d7b6999",
+    "offer_subscription_status_id": 1,
+    "requester_id": "ac1cf001-7fbc-1f2f-817f-bce0575a0011",
+    "id": "92be9d79-4064-422c-bdc8-a12ca7d26e5d",
+    "last_editor_id": null,
+    "display_name": null,
+    "description": null
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offers.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offers.test.json
@@ -236,5 +236,22 @@
       "offer_type_id": 1,
       "last_editor_id": null,
       "license_type_id":1
-    }
+    },
+  {
+    "id": "19e05734-9b1f-1234-b961-8ffa1d7b6999",
+    "name": "Test App",
+    "date_created": "2022-10-01 00:00:00.000000 +00:00",
+    "date_released": "2022-10-01 00:00:00.000005 +00:00",
+    "marketing_url": null,
+    "contact_email": null,
+    "contact_number": null,
+    "provider": "Test Company",
+    "provider_company_id": "41fd2ab8-7123-4546-9bef-a388d91b2999",
+    "offer_status_id": 3,
+    "date_last_changed": "2022-10-01 00:00:00.000000 +00:00",
+    "sales_manager_id": "ac1cf001-7fbc-1f2f-817f-bce058020005",
+    "offer_type_id": 1,
+    "last_editor_id": null,
+    "license_type_id":1
+  }
 ]


### PR DESCRIPTION
## Description

add /api/administration/connectors/offerSubscriptions to get all offerSubscriptions for the connector view

## Why

To provide a selection of the current offer subscriptions for the user to be able to create a managed connector the endpoint is needed.

## Issue

N/A - CPLP-2947

## Depending On:

This PR depends on #129 please review this PR after 129 was reviewed and merged.

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
