### PR TITLE
feat(apps & services): put and post enpoints

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppChangeBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppChangeBusinessLogic.cs
@@ -97,6 +97,9 @@ public class AppChangeBusinessLogic : IAppChangeBusinessLogic
             await _provisioningManager.AddRolesToClientAsync(clientId, userRoles.Select(x => x.Role)).ConfigureAwait(false);
         }
 
+        _portalRepositories.GetInstance<IOfferRepository>().AttachAndModifyOffer(appId, offer =>
+            offer.DateLastChanged = DateTimeOffset.UtcNow);
+
         var notificationContent = new
         {
             AppName = result.AppName,
@@ -125,6 +128,8 @@ public class AppChangeBusinessLogic : IAppChangeBusinessLogic
             await ValidateAndGetAppDescription(appId, companyId, offerRepository),
             offerDescriptionDatas.Select(od => new ValueTuple<string, string, string>(od.LanguageCode, od.LongDescription, od.ShortDescription)));
 
+        offerRepository.AttachAndModifyOffer(appId, offer =>
+            offer.DateLastChanged = DateTimeOffset.UtcNow);
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
 
@@ -189,6 +194,8 @@ public class AppChangeBusinessLogic : IAppChangeBusinessLogic
         offerRepository.RemoveOfferAssignedDocuments(result.documentStatusDatas.Select(data => (appId, data.DocumentId)));
         documentRepository.RemoveDocuments(result.documentStatusDatas.Select(data => data.DocumentId));
 
+        offerRepository.AttachAndModifyOffer(appId, offer =>
+            offer.DateLastChanged = DateTimeOffset.UtcNow);
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
 
@@ -245,6 +252,9 @@ public class AppChangeBusinessLogic : IAppChangeBusinessLogic
             {
                 os.AppSubscriptionUrl = url;
             });
+
+        _portalRepositories.GetInstance<IOfferRepository>().AttachAndModifyOffer(offerId, offer =>
+            offer.DateLastChanged = DateTimeOffset.UtcNow);
 
         if (!string.IsNullOrEmpty(detailData.ClientClientId))
         {

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -140,6 +140,9 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
             throw new ForbiddenException($"Company {companyId} is not the provider company of app {appId}");
         }
         var roleData = AppExtensions.CreateUserRolesWithDescriptions(_portalRepositories.GetInstance<IUserRolesRepository>(), appId, userRoles);
+
+        _portalRepositories.GetInstance<IOfferRepository>().AttachAndModifyOffer(appId, offer =>
+            offer.DateLastChanged = DateTimeOffset.UtcNow);
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
         return roleData;
     }

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -342,6 +342,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
             app.ContactEmail = appData.ContactEmail;
             app.ContactNumber = appData.ContactNumber;
             app.MarketingUrl = appData.MarketingUrl;
+            app.DateLastChanged = DateTimeOffset.UtcNow;
         });
 
         _offerService.UpsertRemoveOfferDescription(appId, appRequestModel.Descriptions, appData.OfferDescriptions);

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -147,6 +147,8 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     public async Task AddFavouriteAppForUserAsync(Guid appId, Guid userId)
     {
         _portalRepositories.GetInstance<IOfferRepository>().CreateAppFavourite(appId, userId);
+        _portalRepositories.GetInstance<IOfferRepository>().AttachAndModifyOffer(appId, offer =>
+            offer.DateLastChanged = DateTimeOffset.UtcNow);
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
 

--- a/src/marketplace/Offers.Library.Web/OfferDocumentService.cs
+++ b/src/marketplace/Offers.Library.Web/OfferDocumentService.cs
@@ -97,6 +97,10 @@ public class OfferDocumentService : IOfferDocumentService
             x.CompanyUserId = identity.UserId;
         });
         _portalRepositories.GetInstance<IOfferRepository>().CreateOfferAssignedDocument(id, doc.Id);
+
+        _portalRepositories.GetInstance<IOfferRepository>().AttachAndModifyOffer(id, offer =>
+            offer.DateLastChanged = DateTimeOffset.UtcNow);
+
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
 }

--- a/src/marketplace/Offers.Library.Web/OfferDocumentService.cs
+++ b/src/marketplace/Offers.Library.Web/OfferDocumentService.cs
@@ -98,7 +98,7 @@ public class OfferDocumentService : IOfferDocumentService
         });
         _portalRepositories.GetInstance<IOfferRepository>().CreateOfferAssignedDocument(id, doc.Id);
 
-        _portalRepositories.GetInstance<IOfferRepository>().AttachAndModifyOffer(id, offer =>
+        offerRepository.AttachAndModifyOffer(id, offer =>
             offer.DateLastChanged = DateTimeOffset.UtcNow);
 
         await _portalRepositories.SaveAsync().ConfigureAwait(false);

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -237,6 +237,7 @@ public class OfferService : IOfferService
             service.ProviderCompanyId = identity.CompanyId;
             service.MarketingUrl = data.ProviderUri;
             service.LicenseTypeId = LicenseTypeId.COTS;
+            service.DateLastChanged = DateTimeOffset.UtcNow;
         });
         var licenseId = offerRepository.CreateOfferLicenses(data.Price).Id;
         offerRepository.CreateOfferAssignedLicense(service.Id, licenseId);
@@ -633,7 +634,10 @@ public class OfferService : IOfferService
             throw new ConflictException($"offerStatus is in Incorrect State");
         }
         offerRepository.AttachAndModifyOffer(offerId, offer =>
-            offer.OfferStatusId = OfferStatusId.INACTIVE);
+        {
+            offer.OfferStatusId = OfferStatusId.INACTIVE;
+            offer.DateReleased = DateTime.UtcNow;
+        });
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
 
@@ -787,6 +791,9 @@ public class OfferService : IOfferService
                         .Select(x => x.TechnicalUserProfileId!.Value),
                     x => x.TechnicalUserProfileId)
                 .Select(x => x.TechnicalUserProfileId));
+
+        _portalRepositories.GetInstance<IOfferRepository>().AttachAndModifyOffer(offerId, offer =>
+            offer.DateLastChanged = DateTimeOffset.UtcNow);
 
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -181,6 +181,10 @@ public class OfferService : IOfferService
                 companyUserId,
                 DateTimeOffset.UtcNow)
             .Select(consent => new ConsentStatusData(consent.AgreementId, consent.ConsentStatusId));
+
+        _portalRepositories.GetInstance<IOfferRepository>().AttachAndModifyOffer(offerId, offer =>
+            offer.DateLastChanged = DateTimeOffset.UtcNow);
+
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
         return ConsentStatusdata;
     }

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
@@ -198,10 +198,12 @@ public class ServiceReleaseBusinessLogic : IServiceReleaseBusinessLogic
                 offer.SalesManagerId = data.SalesManager;
                 offer.ContactEmail = data.ContactEmail;
                 offer.MarketingUrl = data.ProviderUri;
+                offer.DateLastChanged = DateTimeOffset.UtcNow;
             },
             offer =>
             {
                 offer.SalesManagerId = serviceData.SalesManagerId;
+                offer.DateLastChanged = DateTimeOffset.UtcNow;
             });
 
         _offerService.UpsertRemoveOfferDescription(serviceId, data.Descriptions, serviceData.Descriptions);

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
@@ -76,7 +76,14 @@ public class AppBusinessLogicTests
     {
         // Arrange
         var appId = _fixture.Create<Guid>();
-
+        var existingOffer = _fixture.Create<Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         var sut = new AppsBusinessLogic(_portalRepositories, null!, null!, null!, Options.Create(new AppsSettings()), null!);
 
         // Act
@@ -85,6 +92,7 @@ public class AppBusinessLogicTests
         // Assert
         A.CallTo(() => _offerRepository.CreateAppFavourite(A<Guid>.That.Matches(x => x == appId), A<Guid>.That.Matches(x => x == _identity.UserId))).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppChangeBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppChangeBusinessLogicTest.cs
@@ -142,7 +142,7 @@ public class AppChangeBusinessLogicTest
             });
         A.CallTo(() => _notificationService.CreateNotifications(A<IEnumerable<UserRoleConfig>>._, A<Guid>._, A<IEnumerable<(string? content, NotificationTypeId notificationTypeId)>>._, A<Guid>._, A<bool?>._))
             .Returns(_fixture.CreateMany<Guid>(4).AsFakeIAsyncEnumerable(out var createNotificationsResultAsyncEnumerator));
-        
+
         //Act
         var result = await _sut.AddActiveAppUserRoleAsync(appId, appAssignedRoleDesc, (_identity.UserId, _identity.CompanyId)).ConfigureAwait(false);
 

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppChangeBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppChangeBusinessLogicTest.cs
@@ -132,10 +132,17 @@ public class AppChangeBusinessLogicTest
                 userRoleDescriptions.Add(createdUserRoleDescriptions);
                 return createdUserRoleDescriptions;
             });
-
+        var existingOffer = _fixture.Create<Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         A.CallTo(() => _notificationService.CreateNotifications(A<IEnumerable<UserRoleConfig>>._, A<Guid>._, A<IEnumerable<(string? content, NotificationTypeId notificationTypeId)>>._, A<Guid>._, A<bool?>._))
             .Returns(_fixture.CreateMany<Guid>(4).AsFakeIAsyncEnumerable(out var createNotificationsResultAsyncEnumerator));
-
+        
         //Act
         var result = await _sut.AddActiveAppUserRoleAsync(appId, appAssignedRoleDesc, (_identity.UserId, _identity.CompanyId)).ConfigureAwait(false);
 
@@ -169,7 +176,7 @@ public class AppChangeBusinessLogicTest
                 x => x.Should().HaveCount(2).And.Satisfy(
                     x => x.UserRoleId == userRoles!.ElementAt(2).Id && x.LanguageShortName == appAssignedRoleDesc[2].Descriptions.ElementAt(0).LanguageCode && x.Description == appAssignedRoleDesc[2].Descriptions.ElementAt(0).Description,
                     x => x.UserRoleId == userRoles!.ElementAt(2).Id && x.LanguageShortName == appAssignedRoleDesc[2].Descriptions.ElementAt(1).LanguageCode && x.Description == appAssignedRoleDesc[2].Descriptions.ElementAt(1).Description));
-
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _notificationService.CreateNotifications(A<IEnumerable<UserRoleConfig>>._, A<Guid>._, A<IEnumerable<(string? content, NotificationTypeId notificationTypeId)>>._, A<Guid>._, A<bool?>._))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => createNotificationsResultAsyncEnumerator.MoveNextAsync())
@@ -201,7 +208,7 @@ public class AppChangeBusinessLogicTest
         var clientIds = new[] { "client" };
         A.CallTo(() => _offerRepository.GetInsertActiveAppUserRoleDataAsync(appId, OfferTypeId.APP))
             .Returns((true, appName, Guid.NewGuid(), clientIds));
-
+        var existingOffer = _fixture.Create<Offer>();
         //Act
         async Task Act() => await _sut.AddActiveAppUserRoleAsync(appId, appAssignedRoleDesc, (_identity.UserId, _identity.CompanyId)).ConfigureAwait(false);
 
@@ -347,13 +354,21 @@ public class AppChangeBusinessLogicTest
 
         A.CallTo(() => _offerRepository.GetActiveOfferDescriptionDataByIdAsync(appId, OfferTypeId.APP, _identity.CompanyId))
             .Returns(appDescriptionData);
-
+        var existingOffer = _fixture.Create<Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         // Act
         await _sut.CreateOrUpdateAppDescriptionByIdAsync(appId, _identity.CompanyId, updateDescriptionData).ConfigureAwait(false);
 
         // Assert
         A.CallTo(() => _offerRepository.CreateUpdateDeleteOfferDescriptions(appId, A<IEnumerable<LocalizedDescription>>._, A<IEnumerable<(string, string, string)>>.That.IsSameSequenceAs(updateDescriptionData.Select(x => new ValueTuple<string, string, string>(x.LanguageCode, x.LongDescription, x.ShortDescription)))))
             .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -480,7 +495,14 @@ public class AppChangeBusinessLogicTest
                 var offerAssignedDocument = new OfferAssignedDocument(offerId, docId);
                 offerAssignedDocuments.Add(offerAssignedDocument);
             });
-
+        var existingOffer = _fixture.Create<Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         // Act
         await _sut.UploadOfferAssignedAppLeadImageDocumentByIdAsync(appId, (_identity.UserId, _identity.CompanyId), file, CancellationToken.None);
 
@@ -490,6 +512,7 @@ public class AppChangeBusinessLogicTest
         A.CallTo(() => _offerRepository.CreateOfferAssignedDocument(A<Guid>._, A<Guid>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _offerRepository.RemoveOfferAssignedDocuments(A<IEnumerable<(Guid OfferId, Guid DocumentId)>>.That.IsSameSequenceAs(documentStatusData.Select(data => new ValueTuple<Guid, Guid>(appId, data.DocumentId))))).MustHaveHappenedOnceExactly();
         A.CallTo(() => _documentRepository.RemoveDocuments(A<IEnumerable<Guid>>.That.IsSameSequenceAs(documentStatusData.Select(data => data.DocumentId)))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         documents.Should().ContainSingle().Which.Should().Match<Document>(x => x.Id == documentId && x.MediaTypeId == MediaTypeId.JPEG && x.DocumentTypeId == DocumentTypeId.APP_LEADIMAGE && x.DocumentStatusId == DocumentStatusId.LOCKED);
         offerAssignedDocuments.Should().ContainSingle().Which.Should().Match<OfferAssignedDocument>(x => x.DocumentId == documentId && x.OfferId == appId);
@@ -622,13 +645,21 @@ public class AppChangeBusinessLogicTest
                 initialize?.Invoke(details);
                 setParameters.Invoke(details);
             });
-
+        var existingOffer = _fixture.Create<Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         // Act
         await _sut.UpdateTenantUrlAsync(appId, subscriptionId, data, _identity.CompanyId).ConfigureAwait(false);
 
         // Assert
         A.CallTo(() => _provisioningManager.UpdateClient(clientClientId, data.Url, A<string>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _notificationService.CreateNotifications(A<IEnumerable<UserRoleConfig>>._, A<Guid?>._, A<IEnumerable<(string? content, NotificationTypeId notificationTypeId)>>._, A<Guid>._, A<bool?>._)).MustNotHaveHappened();
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._)).MustHaveHappenedOnceExactly();
         notifications.Should().ContainSingle().Which
             .NotificationTypeId.Should().Be(NotificationTypeId.SUBSCRIPTION_URL_UPDATE);
         details.AppSubscriptionUrl.Should().Be(data.Url);
@@ -668,7 +699,14 @@ public class AppChangeBusinessLogicTest
                 initialize?.Invoke(details);
                 setParameters.Invoke(details);
             });
-
+        var existingOffer = _fixture.Create<Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         // Act
         await _sut.UpdateTenantUrlAsync(appId, subscriptionId, data, _identity.CompanyId).ConfigureAwait(false);
 
@@ -676,6 +714,7 @@ public class AppChangeBusinessLogicTest
         A.CallTo(() => _provisioningManager.UpdateClient(clientClientId, data.Url, A<string>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => createNotificationsResultAsyncEnumerator.MoveNextAsync())
             .MustHaveHappened(5, Times.Exactly);
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._)).MustHaveHappenedOnceExactly();
         notifications.Should().BeEmpty();
         details.AppSubscriptionUrl.Should().Be(data.Url);
     }
@@ -711,13 +750,21 @@ public class AppChangeBusinessLogicTest
                 initialize?.Invoke(details);
                 setParameters.Invoke(details);
             });
-
+        var existingOffer = _fixture.Create<Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         // Act
         await _sut.UpdateTenantUrlAsync(appId, subscriptionId, data, _identity.CompanyId).ConfigureAwait(false);
 
         // Assert
         A.CallTo(() => _provisioningManager.UpdateClient(clientClientId, data.Url, A<string>._)).MustNotHaveHappened();
         A.CallTo(() => _notificationService.CreateNotifications(A<IEnumerable<UserRoleConfig>>._, A<Guid?>._, A<IEnumerable<(string? content, NotificationTypeId notificationTypeId)>>._, A<Guid>._, A<bool?>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(appId, A<Action<Offer>>._, A<Action<Offer>?>._)).MustHaveHappenedOnceExactly();
         notifications.Should().BeEmpty();
         details.AppSubscriptionUrl.Should().Be(data.Url);
     }
@@ -735,7 +782,6 @@ public class AppChangeBusinessLogicTest
         var detailId = _fixture.Create<Guid>();
         A.CallTo(() => _offerSubscriptionsRepository.GetUpdateUrlDataAsync(appId, subscriptionId, _identity.CompanyId))
             .Returns(new OfferUpdateUrlData("testApp", false, true, Guid.Empty, subscribingCompany, OfferSubscriptionStatusId.ACTIVE, new OfferUpdateUrlSubscriptionDetailData(detailId, clientClientId, oldUrl)));
-
         // Act
         await _sut.UpdateTenantUrlAsync(appId, subscriptionId, data, _identity.CompanyId).ConfigureAwait(false);
 

--- a/tests/marketplace/Offer.Library.Web.Tests/OfferDocumentServiceTests.cs
+++ b/tests/marketplace/Offer.Library.Web.Tests/OfferDocumentServiceTests.cs
@@ -85,11 +85,19 @@ public class OfferDocumentServiceTests
                 var offerAssignedDocument = new OfferAssignedDocument(offerId, docId);
                 offerAssignedDocuments.Add(offerAssignedDocument);
             });
-
+        var existingOffer = _fixture.Create<Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities.Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(_validAppId, A<Action<Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities.Offer>>._, A<Action<Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities.Offer>?>._))
+            .Invokes((Guid _, Action<Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities.Offer> setOptionalParameters, Action<Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities.Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         // Act
         await _sut.UploadDocumentAsync(_validAppId, documentTypeId, file, (_identity.UserId, _identity.CompanyId), offerTypeId, uploadDocumentTypeIdSettings, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(_validAppId, A<Action<Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities.Offer>>._, A<Action<Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities.Offer>?>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         documents.Should().HaveCount(1);
         offerAssignedDocuments.Should().HaveCount(1);

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -1419,7 +1419,14 @@ public class OfferServiceTests
                 new(consentId, agreementId, CompanyUserCompanyId, _companyUser.Id, ConsentStatusId.ACTIVE, utcNow),
                 new(newCreatedConsentId, additionalAgreementId, CompanyUserCompanyId, _companyUser.Id, ConsentStatusId.ACTIVE, utcNow)
             });
-
+        var existingOffer = _fixture.Create<Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(offerId, A<Action<Offer>>._, A<Action<Offer>?>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         // Act
         var result = await _sut.CreateOrUpdateProviderOfferAgreementConsent(offerId, consentData, _identity.CompanyId, offerTypeId).ConfigureAwait(false);
 
@@ -1432,6 +1439,7 @@ public class OfferServiceTests
                 x => x.AgreementId == agreementId && x.ConsentStatus == ConsentStatusId.ACTIVE,
                 x => x.AgreementId == additionalAgreementId && x.ConsentStatus == ConsentStatusId.ACTIVE
             );
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(offerId, A<Action<Offer>>._, A<Action<Offer>?>._)).MustHaveHappenedOnceExactly();
     }
 
     #endregion
@@ -1875,7 +1883,14 @@ public class OfferServiceTests
             .Returns(new Guid[] { userRole1Id, userRole2Id }.ToAsyncEnumerable());
         A.CallTo(() => _technicalUserProfileRepository.CreateTechnicalUserProfile(A<Guid>._, offerId))
             .Returns(new TechnicalUserProfile(newProfileId, offerId));
-
+        var existingOffer = _fixture.Create<Offer>();
+        existingOffer.DateLastChanged = DateTimeOffset.UtcNow;
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(offerId, A<Action<Offer>>._, A<Action<Offer>?>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParemeters) =>
+            {
+                initializeParemeters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
         // Act
         await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, _identity.CompanyId, "cl1").ConfigureAwait(false);
 
@@ -1896,6 +1911,7 @@ public class OfferServiceTests
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => _technicalUserProfileRepository.RemoveTechnicalUserProfiles(A<IEnumerable<Guid>>.That.Matches(x => x.Count() == 2 && x.Contains(technicalUserProfile2) && x.Contains(technicalUserProfile3))))
             .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(offerId, A<Action<Offer>>._, A<Action<Offer>?>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
     }
 


### PR DESCRIPTION
## Description

Added DateLastChanged for most of endpoints of apps and services for put and post
## Why

Added DateLastChanged so that whenever we are updating or creating a record for offer related table there should be update for last date 
## Issue

CPLP-2886

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
