### PR TITLE
fix(apps and services):- post offerId/agreementconsent

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -158,17 +158,17 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
     }
 
     /// <inheritdoc/>
-    public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync(Guid appId, OfferAgreementConsent offerAgreementConsents, Guid companyId)
+    public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync((Guid UserId, Guid CompanyId) identity, Guid appId, OfferAgreementConsent offerAgreementConsents)
     {
         if (appId == Guid.Empty)
         {
             throw new ControllerArgumentException($"AppId must not be empty");
         }
-        return SubmitOfferConsentInternalAsync(appId, offerAgreementConsents, companyId);
+        return SubmitOfferConsentInternalAsync(appId, offerAgreementConsents, identity);
     }
 
-    private Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentInternalAsync(Guid appId, OfferAgreementConsent offerAgreementConsents, Guid companyId) =>
-        _offerService.CreateOrUpdateProviderOfferAgreementConsent(appId, offerAgreementConsents, companyId, OfferTypeId.APP);
+    private Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentInternalAsync(Guid appId, OfferAgreementConsent offerAgreementConsents, (Guid UserId, Guid CompanyId) identity) =>
+        _offerService.CreateOrUpdateProviderOfferAgreementConsent(appId, offerAgreementConsents, identity, OfferTypeId.APP);
 
     /// <inheritdoc/>
     public async Task<AppProviderResponse> GetAppDetailsForStatusAsync(Guid appId, Guid companyId)

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -158,17 +158,14 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
     }
 
     /// <inheritdoc/>
-    public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync((Guid UserId, Guid CompanyId) identity, Guid appId, OfferAgreementConsent offerAgreementConsents)
+    public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync(Guid appId, OfferAgreementConsent offerAgreementConsents, (Guid UserId, Guid CompanyId) identity)
     {
         if (appId == Guid.Empty)
         {
             throw new ControllerArgumentException($"AppId must not be empty");
         }
-        return SubmitOfferConsentInternalAsync(appId, offerAgreementConsents, identity);
+        return _offerService.CreateOrUpdateProviderOfferAgreementConsent(appId, offerAgreementConsents, identity, OfferTypeId.APP);
     }
-
-    private Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentInternalAsync(Guid appId, OfferAgreementConsent offerAgreementConsents, (Guid UserId, Guid CompanyId) identity) =>
-        _offerService.CreateOrUpdateProviderOfferAgreementConsent(appId, offerAgreementConsents, identity, OfferTypeId.APP);
 
     /// <inheritdoc/>
     public async Task<AppProviderResponse> GetAppDetailsForStatusAsync(Guid appId, Guid companyId)

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppReleaseBusinessLogic.cs
@@ -82,7 +82,7 @@ public interface IAppReleaseBusinessLogic
     /// <param name="offerAgreementConsents"></param>
     /// <param name="identity"></param>
     /// <returns></returns>
-    Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync((Guid UserId, Guid CompanyId) identity, Guid appId, OfferAgreementConsent offerAgreementConsents);
+    Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync(Guid appId, OfferAgreementConsent offerAgreementConsents, (Guid UserId, Guid CompanyId) identity);
 
     /// <summary>
     /// Return Offer with Consent Status

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppReleaseBusinessLogic.cs
@@ -80,9 +80,9 @@ public interface IAppReleaseBusinessLogic
     /// </summary>
     /// <param name="appId"></param>
     /// <param name="offerAgreementConsents"></param>
-    /// <param name="companyId"></param>
+    /// <param name="identity"></param>
     /// <returns></returns>
-    Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync(Guid appId, OfferAgreementConsent offerAgreementConsents, Guid companyId);
+    Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync((Guid UserId, Guid CompanyId) identity, Guid appId, OfferAgreementConsent offerAgreementConsents);
 
     /// <summary>
     /// Return Offer with Consent Status

--- a/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
@@ -174,14 +174,14 @@ public class AppReleaseProcessController : ControllerBase
     /// <response code="400">App Id is incorrect.</response>
     [HttpPost]
     [Authorize(Roles = "edit_apps")]
-    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [Authorize(Policy = PolicyTypes.CompanyUser)]
     [Route("consent/{appId}/agreementConsents")]
     [ProducesResponseType(typeof(IEnumerable<ConsentStatusData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentToAgreementsAsync([FromRoute] Guid appId, [FromBody] OfferAgreementConsent offerAgreementConsents) =>
-        this.WithCompanyId(companyId => _appReleaseBusinessLogic.SubmitOfferConsentAsync(appId, offerAgreementConsents, companyId));
+        this.WithUserIdAndCompanyId(identity => _appReleaseBusinessLogic.SubmitOfferConsentAsync(identity, appId, offerAgreementConsents));
 
     /// <summary>
     /// Return app detail with status

--- a/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
@@ -181,7 +181,7 @@ public class AppReleaseProcessController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentToAgreementsAsync([FromRoute] Guid appId, [FromBody] OfferAgreementConsent offerAgreementConsents) =>
-        this.WithUserIdAndCompanyId(identity => _appReleaseBusinessLogic.SubmitOfferConsentAsync(identity, appId, offerAgreementConsents));
+        this.WithUserIdAndCompanyId(identity => _appReleaseBusinessLogic.SubmitOfferConsentAsync(appId, offerAgreementConsents, identity));
 
     /// <summary>
     /// Return app detail with status

--- a/src/marketplace/Offers.Library/Service/IOfferService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferService.cs
@@ -91,10 +91,10 @@ public interface IOfferService
     /// </summary>
     /// <param name="offerId"></param>
     /// <param name="offerAgreementConsent"></param>
-    /// <param name="companyId"></param>
+    /// <param name="identity"></param>
     /// <param name="offerTypeId">OfferTypeId the agreements are associated with</param>
     /// <returns></returns>
-    Task<IEnumerable<ConsentStatusData>> CreateOrUpdateProviderOfferAgreementConsent(Guid offerId, OfferAgreementConsent offerAgreementConsent, Guid companyId, OfferTypeId offerTypeId);
+    Task<IEnumerable<ConsentStatusData>> CreateOrUpdateProviderOfferAgreementConsent(Guid offerId, OfferAgreementConsent offerAgreementConsent, (Guid UserId, Guid CompanyId) identity, OfferTypeId offerTypeId);
 
     /// <summary>
     /// Creates a new service offering

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -189,7 +189,7 @@ public class OfferService : IOfferService
         return ConsentStatusdata;
     }
 
-    private async Task<OfferAgreementConsentUpdate> GetProviderOfferAgreementConsent(Guid offerId,  Guid companyId, OfferStatusId statusId, OfferTypeId offerTypeId)
+    private async Task<OfferAgreementConsentUpdate> GetProviderOfferAgreementConsent(Guid offerId, Guid companyId, OfferStatusId statusId, OfferTypeId offerTypeId)
     {
         var result = await _portalRepositories.GetInstance<IAgreementRepository>().GetOfferAgreementConsent(offerId, companyId, statusId, offerTypeId).ConfigureAwait(false);
         if (result == default)

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -163,9 +163,9 @@ public class OfferService : IOfferService
         return result.OfferAgreementConsent;
     }
 
-    public async Task<IEnumerable<ConsentStatusData>> CreateOrUpdateProviderOfferAgreementConsent(Guid offerId, OfferAgreementConsent offerAgreementConsent, Guid companyId, OfferTypeId offerTypeId)
+    public async Task<IEnumerable<ConsentStatusData>> CreateOrUpdateProviderOfferAgreementConsent(Guid offerId, OfferAgreementConsent offerAgreementConsent, (Guid UserId, Guid CompanyId) identity, OfferTypeId offerTypeId)
     {
-        var (companyUserId, dbAgreements, requiredAgreementIds) = await GetProviderOfferAgreementConsent(offerId, companyId, OfferStatusId.CREATED, offerTypeId).ConfigureAwait(false);
+        var (dbAgreements, requiredAgreementIds) = await GetProviderOfferAgreementConsent(offerId, identity.CompanyId, OfferStatusId.CREATED, offerTypeId).ConfigureAwait(false);
         var invalidConsents = offerAgreementConsent.Agreements.ExceptBy(requiredAgreementIds, consent => consent.AgreementId);
         if (invalidConsents.Any())
         {
@@ -177,8 +177,8 @@ public class OfferService : IOfferService
                 dbAgreements,
                 offerAgreementConsent.Agreements,
                 offerId,
-                companyId,
-                companyUserId,
+                identity.CompanyId,
+                identity.UserId,
                 DateTimeOffset.UtcNow)
             .Select(consent => new ConsentStatusData(consent.AgreementId, consent.ConsentStatusId));
 
@@ -189,7 +189,7 @@ public class OfferService : IOfferService
         return ConsentStatusdata;
     }
 
-    private async Task<OfferAgreementConsentUpdate> GetProviderOfferAgreementConsent(Guid offerId, Guid companyId, OfferStatusId statusId, OfferTypeId offerTypeId)
+    private async Task<OfferAgreementConsentUpdate> GetProviderOfferAgreementConsent(Guid offerId,  Guid companyId, OfferStatusId statusId, OfferTypeId offerTypeId)
     {
         var result = await _portalRepositories.GetInstance<IAgreementRepository>().GetOfferAgreementConsent(offerId, companyId, statusId, offerTypeId).ConfigureAwait(false);
         if (result == default)

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceReleaseBusinessLogic.cs
@@ -72,7 +72,7 @@ public interface IServiceReleaseBusinessLogic
     /// <param name="serviceId">Id of the service</param>
     /// <param name="offerAgreementConsents">Data of the consents for the agreements</param>
     /// <param name="identity">Id of the users company</param>
-    Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync((Guid UserId, Guid CompanyId) identity, Guid serviceId, OfferAgreementConsent offerAgreementConsents);
+    Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync(Guid serviceId, OfferAgreementConsent offerAgreementConsents, (Guid UserId, Guid CompanyId) identity);
 
     /// <summary>
     /// Retrieves all in review status offer in the marketplace.

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceReleaseBusinessLogic.cs
@@ -71,8 +71,8 @@ public interface IServiceReleaseBusinessLogic
     /// </summary>
     /// <param name="serviceId">Id of the service</param>
     /// <param name="offerAgreementConsents">Data of the consents for the agreements</param>
-    /// <param name="companyId">Id of the users company</param>
-    Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync(Guid serviceId, OfferAgreementConsent offerAgreementConsents, Guid companyId);
+    /// <param name="identity">Id of the users company</param>
+    Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync((Guid UserId, Guid CompanyId) identity, Guid serviceId, OfferAgreementConsent offerAgreementConsents);
 
     /// <summary>
     /// Retrieves all in review status offer in the marketplace.

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
@@ -123,18 +123,15 @@ public class ServiceReleaseBusinessLogic : IServiceReleaseBusinessLogic
     }
 
     /// <inheritdoc/>
-    public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync((Guid UserId, Guid CompanyId) identity, Guid serviceId, OfferAgreementConsent offerAgreementConsents)
+    public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync(Guid serviceId, OfferAgreementConsent offerAgreementConsents, (Guid UserId, Guid CompanyId) identity)
     {
         if (serviceId == Guid.Empty)
         {
             throw new ControllerArgumentException("ServiceId must not be empty");
         }
 
-        return SubmitOfferConsentInternalAsync(serviceId, offerAgreementConsents, identity);
+        return _offerService.CreateOrUpdateProviderOfferAgreementConsent(serviceId, offerAgreementConsents, identity, OfferTypeId.SERVICE);
     }
-
-    private Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentInternalAsync(Guid serviceId, OfferAgreementConsent offerAgreementConsents, (Guid UserId, Guid CompanyId) identity) =>
-        _offerService.CreateOrUpdateProviderOfferAgreementConsent(serviceId, offerAgreementConsents, identity, OfferTypeId.SERVICE);
 
     /// <inheritdoc/>
     public Task<Pagination.Response<InReviewServiceData>> GetAllInReviewStatusServiceAsync(int page, int size, OfferSorting? sorting, string? serviceName, string? languageShortName, ServiceReleaseStatusIdFilter? statusId) =>

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
@@ -123,18 +123,18 @@ public class ServiceReleaseBusinessLogic : IServiceReleaseBusinessLogic
     }
 
     /// <inheritdoc/>
-    public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync(Guid serviceId, OfferAgreementConsent offerAgreementConsents, Guid companyId)
+    public Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentAsync((Guid UserId, Guid CompanyId) identity, Guid serviceId, OfferAgreementConsent offerAgreementConsents)
     {
         if (serviceId == Guid.Empty)
         {
             throw new ControllerArgumentException("ServiceId must not be empty");
         }
 
-        return SubmitOfferConsentInternalAsync(serviceId, offerAgreementConsents, companyId);
+        return SubmitOfferConsentInternalAsync(serviceId, offerAgreementConsents, identity);
     }
 
-    private Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentInternalAsync(Guid serviceId, OfferAgreementConsent offerAgreementConsents, Guid companyId) =>
-        _offerService.CreateOrUpdateProviderOfferAgreementConsent(serviceId, offerAgreementConsents, companyId, OfferTypeId.SERVICE);
+    private Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentInternalAsync(Guid serviceId, OfferAgreementConsent offerAgreementConsents, (Guid UserId, Guid CompanyId) identity) =>
+        _offerService.CreateOrUpdateProviderOfferAgreementConsent(serviceId, offerAgreementConsents, identity, OfferTypeId.SERVICE);
 
     /// <inheritdoc/>
     public Task<Pagination.Response<InReviewServiceData>> GetAllInReviewStatusServiceAsync(int page, int size, OfferSorting? sorting, string? serviceName, string? languageShortName, ServiceReleaseStatusIdFilter? statusId) =>

--- a/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
@@ -149,7 +149,7 @@ public class ServiceReleaseController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     public async Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentToAgreementsAsync([FromRoute] Guid serviceId, [FromBody] OfferAgreementConsent offerAgreementConsents) =>
-        await this.WithUserIdAndCompanyId(identity => _serviceReleaseBusinessLogic.SubmitOfferConsentAsync(identity, serviceId, offerAgreementConsents));
+        await this.WithUserIdAndCompanyId(identity => _serviceReleaseBusinessLogic.SubmitOfferConsentAsync(serviceId, offerAgreementConsents, identity));
 
     /// <summary>
     /// Retrieves all in review status service in the marketplace .

--- a/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
@@ -143,13 +143,13 @@ public class ServiceReleaseController : ControllerBase
     [HttpPost]
     [Route("consent/{serviceId}/agreementConsents")]
     [Authorize(Roles = "add_service_offering")]
-    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [Authorize(Policy = PolicyTypes.CompanyUser)]
     [ProducesResponseType(typeof(IEnumerable<ConsentStatusData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     public async Task<IEnumerable<ConsentStatusData>> SubmitOfferConsentToAgreementsAsync([FromRoute] Guid serviceId, [FromBody] OfferAgreementConsent offerAgreementConsents) =>
-        await this.WithCompanyId(companyId => _serviceReleaseBusinessLogic.SubmitOfferConsentAsync(serviceId, offerAgreementConsents, companyId));
+        await this.WithUserIdAndCompanyId(identity => _serviceReleaseBusinessLogic.SubmitOfferConsentAsync(identity, serviceId, offerAgreementConsents));
 
     /// <summary>
     /// Retrieves all in review status service in the marketplace .

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferAgreementConsent.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferAgreementConsent.cs
@@ -26,4 +26,4 @@ public record OfferAgreementConsent(IEnumerable<AgreementConsentStatus> Agreemen
 
 public record AppAgreementConsentStatus(Guid AgreementId, Guid ConsentId, ConsentStatusId ConsentStatusId);
 
-public record OfferAgreementConsentUpdate(Guid CompanyUserId, IEnumerable<AppAgreementConsentStatus> ExistingAgreements, IEnumerable<Guid> RequiredAgreementIds);
+public record OfferAgreementConsentUpdate(IEnumerable<AppAgreementConsentStatus> ExistingAgreements, IEnumerable<Guid> RequiredAgreementIds);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/AgreementRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/AgreementRepository.cs
@@ -101,7 +101,6 @@ public class AgreementRepository : IAgreementRepository
                 offer.OfferTypeId == offerTypeId)
             .Select(offer => new ValueTuple<OfferAgreementConsentUpdate, bool>(
                 new OfferAgreementConsentUpdate(
-                    offer.ProviderCompany!.Identities.Select(companyUser => companyUser.Id).SingleOrDefault(),
                     offer.ConsentAssignedOffers.Select(consentAssignedOffer => new AppAgreementConsentStatus(
                         consentAssignedOffer.Consent!.AgreementId,
                         consentAssignedOffer.Consent.Id,

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -529,7 +529,7 @@ public class AppReleaseBusinessLogicTest
     {
         // Act
         var identitytestdata = (_identity.UserId, _identity.CompanyId);
-        async Task Act() => await _sut.SubmitOfferConsentAsync(identitytestdata, Guid.Empty, _fixture.Create<OfferAgreementConsent>()).ConfigureAwait(false);
+        async Task Act() => await _sut.SubmitOfferConsentAsync(Guid.Empty, _fixture.Create<OfferAgreementConsent>(), identitytestdata).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
@@ -544,7 +544,7 @@ public class AppReleaseBusinessLogicTest
         var data = _fixture.Create<OfferAgreementConsent>();
 
         // Act
-        await _sut.SubmitOfferConsentAsync(identitytestdata, _existingAppId, data).ConfigureAwait(false);
+        await _sut.SubmitOfferConsentAsync(_existingAppId, data, identitytestdata).ConfigureAwait(false);
 
         // Assert
         A.CallTo(() => _offerService.CreateOrUpdateProviderOfferAgreementConsent(_existingAppId, data, identitytestdata, OfferTypeId.APP)).MustHaveHappenedOnceExactly();

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -528,7 +528,8 @@ public class AppReleaseBusinessLogicTest
     public async Task SubmitOfferConsentAsync_WithEmptyAppId_ThrowsControllerArgumentException()
     {
         // Act
-        async Task Act() => await _sut.SubmitOfferConsentAsync(Guid.Empty, _fixture.Create<OfferAgreementConsent>(), _identity.CompanyId).ConfigureAwait(false);
+        var identitytestdata = (_identity.UserId, _identity.CompanyId);
+        async Task Act() => await _sut.SubmitOfferConsentAsync(identitytestdata, Guid.Empty, _fixture.Create<OfferAgreementConsent>()).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
@@ -539,13 +540,14 @@ public class AppReleaseBusinessLogicTest
     public async Task SubmitOfferConsentAsync_WithAppId_CallsOfferService()
     {
         // Arrange
+        var identitytestdata = (_identity.UserId, _identity.CompanyId);
         var data = _fixture.Create<OfferAgreementConsent>();
 
         // Act
-        await _sut.SubmitOfferConsentAsync(_existingAppId, data, _identity.CompanyId).ConfigureAwait(false);
+        await _sut.SubmitOfferConsentAsync(identitytestdata, _existingAppId, data).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _offerService.CreateOrUpdateProviderOfferAgreementConsent(_existingAppId, data, _identity.CompanyId, OfferTypeId.APP)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerService.CreateOrUpdateProviderOfferAgreementConsent(_existingAppId, data, identitytestdata, OfferTypeId.APP)).MustHaveHappenedOnceExactly();
     }
 
     #endregion

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppReleaseProcessControllerTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppReleaseProcessControllerTest.cs
@@ -21,7 +21,6 @@
 using AutoFixture;
 using FakeItEasy;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Org.Eclipse.TractusX.Portal.Backend.Apps.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Apps.Service.ViewModels;
@@ -64,8 +63,6 @@ public class AppReleaseProcessControllerTest
             "https://test.provider.com",
             null,
             null);
-        A.CallTo(() => _logic.UpdateAppAsync(A<Guid>._, A<AppEditableDetail>._, A<Guid>._))
-            .ReturnsLazily(() => Task.CompletedTask);
 
         // Act
         var result = await this._controller.UpdateApp(appId, data).ConfigureAwait(false);
@@ -82,9 +79,6 @@ public class AppReleaseProcessControllerTest
         var appId = new Guid("5cf74ef8-e0b7-4984-a872-474828beb5d2");
         var documentTypeId = DocumentTypeId.ADDITIONAL_DETAILS;
         var file = FormFileHelper.GetFormFile("this is just a test", "superFile.pdf", "application/pdf");
-
-        A.CallTo(() => _logic.CreateAppDocumentAsync(A<Guid>._, A<DocumentTypeId>._, A<FormFile>._, A<ValueTuple<Guid, Guid>>.That.Matches(x => x.Item1 == _identity.UserId && x.Item2 == _identity.CompanyId), A<CancellationToken>._))
-            .ReturnsLazily(() => Task.CompletedTask);
 
         //Act
         await this._controller.UpdateAppDocumentAsync(appId, documentTypeId, file, CancellationToken.None).ConfigureAwait(false);
@@ -156,15 +150,15 @@ public class AppReleaseProcessControllerTest
         var data = _fixture.Create<OfferAgreementConsent>();
         var consentStatusData = new ConsentStatusData(Guid.NewGuid(), ConsentStatusId.ACTIVE);
         var identitydatas = (_identity.UserId, _identity.CompanyId);
-        A.CallTo(() => _logic.SubmitOfferConsentAsync(identitydatas, A<Guid>._, A<OfferAgreementConsent>._))
-            .ReturnsLazily(() => Enumerable.Repeat(consentStatusData, 1));
+        A.CallTo(() => _logic.SubmitOfferConsentAsync(A<Guid>._, A<OfferAgreementConsent>._, A<(Guid, Guid)>._))
+            .Returns(Enumerable.Repeat(consentStatusData, 1));
 
         //Act
         var result = await this._controller.SubmitOfferConsentToAgreementsAsync(appId, data).ConfigureAwait(false);
 
         // Assert 
         result.Should().HaveCount(1);
-        A.CallTo(() => _logic.SubmitOfferConsentAsync(identitydatas, appId, data))
+        A.CallTo(() => _logic.SubmitOfferConsentAsync(appId, data, identitydatas))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -175,7 +169,7 @@ public class AppReleaseProcessControllerTest
         var appId = Guid.NewGuid();
         var data = _fixture.Create<AppProviderResponse>();
         A.CallTo(() => _logic.GetAppDetailsForStatusAsync(A<Guid>._, A<Guid>._))
-            .ReturnsLazily(() => data);
+            .Returns(data);
 
         //Act
         var result = await this._controller.GetAppDetailsForStatusAsync(appId).ConfigureAwait(false);
@@ -192,8 +186,6 @@ public class AppReleaseProcessControllerTest
         //Arrange
         var appId = Guid.NewGuid();
         var roleId = Guid.NewGuid();
-        A.CallTo(() => _logic.DeleteAppRoleAsync(A<Guid>._, A<Guid>._, A<Guid>._))
-            .ReturnsLazily(() => Task.CompletedTask);
 
         //Act
         var result = await this._controller.DeleteAppRoleAsync(appId, roleId).ConfigureAwait(false);
@@ -210,7 +202,7 @@ public class AppReleaseProcessControllerTest
         //Arrange
         var data = _fixture.CreateMany<CompanyUserNameData>(5).ToAsyncEnumerable();
         A.CallTo(() => _logic.GetAppProviderSalesManagersAsync(A<Guid>._))
-            .ReturnsLazily(() => data);
+            .Returns(data);
 
         //Act
         var result = await this._controller.GetAppProviderSalesManagerAsync().ToListAsync().ConfigureAwait(false);
@@ -228,7 +220,7 @@ public class AppReleaseProcessControllerTest
         var appId = _fixture.Create<Guid>();
         var data = _fixture.Create<AppRequestModel>();
         A.CallTo(() => _logic.AddAppAsync(A<AppRequestModel>._, _identity.CompanyId))
-            .ReturnsLazily(() => appId);
+            .Returns(appId);
 
         //Act
         var result = await this._controller.ExecuteAppCreation(data).ConfigureAwait(false);
@@ -269,8 +261,6 @@ public class AppReleaseProcessControllerTest
             "test@gmail.com",
             "9456321678"
             );
-        A.CallTo(() => _logic.UpdateAppReleaseAsync(A<Guid>._, A<AppRequestModel>._, _identity.CompanyId))
-            .ReturnsLazily(() => Task.CompletedTask);
 
         // Act
         var result = await this._controller.UpdateAppRelease(appId, data).ConfigureAwait(false);
@@ -286,7 +276,7 @@ public class AppReleaseProcessControllerTest
         //Arrange
         var paginationResponse = new Pagination.Response<InReviewAppData>(new Pagination.Metadata(15, 1, 1, 15), _fixture.CreateMany<InReviewAppData>(5));
         A.CallTo(() => _logic.GetAllInReviewStatusAppsAsync(A<int>._, A<int>._, A<OfferSorting?>._, null))
-            .ReturnsLazily(() => paginationResponse);
+            .Returns(paginationResponse);
 
         //Act
         var result = await this._controller.GetAllInReviewStatusAppsAsync().ConfigureAwait(false);
@@ -301,8 +291,6 @@ public class AppReleaseProcessControllerTest
     {
         //Arrange
         var appId = _fixture.Create<Guid>();
-        A.CallTo(() => _logic.SubmitAppReleaseRequestAsync(appId, A<Guid>._))
-            .ReturnsLazily(() => Task.CompletedTask);
 
         //Act
         var result = await this._controller.SubmitAppReleaseRequest(appId).ConfigureAwait(false);
@@ -317,8 +305,6 @@ public class AppReleaseProcessControllerTest
     {
         //Arrange
         var appId = _fixture.Create<Guid>();
-        A.CallTo(() => _logic.ApproveAppRequestAsync(appId, A<Guid>._))
-            .ReturnsLazily(() => Task.CompletedTask);
 
         //Act
         var result = await this._controller.ApproveAppRequest(appId).ConfigureAwait(false);
@@ -334,8 +320,6 @@ public class AppReleaseProcessControllerTest
         //Arrange
         var appId = _fixture.Create<Guid>();
         var data = new OfferDeclineRequest("Just a test");
-        A.CallTo(() => _logic.DeclineAppRequestAsync(A<Guid>._, A<Guid>._, A<OfferDeclineRequest>._))
-            .ReturnsLazily(() => Task.CompletedTask);
 
         //Act
         var result = await this._controller.DeclineAppRequest(appId, data).ConfigureAwait(false);
@@ -369,8 +353,6 @@ public class AppReleaseProcessControllerTest
     {
         //Arrange
         var documentId = Guid.NewGuid();
-        A.CallTo(() => _logic.DeleteAppDocumentsAsync(A<Guid>._, A<Guid>._))
-            .ReturnsLazily(() => Task.CompletedTask);
 
         //Act
         var result = await this._controller.DeleteAppDocumentsAsync(documentId).ConfigureAwait(false);
@@ -386,8 +368,6 @@ public class AppReleaseProcessControllerTest
     {
         //Arrange
         var appId = _fixture.Create<Guid>();
-        A.CallTo(() => _logic.DeleteAppAsync(A<Guid>._, A<Guid>._))
-            .ReturnsLazily(() => Task.CompletedTask);
 
         //Act
         var result = await this._controller.DeleteAppAsync(appId).ConfigureAwait(false);

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppReleaseProcessControllerTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppReleaseProcessControllerTest.cs
@@ -155,7 +155,8 @@ public class AppReleaseProcessControllerTest
         var appId = Guid.NewGuid();
         var data = _fixture.Create<OfferAgreementConsent>();
         var consentStatusData = new ConsentStatusData(Guid.NewGuid(), ConsentStatusId.ACTIVE);
-        A.CallTo(() => _logic.SubmitOfferConsentAsync(A<Guid>._, A<OfferAgreementConsent>._, A<Guid>._))
+        var identitydatas = (_identity.UserId, _identity.CompanyId);
+        A.CallTo(() => _logic.SubmitOfferConsentAsync(identitydatas, A<Guid>._, A<OfferAgreementConsent>._))
             .ReturnsLazily(() => Enumerable.Repeat(consentStatusData, 1));
 
         //Act
@@ -163,7 +164,7 @@ public class AppReleaseProcessControllerTest
 
         // Assert 
         result.Should().HaveCount(1);
-        A.CallTo(() => _logic.SubmitOfferConsentAsync(appId, data, _identity.CompanyId))
+        A.CallTo(() => _logic.SubmitOfferConsentAsync(identitydatas, appId, data))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -1416,7 +1416,7 @@ public class OfferServiceTests
             });
         A.CallTo(() => _agreementRepository.GetOfferAgreementConsent(offerId, _identity.CompanyId, OfferStatusId.CREATED, offerTypeId))
             .Returns((offerAgreementConsent, true));
-        A.CallTo(() => _consentRepository.AddAttachAndModifyOfferConsents(A<IEnumerable<AppAgreementConsentStatus>>._, A<IEnumerable<AgreementConsentStatus>>._, A<Guid>._, _identity.CompanyId, _identity.UserId, A<DateTimeOffset>._))
+        A.CallTo(() => _consentRepository.AddAttachAndModifyOfferConsents(A<IEnumerable<AppAgreementConsentStatus>>._, A<IEnumerable<AgreementConsentStatus>>._, A<Guid>._, A<Guid>._, A<Guid>._, A<DateTimeOffset>._))
             .Returns(new Consent[] {
                 new(consentId, agreementId, CompanyUserCompanyId, _companyUser.Id, ConsentStatusId.ACTIVE, utcNow),
                 new(newCreatedConsentId, additionalAgreementId, CompanyUserCompanyId, _companyUser.Id, ConsentStatusId.ACTIVE, utcNow)

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -1322,12 +1322,13 @@ public class OfferServiceTests
         //Arrange
         var offerId = Guid.NewGuid();
         var agreementId = Guid.NewGuid();
+        var identitytestdata = (_identity.UserId, _identity.CompanyId);
         var consentData = new OfferAgreementConsent(new[] { new AgreementConsentStatus(agreementId, ConsentStatusId.ACTIVE) });
         A.CallTo(() => _agreementRepository.GetOfferAgreementConsent(offerId, _identity.CompanyId, OfferStatusId.CREATED, offerTypeId))
             .Returns(((OfferAgreementConsentUpdate, bool))default);
 
         // Act
-        async Task Act() => await _sut.CreateOrUpdateProviderOfferAgreementConsent(offerId, consentData, _identity.CompanyId, offerTypeId).ConfigureAwait(false);
+        async Task Act() => await _sut.CreateOrUpdateProviderOfferAgreementConsent(offerId, consentData, identitytestdata, offerTypeId).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
@@ -1342,12 +1343,13 @@ public class OfferServiceTests
         //Arrange
         var offerId = Guid.NewGuid();
         var agreementId = Guid.NewGuid();
+        var identitytestdata = (_identity.UserId, _identity.CompanyId);
         var consentData = new OfferAgreementConsent(new[] { new AgreementConsentStatus(agreementId, ConsentStatusId.ACTIVE) });
         A.CallTo(() => _agreementRepository.GetOfferAgreementConsent(offerId, _identity.CompanyId, OfferStatusId.CREATED, offerTypeId))
-            .Returns((new OfferAgreementConsentUpdate(_companyUser.Id, Enumerable.Empty<AppAgreementConsentStatus>(), Enumerable.Empty<Guid>()), false));
+            .Returns((new OfferAgreementConsentUpdate(Enumerable.Empty<AppAgreementConsentStatus>(), Enumerable.Empty<Guid>()), false));
 
         // Act
-        async Task Act() => await _sut.CreateOrUpdateProviderOfferAgreementConsent(offerId, consentData, _identity.CompanyId, offerTypeId).ConfigureAwait(false);
+        async Task Act() => await _sut.CreateOrUpdateProviderOfferAgreementConsent(offerId, consentData, identitytestdata, offerTypeId).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
@@ -1364,9 +1366,9 @@ public class OfferServiceTests
         var agreementId = Guid.NewGuid();
         var additionalAgreementId = Guid.NewGuid();
         var consentId = Guid.NewGuid();
+        var identitytestdata = (_identity.UserId, _identity.CompanyId);
         var consentData = new OfferAgreementConsent(new[] { new AgreementConsentStatus(agreementId, ConsentStatusId.ACTIVE), new AgreementConsentStatus(additionalAgreementId, ConsentStatusId.ACTIVE) });
         var offerAgreementConsent = new OfferAgreementConsentUpdate(
-            _companyUser.Id,
             new[]
             {
                 new AppAgreementConsentStatus(agreementId, consentId, ConsentStatusId.INACTIVE)
@@ -1379,7 +1381,7 @@ public class OfferServiceTests
             .Returns((offerAgreementConsent, true));
 
         // Act
-        async Task Act() => await _sut.CreateOrUpdateProviderOfferAgreementConsent(offerId, consentData, _identity.CompanyId, offerTypeId).ConfigureAwait(false);
+        async Task Act() => await _sut.CreateOrUpdateProviderOfferAgreementConsent(offerId, consentData, identitytestdata, offerTypeId).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
@@ -1400,9 +1402,9 @@ public class OfferServiceTests
         var consentId = Guid.NewGuid();
         var newCreatedConsentId = Guid.NewGuid();
         var utcNow = DateTimeOffset.UtcNow;
+        var identitytestdata = (_identity.UserId, _identity.CompanyId);
         var consentData = new OfferAgreementConsent(new[] { new AgreementConsentStatus(agreementId, ConsentStatusId.ACTIVE), new AgreementConsentStatus(additionalAgreementId, ConsentStatusId.ACTIVE) });
         var offerAgreementConsent = new OfferAgreementConsentUpdate(
-            _companyUser.Id,
             new[]
             {
                 new AppAgreementConsentStatus(agreementId, consentId, ConsentStatusId.INACTIVE)
@@ -1414,7 +1416,7 @@ public class OfferServiceTests
             });
         A.CallTo(() => _agreementRepository.GetOfferAgreementConsent(offerId, _identity.CompanyId, OfferStatusId.CREATED, offerTypeId))
             .Returns((offerAgreementConsent, true));
-        A.CallTo(() => _consentRepository.AddAttachAndModifyOfferConsents(A<IEnumerable<AppAgreementConsentStatus>>._, A<IEnumerable<AgreementConsentStatus>>._, A<Guid>._, A<Guid>._, A<Guid>._, A<DateTimeOffset>._))
+        A.CallTo(() => _consentRepository.AddAttachAndModifyOfferConsents(A<IEnumerable<AppAgreementConsentStatus>>._, A<IEnumerable<AgreementConsentStatus>>._, A<Guid>._, _identity.CompanyId, _identity.UserId, A<DateTimeOffset>._))
             .Returns(new Consent[] {
                 new(consentId, agreementId, CompanyUserCompanyId, _companyUser.Id, ConsentStatusId.ACTIVE, utcNow),
                 new(newCreatedConsentId, additionalAgreementId, CompanyUserCompanyId, _companyUser.Id, ConsentStatusId.ACTIVE, utcNow)
@@ -1428,10 +1430,10 @@ public class OfferServiceTests
                 setOptionalParameters(existingOffer);
             });
         // Act
-        var result = await _sut.CreateOrUpdateProviderOfferAgreementConsent(offerId, consentData, _identity.CompanyId, offerTypeId).ConfigureAwait(false);
+        var result = await _sut.CreateOrUpdateProviderOfferAgreementConsent(offerId, consentData, identitytestdata, offerTypeId).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _consentRepository.AddAttachAndModifyOfferConsents(A<IEnumerable<AppAgreementConsentStatus>>._, A<IEnumerable<AgreementConsentStatus>>._, offerId, CompanyUserCompanyId, _companyUser.Id, A<DateTimeOffset>._))
+        A.CallTo(() => _consentRepository.AddAttachAndModifyOfferConsents(A<IEnumerable<AppAgreementConsentStatus>>._, A<IEnumerable<AgreementConsentStatus>>._, offerId, _identity.CompanyId, _identity.UserId, A<DateTimeOffset>._))
             .MustHaveHappenedOnceExactly();
         result.Should()
             .HaveCount(2)

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
@@ -314,12 +314,13 @@ public class ServiceReleaseBusinessLogicTest
     {
         var serviceId = Guid.NewGuid();
         var iamUserId = Guid.NewGuid().ToString();
+        var identitytestData = (_identity.UserId, _identity.CompanyId);
         var data = new OfferAgreementConsent(new List<AgreementConsentStatus>());
 
-        A.CallTo(() => _offerService.CreateOrUpdateProviderOfferAgreementConsent(serviceId, data, _identity.CompanyId, OfferTypeId.SERVICE))
+        A.CallTo(() => _offerService.CreateOrUpdateProviderOfferAgreementConsent(serviceId, data, identitytestData, OfferTypeId.SERVICE))
             .ReturnsLazily(() => new[] { new ConsentStatusData(Guid.NewGuid(), ConsentStatusId.ACTIVE) });
 
-        var result = await _sut.SubmitOfferConsentAsync(serviceId, data, _identity.CompanyId).ConfigureAwait(false);
+        var result = await _sut.SubmitOfferConsentAsync(identitytestData, serviceId, data).ConfigureAwait(false);
 
         result.Should().ContainSingle().Which.ConsentStatus.Should().Be(ConsentStatusId.ACTIVE);
     }
@@ -328,7 +329,8 @@ public class ServiceReleaseBusinessLogicTest
     public async Task SubmitOfferConsentAsync_WithEmptyGuid_ThrowsControllerArgumentException()
     {
         var data = new OfferAgreementConsent(new List<AgreementConsentStatus>());
-        async Task Act() => await _sut.SubmitOfferConsentAsync(Guid.Empty, data, _fixture.Create<Guid>()).ConfigureAwait(false);
+        var identitytestData = (_identity.UserId, _identity.CompanyId);
+        async Task Act() => await _sut.SubmitOfferConsentAsync(identitytestData, Guid.Empty, data).ConfigureAwait(false);
 
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
         ex.Message.Should().Be("ServiceId must not be empty");

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
@@ -317,12 +317,14 @@ public class ServiceReleaseBusinessLogicTest
         var identitytestData = (_identity.UserId, _identity.CompanyId);
         var data = new OfferAgreementConsent(new List<AgreementConsentStatus>());
 
-        A.CallTo(() => _offerService.CreateOrUpdateProviderOfferAgreementConsent(serviceId, data, identitytestData, OfferTypeId.SERVICE))
-            .ReturnsLazily(() => new[] { new ConsentStatusData(Guid.NewGuid(), ConsentStatusId.ACTIVE) });
+        A.CallTo(() => _offerService.CreateOrUpdateProviderOfferAgreementConsent(A<Guid>._, A<OfferAgreementConsent>._, A<(Guid, Guid)>._, A<OfferTypeId>._))
+            .Returns(new[] { new ConsentStatusData(Guid.NewGuid(), ConsentStatusId.ACTIVE) });
 
-        var result = await _sut.SubmitOfferConsentAsync(identitytestData, serviceId, data).ConfigureAwait(false);
+        var result = await _sut.SubmitOfferConsentAsync(serviceId, data, identitytestData).ConfigureAwait(false);
 
         result.Should().ContainSingle().Which.ConsentStatus.Should().Be(ConsentStatusId.ACTIVE);
+        A.CallTo(() => _offerService.CreateOrUpdateProviderOfferAgreementConsent(serviceId, data, identitytestData, OfferTypeId.SERVICE))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -330,7 +332,7 @@ public class ServiceReleaseBusinessLogicTest
     {
         var data = new OfferAgreementConsent(new List<AgreementConsentStatus>());
         var identitytestData = (_identity.UserId, _identity.CompanyId);
-        async Task Act() => await _sut.SubmitOfferConsentAsync(identitytestData, Guid.Empty, data).ConfigureAwait(false);
+        async Task Act() => await _sut.SubmitOfferConsentAsync(Guid.Empty, data, identitytestData).ConfigureAwait(false);
 
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
         ex.Message.Should().Be("ServiceId must not be empty");
@@ -366,7 +368,7 @@ public class ServiceReleaseBusinessLogicTest
         var serviceId = Guid.NewGuid();
         var offerService = A.Fake<IOfferService>();
         _fixture.Inject(offerService);
-        A.CallTo(() => offerService.CreateServiceOfferingAsync(A<ServiceOfferingData>._, A<ValueTuple<Guid, Guid>>._, A<OfferTypeId>._)).ReturnsLazily(() => serviceId);
+        A.CallTo(() => offerService.CreateServiceOfferingAsync(A<ServiceOfferingData>._, A<(Guid, Guid)>._, A<OfferTypeId>._)).Returns(serviceId);
         var sut = _fixture.Create<ServiceReleaseBusinessLogic>();
 
         // Act
@@ -553,7 +555,7 @@ public class ServiceReleaseBusinessLogicTest
         await sut.CreateServiceDocumentAsync(serviceId, DocumentTypeId.ADDITIONAL_DETAILS, file, (_identity.UserId, _identity.CompanyId), CancellationToken.None).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _offerDocumentService.UploadDocumentAsync(serviceId, DocumentTypeId.ADDITIONAL_DETAILS, file, A<ValueTuple<Guid, Guid>>.That.Matches(x => x.Item1 == _identity.UserId && x.Item2 == _identity.CompanyId), OfferTypeId.SERVICE, settings.UploadServiceDocumentTypeIds, CancellationToken.None)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerDocumentService.UploadDocumentAsync(serviceId, DocumentTypeId.ADDITIONAL_DETAILS, file, A<(Guid, Guid)>.That.Matches(x => x.Item1 == _identity.UserId && x.Item2 == _identity.CompanyId), OfferTypeId.SERVICE, settings.UploadServiceDocumentTypeIds, CancellationToken.None)).MustHaveHappenedOnceExactly();
     }
 
     #endregion
@@ -622,13 +624,13 @@ public class ServiceReleaseBusinessLogicTest
     private void SetupUpdateService()
     {
         A.CallTo(() => _offerRepository.GetServiceUpdateData(_notExistingServiceId, A<IEnumerable<ServiceTypeId>>._, _identity.CompanyId))
-            .ReturnsLazily(() => (ServiceUpdateData?)null);
+            .Returns((ServiceUpdateData?)null);
         A.CallTo(() => _offerRepository.GetServiceUpdateData(_activeServiceId, A<IEnumerable<ServiceTypeId>>._, _identity.CompanyId))
-            .ReturnsLazily(() => new ServiceUpdateData(OfferStatusId.ACTIVE, false, Array.Empty<(ServiceTypeId serviceTypeId, bool IsMatch)>(), new ValueTuple<Guid, string, bool>(), Array.Empty<LocalizedDescription>(), null));
+            .Returns(new ServiceUpdateData(OfferStatusId.ACTIVE, false, Array.Empty<(ServiceTypeId serviceTypeId, bool IsMatch)>(), ((Guid, string, bool))default, Array.Empty<LocalizedDescription>(), null));
         A.CallTo(() => _offerRepository.GetServiceUpdateData(_differentCompanyServiceId, A<IEnumerable<ServiceTypeId>>._, _identity.CompanyId))
-            .ReturnsLazily(() => new ServiceUpdateData(OfferStatusId.CREATED, false, Array.Empty<(ServiceTypeId serviceTypeId, bool IsMatch)>(), new ValueTuple<Guid, string, bool>(), Array.Empty<LocalizedDescription>(), null));
+            .Returns(new ServiceUpdateData(OfferStatusId.CREATED, false, Array.Empty<(ServiceTypeId serviceTypeId, bool IsMatch)>(), ((Guid, string, bool))default, Array.Empty<LocalizedDescription>(), null));
         A.CallTo(() => _offerRepository.GetServiceUpdateData(_existingServiceId, A<IEnumerable<ServiceTypeId>>._, _identity.CompanyId))
-            .ReturnsLazily(() => new ServiceUpdateData(OfferStatusId.CREATED, true, Enumerable.Repeat(new ValueTuple<ServiceTypeId, bool>(ServiceTypeId.DATASPACE_SERVICE, false), 1), new ValueTuple<Guid, string, bool>(Guid.NewGuid(), "123", false), Array.Empty<LocalizedDescription>(), Guid.NewGuid()));
+            .Returns(new ServiceUpdateData(OfferStatusId.CREATED, true, new[] { (ServiceTypeId.DATASPACE_SERVICE, false) }, (Guid.NewGuid(), "123", false), Array.Empty<LocalizedDescription>(), Guid.NewGuid()));
     }
 
     private void SetupRepositories()

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceReleaseControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceReleaseControllerTest.cs
@@ -145,16 +145,17 @@ public class ServiceReleaseControllerTest
         //Arrange
         var serviceId = Guid.NewGuid();
         var agreementId = Guid.NewGuid();
+        var identitytestData = (_identity.UserId, _identity.CompanyId);
         var consentStatusData = new ConsentStatusData(Guid.NewGuid(), ConsentStatusId.ACTIVE);
         var offerAgreementConsentData = new OfferAgreementConsent(new[] { new AgreementConsentStatus(agreementId, ConsentStatusId.ACTIVE) });
-        A.CallTo(() => _logic.SubmitOfferConsentAsync(serviceId, A<OfferAgreementConsent>._, A<Guid>._))
+        A.CallTo(() => _logic.SubmitOfferConsentAsync(identitytestData, serviceId, A<OfferAgreementConsent>._))
             .ReturnsLazily(() => Enumerable.Repeat(consentStatusData, 1));
 
         //Act
         var result = await this._controller.SubmitOfferConsentToAgreementsAsync(serviceId, offerAgreementConsentData).ConfigureAwait(false);
 
         //Assert
-        A.CallTo(() => _logic.SubmitOfferConsentAsync(serviceId, offerAgreementConsentData, _identity.CompanyId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.SubmitOfferConsentAsync(identitytestData, serviceId, offerAgreementConsentData)).MustHaveHappenedOnceExactly();
         result.Should().HaveCount(1);
     }
 


### PR DESCRIPTION
## Description

aoi/apps/appreleaseproces/consent/appid/agrremntconsent and aoi/apps/appreleaseproces/consent/appid/agrremntconsent 
was throwing 500 internal service error due to foreign key constraint .

## Why

The exception was thrown due to qury condtion of providercompany.idenriries .companyuserid singleordefault which never ensure the comparison.if companyuserid is null then it will give foreign key issue.

## Issue

CPLP-3018

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
