### PR TITLE
feat(ssi): adjust certificateTypes endpoint

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -492,6 +492,6 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     /// <inheritdoc />
-    public IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes() =>
-        _portalRepositories.GetInstance<ICompanySsiDetailsRepository>().GetCertificateTypes();
+    public IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes(Guid companyId) =>
+        _portalRepositories.GetInstance<ICompanySsiDetailsRepository>().GetCertificateTypes(companyId);
 }

--- a/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
@@ -51,5 +51,5 @@ public interface ICompanyDataBusinessLogic
     Task ApproveCredential(Guid userId, Guid credentialId, CancellationToken cancellationToken);
 
     Task RejectCredential(Guid userId, Guid credentialId);
-    IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes();
+    IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes(Guid companyId);
 }

--- a/src/administration/Administration.Service/Controllers/CompanyDataController.cs
+++ b/src/administration/Administration.Service/Controllers/CompanyDataController.cs
@@ -213,7 +213,7 @@ public class CompanyDataController : ControllerBase
     [Route("certificateTypes")]
     [ProducesResponseType(typeof(IEnumerable<SsiCertificateTransferData>), StatusCodes.Status200OK)]
     public IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes() =>
-        _logic.GetCertificateTypes();
+        this.WithCompanyId(companyId => _logic.GetCertificateTypes(companyId));
 
     /// <summary>
     /// Creates the useCaseParticipation

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanySsiDetailsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanySsiDetailsRepository.cs
@@ -209,9 +209,13 @@ public class CompanySsiDetailsRepository : ICompanySsiDetailsRepository
     }
 
     /// <inheritdoc />
-    public IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes() =>
+    public IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes(Guid companyId) =>
         _context.VerifiedCredentialTypes
-            .Where(x => x.VerifiedCredentialTypeAssignedKind!.VerifiedCredentialTypeKindId == VerifiedCredentialTypeKindId.CERTIFICATE)
+            .Where(x =>
+                x.VerifiedCredentialTypeAssignedKind!.VerifiedCredentialTypeKindId == VerifiedCredentialTypeKindId.CERTIFICATE &&
+                !x.CompanySsiDetails.Any(ssi =>
+                    ssi.CompanyId == companyId &&
+                    (ssi.CompanySsiDetailStatusId == CompanySsiDetailStatusId.PENDING || ssi.CompanySsiDetailStatusId == CompanySsiDetailStatusId.ACTIVE)))
             .Select(x => x.Id)
             .ToAsyncEnumerable();
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanySsiDetailsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanySsiDetailsRepository.cs
@@ -90,5 +90,5 @@ public interface ICompanySsiDetailsRepository
     Task<(bool exists, SsiApprovalData data)> GetSsiApprovalData(Guid credentialId);
     Task<(bool Exists, CompanySsiDetailStatusId Status, VerifiedCredentialTypeId Type, Guid RequesterId, string? RequesterEmail, string? Firstname, string? Lastname)> GetSsiRejectionData(Guid credentialId);
     void AttachAndModifyCompanySsiDetails(Guid id, Action<CompanySsiDetail>? initialize, Action<CompanySsiDetail> updateFields);
-    IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes();
+    IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes(Guid companyId);
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -1461,11 +1461,11 @@ public class CompanyDataBusinessLogicTests
     public async Task GetCertificateTypes_WithFilter_ReturnsList()
     {
         // Arrange
-        A.CallTo(() => _companySsiDetailsRepository.GetCertificateTypes())
+        A.CallTo(() => _companySsiDetailsRepository.GetCertificateTypes(_identity.CompanyId))
             .Returns(new[] { VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE }.ToAsyncEnumerable());
 
         // Act
-        var result = await _sut.GetCertificateTypes().ToListAsync().ConfigureAwait(false);
+        var result = await _sut.GetCertificateTypes(_identity.CompanyId).ToListAsync().ConfigureAwait(false);
 
         // Assert
         result.Should().HaveCount(1);

--- a/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
@@ -283,7 +283,7 @@ public class CompanyDataControllerTests
     public async Task GetCredentialTypes()
     {
         // Arrange
-        A.CallTo(() => _logic.GetCertificateTypes())
+        A.CallTo(() => _logic.GetCertificateTypes(_identity.CompanyId))
             .Returns(new[] { VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE }.ToAsyncEnumerable());
 
         //Act

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanySsiDetailsRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanySsiDetailsRepositoryTests.cs
@@ -411,7 +411,20 @@ public class CompanySsiDetailsRepositoryTests
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetCertificateTypes().ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetCertificateTypes(_validCompanyId).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCertificateTypes_WithoutCertificate_ReturnsExpected()
+    {
+        // Arrange
+        var sut = await CreateSut();
+
+        // Act
+        var result = await sut.GetCertificateTypes(Guid.NewGuid()).ToListAsync().ConfigureAwait(false);
 
         // Assert
         result.Should().ContainSingle().Which.Should().Be(VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE);


### PR DESCRIPTION
## Description

enhance businessLogic of the GET /administration/companydata/certificateTypes to return only the possible certificateTypes

## Why

To show the user only the possible certificates he can request

## Issue

N/A - Jira Issue: CPLP-3002

## Checklist


- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
