### PR TITLE
feat(applicationChecklist)! : updated the createWallet responce message

### DIFF
--- a/src/externalsystems/Custodian.Library/Models/WalletErrorResponse.cs
+++ b/src/externalsystems/Custodian.Library/Models/WalletErrorResponse.cs
@@ -25,3 +25,5 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Custodian.Library.Models;
 public record WalletErrorResponse([property: JsonPropertyName("message")] string Message);
 
 public record MembershipErrorResponse([property: JsonPropertyName("title")] string Title);
+
+public record WalletCreationResponse([property: JsonPropertyName("DID")] string did, [property: JsonPropertyName("CreatedAt")] DateTimeOffset createdAt);

--- a/src/externalsystems/Custodian.Library/Models/WalletErrorResponse.cs
+++ b/src/externalsystems/Custodian.Library/Models/WalletErrorResponse.cs
@@ -26,4 +26,4 @@ public record WalletErrorResponse([property: JsonPropertyName("message")] string
 
 public record MembershipErrorResponse([property: JsonPropertyName("title")] string Title);
 
-public record WalletCreationResponse([property: JsonPropertyName("DID")] string did, [property: JsonPropertyName("CreatedAt")] DateTimeOffset createdAt);
+public record WalletCreationResponse([property: JsonPropertyName("DID")] string Did, [property: JsonPropertyName("CreatedAt")] DateTimeOffset CreatedAt);

--- a/tests/externalsystems/Custodian.Library.Tests/CustodianServiceTests.cs
+++ b/tests/externalsystems/Custodian.Library.Tests/CustodianServiceTests.cs
@@ -70,14 +70,14 @@ public class CustodianServiceTests
 
     [Theory]
     [InlineData("did:sov:GamAMqXnXr1chS4viYXoxB", true)]
-     [InlineData(null, false)]
+    [InlineData(null, false)]
     public async Task CreateWallet_WithValidData_DoesNotThrowException(string DID, bool IsCreatedAt)
     {
         // Arrange
         const string bpn = "123";
         const string name = "test";
         var data = JsonSerializer.Serialize(
-            new WalletCreationResponse("did:sov:GamAMqXnXr1chS4viYXoxB", IsCreatedAt ? DateTimeOffset.UtcNow : default), JsonOptions);
+            new WalletCreationResponse(DID, IsCreatedAt ? DateTimeOffset.UtcNow : default), JsonOptions);
         var httpMessageHandlerMock =
             new HttpMessageHandlerMock(HttpStatusCode.OK, data.ToFormContent("application/json"));
         var httpClient = new HttpClient(httpMessageHandlerMock)
@@ -133,7 +133,7 @@ public class CustodianServiceTests
         // Arrange
         const string bpn = "123";
         const string name = "test";
-        string content = "this is no json data";
+        var content = "this is no json data";
         var httpMessageHandlerMock =
             new HttpMessageHandlerMock(HttpStatusCode.OK, new StringContent(content));
         var httpClient = new HttpClient(httpMessageHandlerMock)


### PR DESCRIPTION

## Description

updated the createWallet responce message

## Why

Store only DID id and CreatedAt fields when CreateWallet responce message is success

## Issue

[CPLP-2840](https://jira.catena-x.net/browse/CPLP-2840)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
