### PR TITLE
fix(ssi): ignore existing inactive ssi entries

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanySsiDetailsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanySsiDetailsRepository.cs
@@ -130,6 +130,7 @@ public class CompanySsiDetailsRepository : ICompanySsiDetailsRepository
                 x.CompanyId == companyId &&
                 x.VerifiedCredentialTypeId == verifiedCredentialTypeId &&
                 x.VerifiedCredentialType!.VerifiedCredentialTypeAssignedKind!.VerifiedCredentialTypeKindId == kindId &&
+                x.CompanySsiDetailStatusId != CompanySsiDetailStatusId.INACTIVE &&
                 (verifiedCredentialExternalTypeUseCaseDetailId == null || x.VerifiedCredentialExternalTypeUseCaseDetailId == verifiedCredentialExternalTypeUseCaseDetailId));
 
     /// <inheritdoc />

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanySsiDetailsRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanySsiDetailsRepositoryTests.cs
@@ -82,13 +82,14 @@ public class CompanySsiDetailsRepositoryTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Count.Should().Be(4);
-        result.Should().HaveCount(4);
-        result.Where(x => x.CompanyId == _validCompanyId).Should().HaveCount(3)
+        result.Count.Should().Be(5);
+        result.Should().HaveCount(5);
+        result.Where(x => x.CompanyId == _validCompanyId).Should().HaveCount(4)
             .And.Satisfy(
-                x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK,
-                x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.PCF_FRAMEWORK,
-                x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE);
+                x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.PENDING,
+                x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.PCF_FRAMEWORK && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.PENDING,
+                x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.PENDING,
+                x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.BEHAVIOR_TWIN_FRAMEWORK && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.INACTIVE);
         result.Where(x => x.CompanyId == new Guid("3390c2d7-75c1-4169-aa27-6ce00e1f3cdd")).Should().ContainSingle()
             .And.Satisfy(x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK);
     }
@@ -222,6 +223,19 @@ public class CompanySsiDetailsRepositoryTests
 
         // Act
         var result = await sut.CheckSsiDetailsExistsForCompany(Guid.NewGuid(), VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, VerifiedCredentialTypeKindId.CERTIFICATE, new Guid("1268a76a-ca19-4dd8-b932-01f24071d560")).ConfigureAwait(false);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CheckCredentialDetailsExistsForCompany_WithInactive_ReturnsFalse()
+    {
+        // Arrange
+        var sut = await CreateSut();
+
+        // Act
+        var result = await sut.CheckSsiDetailsExistsForCompany(_validCompanyId, VerifiedCredentialTypeId.BEHAVIOR_TWIN_FRAMEWORK, VerifiedCredentialTypeKindId.USE_CASE, new Guid("1268a76a-ca19-4dd8-b932-01f24071d562")).ConfigureAwait(false);
 
         // Assert
         result.Should().BeFalse();

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_ssi_details.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_ssi_details.test.json
@@ -41,5 +41,16 @@
     "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020006",
     "date_created": "2023-06-01 00:00:00.000000 +00:00",
     "verified_credential_external_type_use_case_detail_id": "1268a76a-ca19-4dd8-b932-01f24071d560"
+  },
+  {
+    "id": "9f5b9934-4014-4099-91e9-7b1aee696b07",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "verified_credential_type_id": 3,
+    "company_ssi_detail_status_id": 3,
+    "document_id": "e020787d-1e04-4c0b-9c06-bd1cd44724b2",
+    "expiry_date": null,
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020006",
+    "date_created": "2023-06-01 00:00:00.000000 +00:00",
+    "verified_credential_external_type_use_case_detail_id": "1268a76a-ca19-4dd8-b932-01f24071d562"
   }
 ]


### PR DESCRIPTION
## Description

ignore inactive ssi entries when creating a new entry

## Why

Currently it is not possible to create a second ssi certificate even if the first one is inactive

## Issue

N/A - Jira Issue: CPLP-3022

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
