### PR TITLE
fix: resolved apps-business endpoint empty results

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -85,9 +85,9 @@ public class AppsBusinessLogic : IAppsBusinessLogic
                     app.UseCaseNames));
 
     /// <inheritdoc/>
-    public IAsyncEnumerable<BusinessAppData> GetAllUserUserBusinessAppsAsync(Guid companyId) =>
+    public IAsyncEnumerable<BusinessAppData> GetAllUserUserBusinessAppsAsync(Guid userId) =>
         _portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
-            .GetAllBusinessAppDataForUserIdAsync(companyId)
+            .GetAllBusinessAppDataForUserIdAsync(userId)
             .Select(x =>
                 new BusinessAppData(
                     x.OfferId,

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -41,9 +41,9 @@ public interface IAppsBusinessLogic
     /// <summary>
     /// Get all apps that a user has been assigned roles in.
     /// </summary>
-    /// <param name="companyId">Id of the user to get available apps for.</param>
+    /// <param name="userId">Id of the user to get available apps for.</param>
     /// <returns>List of available apps for user.</returns>
-    public IAsyncEnumerable<BusinessAppData> GetAllUserUserBusinessAppsAsync(Guid companyId);
+    public IAsyncEnumerable<BusinessAppData> GetAllUserUserBusinessAppsAsync(Guid userId);
 
     /// <summary>
     /// Get detailed application data for a single app by id.

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -78,7 +78,7 @@ public class AppsController : ControllerBase
     [ProducesResponseType(typeof(IAsyncEnumerable<BusinessAppData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     public IAsyncEnumerable<BusinessAppData> GetAllBusinessAppsForCurrentUserAsync() =>
-        this.WithCompanyId(companyId => _appsBusinessLogic.GetAllUserUserBusinessAppsAsync(companyId));
+        this.WithUserId(userId => _appsBusinessLogic.GetAllUserUserBusinessAppsAsync(userId));
 
     /// <summary>
     /// Retrieves app details for an app referenced by id.

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -74,7 +74,7 @@ public class AppsController : ControllerBase
     [HttpGet]
     [Route("business")]
     [Authorize(Roles = "view_apps")]
-    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [Authorize(Policy = PolicyTypes.CompanyUser)]
     [ProducesResponseType(typeof(IAsyncEnumerable<BusinessAppData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     public IAsyncEnumerable<BusinessAppData> GetAllBusinessAppsForCurrentUserAsync() =>

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
@@ -85,7 +85,7 @@ public class AppsControllerTests
         var result = await this._controller.GetAllBusinessAppsForCurrentUserAsync().ToListAsync().ConfigureAwait(false);
 
         //Assert
-        A.CallTo(() => _logic.GetAllUserUserBusinessAppsAsync(_identity.CompanyId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetAllUserUserBusinessAppsAsync(_identity.UserId)).MustHaveHappenedOnceExactly();
         result.Should().HaveCount(5);
     }
 


### PR DESCRIPTION
## Description

resolved apps-business endpoint empty results

## Why

For apps/business endpoint , we passed CompanyId as parameter to fetch the result. because of that result is empty.
Now by changing the passing parameter to UserId, we able to fetch appropriate result.

## Issue

[CPLP-3048](https://jira.catena-x.net/browse/CPLP-3048)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
