### PR TITLE
fix(notification): get notification details

### DIFF
--- a/src/notifications/Notifications.Service/Controllers/NotificationController.cs
+++ b/src/notifications/Notifications.Service/Controllers/NotificationController.cs
@@ -61,7 +61,7 @@ public class NotificationController : ControllerBase
     /// <param name="notificationTopicId">OPTIONAL: Topic of the notifications</param>
     /// <param name="onlyDueDate">OPTIONAL: If true only notifications with a due date will be returned</param>
     /// <param name="sorting">Defines the sorting of the list</param>
-    /// <param name="doneState">Defines the done state</param>
+    /// <param name="doneState">OPTIONAL: Defines the done state</param>
     /// <response code="200">Collection of the unread notifications for the user.</response>
     /// <response code="400">NotificationType or NotificationStatus don't exist.</response>
     [HttpGet]

--- a/src/portalbackend/PortalBackend.DBAccess/Models/NotificationDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/NotificationDetailData.cs
@@ -36,7 +36,7 @@ public record NotificationDetailData(
     Guid Id,
     DateTimeOffset Created,
     NotificationTypeId TypeId,
-    NotificationTopicId NotificationTopic,
+    NotificationTopicId? NotificationTopic,
     bool IsRead,
     string? Content,
     DateTimeOffset? DueDate,

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -403,6 +403,30 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         result.Should().NotBeNull();
         result.IsUserReceiver.Should().BeTrue();
         result.NotificationDetailData.IsRead.Should().BeTrue();
+        result.NotificationDetailData.NotificationTopic.Should().Be(NotificationTopicId.INFO);
+    }
+
+    [Fact]
+    public async Task GetNotificationByIdAndIamUserId_WithoutLinkedTopic_GetsExpectedNotification()
+    {
+        // Arrange
+        var (sut, context) = await CreateSutWithContext().ConfigureAwait(false);
+        using var trans = await context.Database.BeginTransactionAsync().ConfigureAwait(false);
+        context.NotificationTypeAssignedTopics.Remove(new NotificationTypeAssignedTopic(NotificationTypeId.INFO, NotificationTopicId.INFO));
+        await context.SaveChangesAsync().ConfigureAwait(false);
+
+        // Act
+        var result = await sut
+            .GetNotificationByIdAndValidateReceiverAsync(new Guid("500E4D2C-9919-4CA8-B75B-D523FBC99259"), _companyUserId)
+            .ConfigureAwait(false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsUserReceiver.Should().BeTrue();
+        result.NotificationDetailData.IsRead.Should().BeTrue();
+        result.NotificationDetailData.NotificationTopic.Should().BeNull();
+
+        await trans.RollbackAsync().ConfigureAwait(false);
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -362,7 +362,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
             results!.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x => x.Done == doneState.Value));
         }
     }
-    
+
     [Fact]
     public async Task GetAllAsDetailsByUserIdUntracked_WithUnlinkedNotificationTypeIdandTopicId_ReturnsExpectedNotificationDetailData()
     {


### PR DESCRIPTION
## Description

Changed NotificationTopicId to nullable, to make sure the database query doesn't throw an exception when a link for notificationTypeId and NotificationTopicId is missing

## Why

Endpoint was throwing exception if there was no link data for notificationtypeid and notificationtopicid

## Issue

N/A - Jira Ticket: CPLP-2934

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have commented my code, particularly in hard-to-understand areas
