### PR TITLE
feat(applicationChecklist)! : retriggerProcessSteps update comments for applicationChecklist type

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -251,7 +251,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
         _portalRepositories.GetInstance<ICompanyRepository>().AttachAndModifyCompany(applicationCompanyData.CompanyId, null,
             c => { c.BusinessPartnerNumber = bpn; });
 
-        var registrationValidationFailed = context.Checklist[ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION] == ApplicationChecklistEntryStatusId.FAILED;
+        var registrationValidationFailed = context.Checklist[ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION] == new ValueTuple<ApplicationChecklistEntryStatusId, string?>(ApplicationChecklistEntryStatusId.FAILED, null);
 
         _checklistService.SkipProcessSteps(
             context,
@@ -339,9 +339,12 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
         _checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
-            inital =>
+            initial =>
             {
-                inital.Comment = context.ChecklistComment.SingleOrDefault(x => x.Key == entryTypeId).Value;
+                if (context.Checklist.TryGetValue(entryTypeId, out var data))
+                {
+                    initial.Comment = data.Comment;
+                }
             },
             item =>
             {
@@ -384,7 +387,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
                 new[] { ProcessStepTypeId.CREATE_IDENTITY_WALLET })
             .ConfigureAwait(false);
 
-        var businessPartnerSuccess = context.Checklist[ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER] == ApplicationChecklistEntryStatusId.DONE;
+        var businessPartnerSuccess = context.Checklist[ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER] == new ValueTuple<ApplicationChecklistEntryStatusId, string?>(ApplicationChecklistEntryStatusId.DONE, null);
 
         _checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -264,6 +264,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
         _checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
+            null,
             entry => entry.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.DONE,
             registrationValidationFailed
                 ? null
@@ -338,9 +339,14 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
         _checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
+            inital =>
+            {
+                inital.Comment = context.ChecklistComment.SingleOrDefault(x => x.Key == entryTypeId).Value;
+            },
             item =>
             {
                 item.ApplicationChecklistEntryStatusId = checklistEntryStatusId;
+                item.Comment = null;
             },
             new[] { nextProcessStepTypeId });
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
@@ -382,6 +388,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
         _checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
+            null,
             entry =>
             {
                 entry.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.DONE;
@@ -417,6 +424,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
         _checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
+            null,
             entry =>
             {
                 entry.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.FAILED;

--- a/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
+++ b/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
@@ -120,6 +120,7 @@ public class ClearinghouseBusinessLogic : IClearinghouseBusinessLogic
 
         _checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
+            null,
             item =>
             {
                 item.ApplicationChecklistEntryStatusId = declined

--- a/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
+++ b/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
@@ -113,6 +113,7 @@ public class SdFactoryBusinessLogic : ISdFactoryBusinessLogic
 
         _checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
+            null,
             item =>
             {
                 item.ApplicationChecklistEntryStatusId =

--- a/src/portalbackend/PortalBackend.DBAccess/Models/VerifyChecklistData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/VerifyChecklistData.cs
@@ -26,5 +26,5 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 public record VerifyChecklistData(
     bool IsSubmitted,
     Process? Process,
-    IEnumerable<(ApplicationChecklistEntryTypeId TypeId, ApplicationChecklistEntryStatusId StatusId)>? Checklist,
+    IEnumerable<(ApplicationChecklistEntryTypeId TypeId, ApplicationChecklistEntryStatusId StatusId, string? comment)>? Checklist,
     IEnumerable<ProcessStep>? ProcessSteps);

--- a/src/portalbackend/PortalBackend.DBAccess/Models/VerifyChecklistData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/VerifyChecklistData.cs
@@ -26,5 +26,5 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 public record VerifyChecklistData(
     bool IsSubmitted,
     Process? Process,
-    IEnumerable<(ApplicationChecklistEntryTypeId TypeId, ApplicationChecklistEntryStatusId StatusId, string? comment)>? Checklist,
+    IEnumerable<(ApplicationChecklistEntryTypeId TypeId, ApplicationChecklistEntryStatusId StatusId, string Comment)> Checklist,
     IEnumerable<ProcessStep>? ProcessSteps);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationChecklistRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationChecklistRepository.cs
@@ -52,9 +52,10 @@ public class ApplicationChecklistRepository : IApplicationChecklistRepository
     }
 
     /// <inheritdoc />
-    public ApplicationChecklistEntry AttachAndModifyApplicationChecklist(Guid applicationId, ApplicationChecklistEntryTypeId applicationChecklistTypeId, Action<ApplicationChecklistEntry> setFields)
+    public ApplicationChecklistEntry AttachAndModifyApplicationChecklist(Guid applicationId, ApplicationChecklistEntryTypeId applicationChecklistTypeId, Action<ApplicationChecklistEntry>? initialize, Action<ApplicationChecklistEntry> setFields)
     {
         var entity = new ApplicationChecklistEntry(applicationId, applicationChecklistTypeId, default, default);
+        initialize?.Invoke(entity);
         _portalDbContext.ApplicationChecklist.Attach(entity);
         entity.DateLastChanged = DateTimeOffset.UtcNow;
         setFields.Invoke(entity);
@@ -96,7 +97,7 @@ public class ApplicationChecklistRepository : IApplicationChecklistRepository
                 x.IsSubmitted
                     ? x.Application.ApplicationChecklistEntries
                         .Where(entry => entryTypeIds.Contains(entry.ApplicationChecklistEntryTypeId))
-                        .Select(entry => new ValueTuple<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>(entry.ApplicationChecklistEntryTypeId, entry.ApplicationChecklistEntryStatusId))
+                        .Select(entry => new ValueTuple<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId, string?>(entry.ApplicationChecklistEntryTypeId, entry.ApplicationChecklistEntryStatusId, entry.Comment))
                     : null,
                 x.IsSubmitted
                     ? x.Process!.ProcessSteps

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationChecklistRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationChecklistRepository.cs
@@ -40,7 +40,7 @@ public interface IApplicationChecklistRepository
     /// <param name="applicationId">Id of the application to modify</param>
     /// <param name="applicationChecklistTypeId">Id of the checklistType to modify</param>
     /// <param name="setFields">Action to sets the fields</param>
-    ApplicationChecklistEntry AttachAndModifyApplicationChecklist(Guid applicationId, ApplicationChecklistEntryTypeId applicationChecklistTypeId, Action<ApplicationChecklistEntry> setFields);
+    ApplicationChecklistEntry AttachAndModifyApplicationChecklist(Guid applicationId, ApplicationChecklistEntryTypeId applicationChecklistTypeId, Action<ApplicationChecklistEntry> initialize, Action<ApplicationChecklistEntry> setFields);
 
     Task<(bool IsValidProcessId, Guid ApplicationId, CompanyApplicationStatusId ApplicationStatusId, IEnumerable<(ApplicationChecklistEntryTypeId EntryTypeId, ApplicationChecklistEntryStatusId EntryStatusId)> Checklist)> GetChecklistData(Guid processId);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationChecklistRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationChecklistRepository.cs
@@ -39,8 +39,9 @@ public interface IApplicationChecklistRepository
     /// </summary>
     /// <param name="applicationId">Id of the application to modify</param>
     /// <param name="applicationChecklistTypeId">Id of the checklistType to modify</param>
+    /// <param name="initialize">Action to initialize the applicationChecklistEntry</param>
     /// <param name="setFields">Action to sets the fields</param>
-    ApplicationChecklistEntry AttachAndModifyApplicationChecklist(Guid applicationId, ApplicationChecklistEntryTypeId applicationChecklistTypeId, Action<ApplicationChecklistEntry> initialize, Action<ApplicationChecklistEntry> setFields);
+    ApplicationChecklistEntry AttachAndModifyApplicationChecklist(Guid applicationId, ApplicationChecklistEntryTypeId applicationChecklistTypeId, Action<ApplicationChecklistEntry>? initialize, Action<ApplicationChecklistEntry> setFields);
 
     Task<(bool IsValidProcessId, Guid ApplicationId, CompanyApplicationStatusId ApplicationStatusId, IEnumerable<(ApplicationChecklistEntryTypeId EntryTypeId, ApplicationChecklistEntryStatusId EntryStatusId)> Checklist)> GetChecklistData(Guid processId);
 

--- a/src/processes/ApplicationChecklist.Executor/ApplicationChecklistProcessTypeExecutor.cs
+++ b/src/processes/ApplicationChecklist.Executor/ApplicationChecklistProcessTypeExecutor.cs
@@ -151,6 +151,7 @@ public class ApplicationChecklistProcessTypeExecutor : IProcessTypeExecutor
             .AttachAndModifyApplicationChecklist(
                 applicationId,
                 entryTypeId,
+                null!,
                 modifyApplicationChecklistEntry);
         checklist![entryTypeId] = entry.ApplicationChecklistEntryStatusId;
         return true;

--- a/src/processes/ApplicationChecklist.Executor/ApplicationChecklistProcessTypeExecutor.cs
+++ b/src/processes/ApplicationChecklist.Executor/ApplicationChecklistProcessTypeExecutor.cs
@@ -36,7 +36,7 @@ public class ApplicationChecklistProcessTypeExecutor : IProcessTypeExecutor
     private readonly IApplicationChecklistRepository _checklistRepository;
 
     private Guid applicationId;
-    private IDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>? checklist = null;
+    private IDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>? checklist;
 
     public ApplicationChecklistProcessTypeExecutor(
         IApplicationChecklistHandlerService checklistHandlerService,
@@ -151,7 +151,7 @@ public class ApplicationChecklistProcessTypeExecutor : IProcessTypeExecutor
             .AttachAndModifyApplicationChecklist(
                 applicationId,
                 entryTypeId,
-                null!,
+                null,
                 modifyApplicationChecklistEntry);
         checklist![entryTypeId] = entry.ApplicationChecklistEntryStatusId;
         return true;

--- a/src/processes/ApplicationChecklist.Library/ApplicationChecklistService.cs
+++ b/src/processes/ApplicationChecklist.Library/ApplicationChecklistService.cs
@@ -104,7 +104,7 @@ public sealed class ApplicationChecklistService : IApplicationChecklistService
         if (modifyApplicationChecklistEntry != null)
         {
             applicationChecklistRepository
-                .AttachAndModifyApplicationChecklist(context.ApplicationId, context.EntryTypeId, initializeApplicationChecklistEntry!, modifyApplicationChecklistEntry);
+                .AttachAndModifyApplicationChecklist(context.ApplicationId, context.EntryTypeId, initializeApplicationChecklistEntry, modifyApplicationChecklistEntry);
         }
         processStepRepository.AttachAndModifyProcessStep(context.ProcessStepId, null, step => step.ProcessStepStatusId = ProcessStepStatusId.DONE);
         if (nextProcessStepTypeIds == null || !nextProcessStepTypeIds.Any())

--- a/src/processes/ApplicationChecklist.Library/ApplicationChecklistService.cs
+++ b/src/processes/ApplicationChecklist.Library/ApplicationChecklistService.cs
@@ -96,7 +96,7 @@ public sealed class ApplicationChecklistService : IApplicationChecklistService
         }
     }
 
-    public void FinalizeChecklistEntryAndProcessSteps(IApplicationChecklistService.ManualChecklistProcessStepData context, Action<ApplicationChecklistEntry>? modifyApplicationChecklistEntry, IEnumerable<ProcessStepTypeId>? nextProcessStepTypeIds)
+    public void FinalizeChecklistEntryAndProcessSteps(IApplicationChecklistService.ManualChecklistProcessStepData context, Action<ApplicationChecklistEntry>? initializeApplicationChecklistEntry, Action<ApplicationChecklistEntry>? modifyApplicationChecklistEntry, IEnumerable<ProcessStepTypeId>? nextProcessStepTypeIds)
     {
         var applicationChecklistRepository = _portalRepositories.GetInstance<IApplicationChecklistRepository>();
         var processStepRepository = _portalRepositories.GetInstance<IProcessStepRepository>();
@@ -104,7 +104,7 @@ public sealed class ApplicationChecklistService : IApplicationChecklistService
         if (modifyApplicationChecklistEntry != null)
         {
             applicationChecklistRepository
-                .AttachAndModifyApplicationChecklist(context.ApplicationId, context.EntryTypeId, modifyApplicationChecklistEntry);
+                .AttachAndModifyApplicationChecklist(context.ApplicationId, context.EntryTypeId, initializeApplicationChecklistEntry!, modifyApplicationChecklistEntry);
         }
         processStepRepository.AttachAndModifyProcessStep(context.ProcessStepId, null, step => step.ProcessStepStatusId = ProcessStepStatusId.DONE);
         if (nextProcessStepTypeIds == null || !nextProcessStepTypeIds.Any())

--- a/src/processes/ApplicationChecklist.Library/IApplicationChecklistService.cs
+++ b/src/processes/ApplicationChecklist.Library/IApplicationChecklistService.cs
@@ -26,7 +26,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Lib
 
 public interface IApplicationChecklistService
 {
-    record ManualChecklistProcessStepData(Guid ApplicationId, Process Process, Guid ProcessStepId, ApplicationChecklistEntryTypeId EntryTypeId, ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId> Checklist, IEnumerable<ProcessStep> ProcessSteps, ImmutableDictionary<ApplicationChecklistEntryTypeId, string?> ChecklistComment);
+    record ManualChecklistProcessStepData(Guid ApplicationId, Process Process, Guid ProcessStepId, ApplicationChecklistEntryTypeId EntryTypeId, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId StatusId, string? Comment)> Checklist, IEnumerable<ProcessStep> ProcessSteps);
     record WorkerChecklistProcessStepData(Guid ApplicationId, ProcessStepTypeId ProcessStepTypeId, ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId> Checklist, IEnumerable<ProcessStepTypeId> ProcessStepTypeIds);
     record WorkerChecklistProcessStepExecutionResult(ProcessStepStatusId StepStatusId, Action<ApplicationChecklistEntry>? ModifyChecklistEntry, IEnumerable<ProcessStepTypeId>? ScheduleStepTypeIds, IEnumerable<ProcessStepTypeId>? SkipStepTypeIds, bool Modified, string? ProcessMessage);
 

--- a/src/processes/ApplicationChecklist.Library/IApplicationChecklistService.cs
+++ b/src/processes/ApplicationChecklist.Library/IApplicationChecklistService.cs
@@ -26,14 +26,14 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Lib
 
 public interface IApplicationChecklistService
 {
-    record ManualChecklistProcessStepData(Guid ApplicationId, Process Process, Guid ProcessStepId, ApplicationChecklistEntryTypeId EntryTypeId, ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId> Checklist, IEnumerable<ProcessStep> ProcessSteps);
+    record ManualChecklistProcessStepData(Guid ApplicationId, Process Process, Guid ProcessStepId, ApplicationChecklistEntryTypeId EntryTypeId, ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId> Checklist, IEnumerable<ProcessStep> ProcessSteps, ImmutableDictionary<ApplicationChecklistEntryTypeId, string?> ChecklistComment);
     record WorkerChecklistProcessStepData(Guid ApplicationId, ProcessStepTypeId ProcessStepTypeId, ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId> Checklist, IEnumerable<ProcessStepTypeId> ProcessStepTypeIds);
     record WorkerChecklistProcessStepExecutionResult(ProcessStepStatusId StepStatusId, Action<ApplicationChecklistEntry>? ModifyChecklistEntry, IEnumerable<ProcessStepTypeId>? ScheduleStepTypeIds, IEnumerable<ProcessStepTypeId>? SkipStepTypeIds, bool Modified, string? ProcessMessage);
 
     Task<ManualChecklistProcessStepData> VerifyChecklistEntryAndProcessSteps(Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, IEnumerable<ApplicationChecklistEntryStatusId> entryStatusIds, ProcessStepTypeId processStepTypeId, IEnumerable<ApplicationChecklistEntryTypeId>? entryTypeIds = null, IEnumerable<ProcessStepTypeId>? processStepTypeIds = null);
     void RequestLock(IApplicationChecklistService.ManualChecklistProcessStepData context, DateTimeOffset lockExpiryDate);
     void SkipProcessSteps(ManualChecklistProcessStepData context, IEnumerable<ProcessStepTypeId> processStepTypeIds);
-    void FinalizeChecklistEntryAndProcessSteps(ManualChecklistProcessStepData context, Action<ApplicationChecklistEntry>? modifyApplicationChecklistEntry, IEnumerable<ProcessStepTypeId>? nextProcessStepTypeIds);
+    void FinalizeChecklistEntryAndProcessSteps(ManualChecklistProcessStepData context, Action<ApplicationChecklistEntry>? initializeApplicationChecklistEntry, Action<ApplicationChecklistEntry>? modifyApplicationChecklistEntry, IEnumerable<ProcessStepTypeId>? nextProcessStepTypeIds);
 
     Task<IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult> HandleServiceErrorAsync(Exception exception, ProcessStepTypeId manualProcessTriggerStep);
 }

--- a/src/processes/ApplicationChecklist.Library/VerifyApplicationChecklistDataExtensions.cs
+++ b/src/processes/ApplicationChecklist.Library/VerifyApplicationChecklistDataExtensions.cs
@@ -72,5 +72,5 @@ public static class VerifyApplicationChecklistDataExtensions
     }
 
     public static IApplicationChecklistService.ManualChecklistProcessStepData CreateManualChecklistProcessStepData(this VerifyChecklistData checklistData, Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, ProcessStep processStep) =>
-        new IApplicationChecklistService.ManualChecklistProcessStepData(applicationId, checklistData.Process!, processStep.Id, entryTypeId, checklistData.Checklist!.ToImmutableDictionary(entry => entry.TypeId, entry => entry.StatusId), checklistData.ProcessSteps!);
+        new IApplicationChecklistService.ManualChecklistProcessStepData(applicationId, checklistData.Process!, processStep.Id, entryTypeId, checklistData.Checklist!.ToImmutableDictionary(entry => entry.TypeId, entry => entry.StatusId), checklistData.ProcessSteps!, checklistData.Checklist!.ToImmutableDictionary(entry => entry.TypeId, entry => entry.comment));
 }

--- a/src/processes/ApplicationChecklist.Library/VerifyApplicationChecklistDataExtensions.cs
+++ b/src/processes/ApplicationChecklist.Library/VerifyApplicationChecklistDataExtensions.cs
@@ -72,5 +72,5 @@ public static class VerifyApplicationChecklistDataExtensions
     }
 
     public static IApplicationChecklistService.ManualChecklistProcessStepData CreateManualChecklistProcessStepData(this VerifyChecklistData checklistData, Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, ProcessStep processStep) =>
-        new IApplicationChecklistService.ManualChecklistProcessStepData(applicationId, checklistData.Process!, processStep.Id, entryTypeId, checklistData.Checklist!.ToImmutableDictionary(entry => entry.TypeId, entry => entry.StatusId), checklistData.ProcessSteps!, checklistData.Checklist!.ToImmutableDictionary(entry => entry.TypeId, entry => entry.comment));
+        new IApplicationChecklistService.ManualChecklistProcessStepData(applicationId, checklistData.Process!, processStep.Id, entryTypeId, checklistData.Checklist!.ToImmutableDictionary(entry => entry.TypeId, entry => new ValueTuple<ApplicationChecklistEntryStatusId, string?>(entry.StatusId, entry.Comment)), checklistData.ProcessSteps!);
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -564,11 +564,9 @@ public class RegistrationBusinessLogicTest
             new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()),
             Guid.NewGuid(),
             typeId,
-            new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>()
+            new Dictionary<ApplicationChecklistEntryTypeId, ValueTuple<ApplicationChecklistEntryStatusId, string?>>()
                 .ToImmutableDictionary(),
-            Enumerable.Empty<ProcessStep>(),
-            new Dictionary<ApplicationChecklistEntryTypeId, string?>()
-                .ToImmutableDictionary());
+            Enumerable.Empty<ProcessStep>());
         A.CallTo(() => _checklistService.VerifyChecklistEntryAndProcessSteps(applicationId,
                 typeId,
                 A<IEnumerable<ApplicationChecklistEntryStatusId>>._,
@@ -774,10 +772,10 @@ public class RegistrationBusinessLogicTest
             }.ToAsyncEnumerable());
 
         A.CallTo(() => _checklistService.VerifyChecklistEntryAndProcessSteps(IdWithoutBpn, ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, A<IEnumerable<ApplicationChecklistEntryStatusId>>._, A<ProcessStepTypeId>._, A<IEnumerable<ApplicationChecklistEntryTypeId>?>._, A<IEnumerable<ProcessStepTypeId>?>._))
-            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
+            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>
             {
-                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE }
-            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>(), null!));
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new ValueTuple<ApplicationChecklistEntryStatusId, string?>(ApplicationChecklistEntryStatusId.DONE, null) }
+            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>()));
     }
 
     private void SetupForApproveRegistrationVerification(ApplicationChecklistEntry applicationChecklistEntry)
@@ -789,15 +787,15 @@ public class RegistrationBusinessLogicTest
             });
 
         A.CallTo(() => _checklistService.VerifyChecklistEntryAndProcessSteps(IdWithoutBpn, ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, A<IEnumerable<ApplicationChecklistEntryStatusId>>._, A<ProcessStepTypeId>._, A<IEnumerable<ApplicationChecklistEntryTypeId>?>._, A<IEnumerable<ProcessStepTypeId>?>._))
-            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
+            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>
             {
-                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.IN_PROGRESS }
-            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>(), null!));
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, new ValueTuple<ApplicationChecklistEntryStatusId, string?>(ApplicationChecklistEntryStatusId.IN_PROGRESS, null) }
+            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>()));
         A.CallTo(() => _checklistService.VerifyChecklistEntryAndProcessSteps(IdWithBpn, ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, A<IEnumerable<ApplicationChecklistEntryStatusId>>._, A<ProcessStepTypeId>._, A<IEnumerable<ApplicationChecklistEntryTypeId>?>._, A<IEnumerable<ProcessStepTypeId>?>._))
-            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
+            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>
             {
-                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE }
-            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>(), null!));
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, new ValueTuple<ApplicationChecklistEntryStatusId, string?>(ApplicationChecklistEntryStatusId.DONE, null) }
+            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>()));
 
         A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(IdWithBpn))
             .Returns((CompanyId, CompanyName));
@@ -812,15 +810,15 @@ public class RegistrationBusinessLogicTest
             });
 
         A.CallTo(() => _checklistService.VerifyChecklistEntryAndProcessSteps(IdWithoutBpn, ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, A<IEnumerable<ApplicationChecklistEntryStatusId>>._, A<ProcessStepTypeId>._, A<IEnumerable<ApplicationChecklistEntryTypeId>?>._, A<IEnumerable<ProcessStepTypeId>?>._))
-            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
+            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>
             {
-                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, checklistStatusId }
-            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>(), null!));
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new ValueTuple<ApplicationChecklistEntryStatusId, string?>(checklistStatusId, null) }
+            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>()));
         A.CallTo(() => _checklistService.VerifyChecklistEntryAndProcessSteps(IdWithBpn, ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, A<IEnumerable<ApplicationChecklistEntryStatusId>>._, A<ProcessStepTypeId>._, A<IEnumerable<ApplicationChecklistEntryTypeId>?>._, A<IEnumerable<ProcessStepTypeId>?>._))
-            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
+            .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(IdWithoutBpn, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.NewGuid(), ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>
             {
-                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE }
-            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>(), null!));
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, new ValueTuple<ApplicationChecklistEntryStatusId, string?>(ApplicationChecklistEntryStatusId.DONE, null) }
+            }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>()));
 
         A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(IdWithBpn))
             .Returns((CompanyId, CompanyName));

--- a/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
+++ b/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
@@ -315,7 +315,7 @@ public class ClearinghouseBusinessLogicTests
                 ProcessStepTypeId.END_CLEARING_HOUSE,
                 A<IEnumerable<ApplicationChecklistEntryTypeId>?>._,
                 A<IEnumerable<ProcessStepTypeId>?>._))
-            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>.Empty, new List<ProcessStep>(), ImmutableDictionary<ApplicationChecklistEntryTypeId, string?>.Empty));
+            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty, new List<ProcessStep>()));
     }
 
     #endregion

--- a/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
+++ b/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
@@ -231,7 +231,7 @@ public class ClearinghouseBusinessLogicTests
         await _logic.ProcessEndClearinghouse(IdWithBpn, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>>.That.Matches(x => x.Count(y => y == ProcessStepTypeId.START_SELF_DESCRIPTION_LP) == 1))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>>.That.Matches(x => x.Count(y => y == ProcessStepTypeId.START_SELF_DESCRIPTION_LP) == 1))).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
         entry.Comment.Should().BeNull();
         entry.ApplicationChecklistEntryStatusId.Should().Be(ApplicationChecklistEntryStatusId.DONE);
@@ -252,7 +252,7 @@ public class ClearinghouseBusinessLogicTests
         await _logic.ProcessEndClearinghouse(IdWithBpn, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>>.That.Matches(x => x.Count(y => y == ProcessStepTypeId.TRIGGER_OVERRIDE_CLEARING_HOUSE) == 1))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>>.That.Matches(x => x.Count(y => y == ProcessStepTypeId.TRIGGER_OVERRIDE_CLEARING_HOUSE) == 1))).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
         entry.Comment.Should().Be("Comment about the error");
         entry.ApplicationChecklistEntryStatusId.Should().Be(ApplicationChecklistEntryStatusId.FAILED);
@@ -301,8 +301,8 @@ public class ClearinghouseBusinessLogicTests
 
     private void SetupForProcessClearinghouseResponse(ApplicationChecklistEntry applicationChecklistEntry)
     {
-        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>>._))
-            .Invokes((IApplicationChecklistService.ManualChecklistProcessStepData _, Action<ApplicationChecklistEntry> modifyApplicationChecklistEntry, IEnumerable<ProcessStepTypeId> _) =>
+        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>>._))
+            .Invokes((IApplicationChecklistService.ManualChecklistProcessStepData _, Action<ApplicationChecklistEntry> initialApplicationChecklistEntry, Action<ApplicationChecklistEntry> modifyApplicationChecklistEntry, IEnumerable<ProcessStepTypeId> _) =>
             {
                 applicationChecklistEntry.DateLastChanged = DateTimeOffset.UtcNow;
                 modifyApplicationChecklistEntry.Invoke(applicationChecklistEntry);
@@ -315,7 +315,7 @@ public class ClearinghouseBusinessLogicTests
                 ProcessStepTypeId.END_CLEARING_HOUSE,
                 A<IEnumerable<ApplicationChecklistEntryTypeId>?>._,
                 A<IEnumerable<ProcessStepTypeId>?>._))
-            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>.Empty, new List<ProcessStep>()));
+            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>.Empty, new List<ProcessStep>(), ImmutableDictionary<ApplicationChecklistEntryTypeId, string?>.Empty));
     }
 
     #endregion

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
@@ -455,9 +455,8 @@ public class SdFactoryBusinessLogicTests
                 new[] { ProcessStepTypeId.START_SELF_DESCRIPTION_LP }))
             .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(ApplicationId, _process, Guid.NewGuid(),
                 ApplicationChecklistEntryTypeId.SELF_DESCRIPTION_LP,
-                ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>.Empty,
-                new List<ProcessStep>(),
-                ImmutableDictionary<ApplicationChecklistEntryTypeId, string?>.Empty));
+                ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty,
+                new List<ProcessStep>()));
         A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(
                 A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._,
                 A<IEnumerable<ProcessStepTypeId>>._))

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
@@ -210,7 +210,7 @@ public class SdFactoryBusinessLogicTests
         await _sut.ProcessFinishSelfDescriptionLpForApplication(data, company.Id, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>>.That.Matches(x => x.Count(y => y == ProcessStepTypeId.ACTIVATE_APPLICATION) == 1))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>>.That.Matches(x => x.Count(y => y == ProcessStepTypeId.ACTIVATE_APPLICATION) == 1))).MustHaveHappenedOnceExactly();
         A.CallTo(() => _documentRepository.CreateDocument($"SelfDescription_LegalPerson.json", A<byte[]>._, A<byte[]>._, MediaTypeId.JSON, DocumentTypeId.SELF_DESCRIPTION, A<Action<Document>?>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _companyRepository.AttachAndModifyCompany(company.Id, null, A<Action<Company>>._)).MustHaveHappenedOnceExactly();
 
@@ -256,7 +256,7 @@ public class SdFactoryBusinessLogicTests
         await _sut.ProcessFinishSelfDescriptionLpForApplication(data, company.Id, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, null)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._, null)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _documentRepository.CreateDocument("SelfDescription_LegalPerson.json", A<byte[]>._, A<byte[]>._, MediaTypeId.JSON, DocumentTypeId.SELF_DESCRIPTION, A<Action<Document>?>._)).MustNotHaveHappened();
         A.CallTo(() => _companyRepository.AttachAndModifyCompany(company.Id, null, A<Action<Company>>._)).MustNotHaveHappened();
 
@@ -456,11 +456,12 @@ public class SdFactoryBusinessLogicTests
             .ReturnsLazily(() => new IApplicationChecklistService.ManualChecklistProcessStepData(ApplicationId, _process, Guid.NewGuid(),
                 ApplicationChecklistEntryTypeId.SELF_DESCRIPTION_LP,
                 ImmutableDictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>.Empty,
-                new List<ProcessStep>()));
+                new List<ProcessStep>(),
+                ImmutableDictionary<ApplicationChecklistEntryTypeId, string?>.Empty));
         A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(
-                A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._,
+                A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._,
                 A<IEnumerable<ProcessStepTypeId>>._))
-            .Invokes((IApplicationChecklistService.ManualChecklistProcessStepData _,
+            .Invokes((IApplicationChecklistService.ManualChecklistProcessStepData _, Action<ApplicationChecklistEntry> initailApplicationChecklistEntry,
                 Action<ApplicationChecklistEntry> modifyApplicationChecklistEntry, IEnumerable<ProcessStepTypeId> _) =>
             {
                 applicationChecklistEntry.DateLastChanged = DateTimeOffset.UtcNow;

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationChecklistRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationChecklistRepositoryTests.cs
@@ -91,6 +91,11 @@ public class ApplicationChecklistRepositoryTests : IAssemblyFixture<TestDbFixtur
 
         // Act
         sut.AttachAndModifyApplicationChecklist(ApplicationWithExistingChecklistId, ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION,
+            initial =>
+            {
+                initial.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.TO_DO;
+                initial.Comment = null;
+            },
             entry =>
             {
                 entry.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.IN_PROGRESS;
@@ -141,6 +146,13 @@ public class ApplicationChecklistRepositoryTests : IAssemblyFixture<TestDbFixtur
     public async Task GetChecklistProcessStepData_WithExisting_ReturnsExpected()
     {
         // Arrange
+        var checklistData = new ValueTuple<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId, string?>[] {
+            ( ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE ,null),
+            ( ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE,null ),
+            ( ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE , null),
+            ( ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.DONE, null ),
+            ( ApplicationChecklistEntryTypeId.SELF_DESCRIPTION_LP, ApplicationChecklistEntryStatusId.DONE, null),
+        };
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
@@ -162,13 +174,7 @@ public class ApplicationChecklistRepositoryTests : IAssemblyFixture<TestDbFixtur
         // Assert
         result.Should().NotBeNull();
         result!.IsSubmitted.Should().BeTrue();
-        result.Checklist.Should().HaveCount(5).And.Contain(new[] {
-            ( ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE ),
-            ( ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE ),
-            ( ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE ),
-            ( ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.DONE ),
-            ( ApplicationChecklistEntryTypeId.SELF_DESCRIPTION_LP, ApplicationChecklistEntryStatusId.DONE ),
-        });
+        result.Checklist.Should().HaveCount(5).And.Contain(checklistData);
         result.Process!.Id.Should().Be(new Guid("1f9a3232-9772-4ecb-8f50-c16e97772dfe"));
         result.Process.ProcessTypeId.Should().Be(ProcessTypeId.APPLICATION_CHECKLIST);
         result.Process.LockExpiryDate.Should().Be(DateTimeOffset.Parse("2023-03-01 00:00:00.000000 +00:00"));

--- a/tests/processes/ApplicationChecklist.Executor.Tests/ApplicationChecklistProcessTypeExecutorTests.cs
+++ b/tests/processes/ApplicationChecklist.Executor.Tests/ApplicationChecklistProcessTypeExecutorTests.cs
@@ -313,8 +313,8 @@ public class ApplicationChecklistProcessTypeExecutorTests
 
         ApplicationChecklistEntry? checklistEntry = null;
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._))
-            .ReturnsLazily((Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, Action<ApplicationChecklistEntry> setFields) =>
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
+            .ReturnsLazily((Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, Action<ApplicationChecklistEntry> Initial, Action<ApplicationChecklistEntry> setFields) =>
             {
                 checklistEntry = new ApplicationChecklistEntry(applicationId, entryTypeId, default, default);
                 setFields(checklistEntry);
@@ -337,7 +337,7 @@ public class ApplicationChecklistProcessTypeExecutorTests
         executionResult.ScheduleStepTypeIds.Should().ContainInOrder(followupStepTypeIds);
         executionResult.SkipStepTypeIds.Should().BeNull();
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(applicationId, ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, A<Action<ApplicationChecklistEntry>>._))
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(applicationId, ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
             .MustHaveHappenedOnceExactly();
 
         checklistEntry.Should().NotBeNull();
@@ -393,8 +393,8 @@ public class ApplicationChecklistProcessTypeExecutorTests
 
         ApplicationChecklistEntry? checklistEntry = null;
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._))
-            .ReturnsLazily((Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, Action<ApplicationChecklistEntry> setFields) =>
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
+            .ReturnsLazily((Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, Action<ApplicationChecklistEntry> initial, Action<ApplicationChecklistEntry> setFields) =>
             {
                 checklistEntry = new ApplicationChecklistEntry(applicationId, entryTypeId, default, default);
                 setFields(checklistEntry);
@@ -418,7 +418,7 @@ public class ApplicationChecklistProcessTypeExecutorTests
         executionResult.SkipStepTypeIds.Should().BeNull();
         executionResult.ProcessMessage.Should().Be("Test message");
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(applicationId, ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, A<Action<ApplicationChecklistEntry>>._))
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(applicationId, ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
             .MustHaveHappenedOnceExactly();
 
         checklistEntry.Should().NotBeNull();
@@ -486,7 +486,7 @@ public class ApplicationChecklistProcessTypeExecutorTests
         executionResult.SkipStepTypeIds.Should().BeNull();
         executionResult.ProcessMessage.Should().Be("Test Message");
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._))
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
             .MustNotHaveHappened();
     }
 
@@ -522,8 +522,8 @@ public class ApplicationChecklistProcessTypeExecutorTests
 
         ApplicationChecklistEntry? checklistEntry = null;
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._))
-            .ReturnsLazily((Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, Action<ApplicationChecklistEntry> setFields) =>
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
+            .ReturnsLazily((Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, Action<ApplicationChecklistEntry> initial, Action<ApplicationChecklistEntry> setFields) =>
             {
                 checklistEntry = new ApplicationChecklistEntry(applicationId, entryTypeId, default, default);
                 setFields(checklistEntry);
@@ -546,7 +546,7 @@ public class ApplicationChecklistProcessTypeExecutorTests
         executionResult.ScheduleStepTypeIds.Should().BeNull();
         executionResult.SkipStepTypeIds.Should().BeNull();
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(applicationId, ApplicationChecklistEntryTypeId.APPLICATION_ACTIVATION, A<Action<ApplicationChecklistEntry>>._))
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(applicationId, ApplicationChecklistEntryTypeId.APPLICATION_ACTIVATION, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
             .MustHaveHappenedOnceExactly();
 
         checklistEntry.Should().NotBeNull();
@@ -588,8 +588,8 @@ public class ApplicationChecklistProcessTypeExecutorTests
 
         ApplicationChecklistEntry? checklistEntry = null;
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._))
-            .ReturnsLazily((Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, Action<ApplicationChecklistEntry> setFields) =>
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
+            .ReturnsLazily((Guid applicationId, ApplicationChecklistEntryTypeId entryTypeId, Action<ApplicationChecklistEntry> initial, Action<ApplicationChecklistEntry> setFields) =>
             {
                 checklistEntry = new ApplicationChecklistEntry(applicationId, entryTypeId, default, default);
                 setFields(checklistEntry);
@@ -612,7 +612,7 @@ public class ApplicationChecklistProcessTypeExecutorTests
         executionResult.ScheduleStepTypeIds.Should().BeNull();
         executionResult.SkipStepTypeIds.Should().BeNull();
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(applicationId, ApplicationChecklistEntryTypeId.APPLICATION_ACTIVATION, A<Action<ApplicationChecklistEntry>>._))
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(applicationId, ApplicationChecklistEntryTypeId.APPLICATION_ACTIVATION, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
             .MustHaveHappenedOnceExactly();
 
         checklistEntry.Should().NotBeNull();
@@ -664,7 +664,7 @@ public class ApplicationChecklistProcessTypeExecutorTests
         A.CallTo(() => _secondProcessFunc(A<IApplicationChecklistService.WorkerChecklistProcessStepData>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
 
-        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._))
+        A.CallTo(() => _checklistRepository.AttachAndModifyApplicationChecklist(A<Guid>._, A<ApplicationChecklistEntryTypeId>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._))
             .MustNotHaveHappened();
 
         executionResult.Message.Should().Be(error.Message);

--- a/tests/processes/ApplicationChecklist.Library.Tests/ApplicationChecklistServiceTests.cs
+++ b/tests/processes/ApplicationChecklist.Library.Tests/ApplicationChecklistServiceTests.cs
@@ -354,9 +354,8 @@ public class ChecklistServiceTests
             process,
             Guid.NewGuid(),
             _fixture.Create<ApplicationChecklistEntryTypeId>(),
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>>().ToImmutableDictionary(),
-            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) },
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, string?>>().ToImmutableDictionary()
+            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>>().ToImmutableDictionary(),
+            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) }
         );
         var lockExpiryDate = _fixture.Create<DateTimeOffset>();
 
@@ -380,9 +379,8 @@ public class ChecklistServiceTests
             process,
             Guid.NewGuid(),
             _fixture.Create<ApplicationChecklistEntryTypeId>(),
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>>().ToImmutableDictionary(),
-            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) },
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, string?>>().ToImmutableDictionary()
+            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>>().ToImmutableDictionary(),
+            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) }
         );
 
         // Act
@@ -408,9 +406,8 @@ public class ChecklistServiceTests
             process,
             Guid.NewGuid(),
             _fixture.Create<ApplicationChecklistEntryTypeId>(),
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>>().ToImmutableDictionary(),
-            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) },
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, string?>>().ToImmutableDictionary()
+            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>>().ToImmutableDictionary(),
+            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) }
         );
 
         ApplicationChecklistEntry? modifiedChecklistEntry = null;
@@ -487,9 +484,8 @@ public class ChecklistServiceTests
             process,
             Guid.NewGuid(),
             _fixture.Create<ApplicationChecklistEntryTypeId>(),
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>>().ToImmutableDictionary(),
-            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) },
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, string?>>().ToImmutableDictionary()
+            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>>().ToImmutableDictionary(),
+            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) }
         );
 
         ProcessStep? modifiedProcessStep = null;
@@ -553,9 +549,8 @@ public class ChecklistServiceTests
             process,
             Guid.NewGuid(),
             _fixture.Create<ApplicationChecklistEntryTypeId>(),
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>>().ToImmutableDictionary(),
-            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) },
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, string?>>().ToImmutableDictionary()
+            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>>().ToImmutableDictionary(),
+            new ProcessStep[] { new(Guid.NewGuid(), _fixture.Create<ProcessStepTypeId>(), ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow) }
         );
 
         ApplicationChecklistEntry? modifiedChecklistEntry = null;
@@ -618,9 +613,8 @@ public class ChecklistServiceTests
             process,
             Guid.NewGuid(),
             _fixture.Create<ApplicationChecklistEntryTypeId>(),
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>>().ToImmutableDictionary(),
-            processSteps,
-            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, string?>>().ToImmutableDictionary()
+            _fixture.Create<Dictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>>().ToImmutableDictionary(),
+            processSteps
         );
 
         var modifiedProcessSteps = new List<ProcessStep>();


### PR DESCRIPTION
## Description

Update comment ,when retrigger the application Checklist type

## Why

when ever the process step failed for the particular application checklist type and the failed message is updated in comment field.
So, when we manually retrigger the failed application checklist type. comment need to set to null 

## Issue

[CPLP-2823](https://jira.catena-x.net/browse/CPLP-2823)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
