### PR TITLE
feat(serviceaccount): get owncompany-serviceaccount

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
@@ -32,6 +32,6 @@ public interface IServiceAccountBusinessLogic
     Task<ServiceAccountConnectorOfferData> GetOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId, Guid companyId);
     Task<ServiceAccountDetails> UpdateOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId, ServiceAccountEditableDetails serviceAccountDetails, Guid companyId);
     Task<ServiceAccountDetails> ResetOwnCompanyServiceAccountSecretAsync(Guid serviceAccountId, Guid companyId);
-    Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, Guid companyId);
+    Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, Guid companyId, string? clientId, bool? isOwner);
     IAsyncEnumerable<UserRoleWithDescription> GetServiceAccountRolesAsync(Guid companyId, string? languageShortName);
 }

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -251,12 +251,12 @@ public class ServiceAccountBusinessLogic : IServiceAccountBusinessLogic
             result.OfferSubscriptionId);
     }
 
-    public Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, Guid companyId) =>
+    public Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, Guid companyId, string? clientId, bool? isOwner) =>
         Pagination.CreateResponseAsync(
             page,
             size,
             15,
-            _portalRepositories.GetInstance<IServiceAccountRepository>().GetOwnCompanyServiceAccountsUntracked(companyId));
+            _portalRepositories.GetInstance<IServiceAccountRepository>().GetOwnCompanyServiceAccountsUntracked(companyId, clientId, isOwner));
 
     IAsyncEnumerable<UserRoleWithDescription> IServiceAccountBusinessLogic.GetServiceAccountRolesAsync(Guid companyId, string? languageShortName) =>
         _portalRepositories.GetInstance<IUserRolesRepository>().GetServiceAccountRolesAsync(companyId, _settings.ClientId, languageShortName ?? Constants.DefaultLanguage);

--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -174,8 +174,6 @@ public class ServiceAccountController : ControllerBase
     public Task<Pagination.Response<CompanyServiceAccountData>> GetServiceAccountsData([FromQuery] int page, [FromQuery] int size, [FromQuery] bool? isOwner, [FromQuery] string? clientId) =>
         this.WithCompanyId(companyId => _logic.GetOwnCompanyServiceAccountsDataAsync(page, size, companyId, clientId, isOwner));
 
-
-
     /// <summary>
     /// Get all service account roles
     /// </summary>

--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -161,6 +161,8 @@ public class ServiceAccountController : ControllerBase
     /// </summary>
     /// <param name="page">the page of service account data</param>
     /// <param name="size">number of service account data</param>
+    /// <param name="isOwner">number of service account data</param>
+    /// <param name="clientId">number of service account data</param>
     /// <returns>Returns the specific number of service account data for the given page.</returns>
     /// <remarks>Example: GET: api/administration/serviceaccount/owncompany/serviceaccounts</remarks>
     /// <response code="200">Returns the specific number of service account data for the given page.</response>
@@ -169,8 +171,10 @@ public class ServiceAccountController : ControllerBase
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("owncompany/serviceaccounts")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyServiceAccountData>), StatusCodes.Status200OK)]
-    public Task<Pagination.Response<CompanyServiceAccountData>> GetServiceAccountsData([FromQuery] int page, [FromQuery] int size) =>
-        this.WithCompanyId(companyId => _logic.GetOwnCompanyServiceAccountsDataAsync(page, size, companyId));
+    public Task<Pagination.Response<CompanyServiceAccountData>> GetServiceAccountsData([FromQuery] int page, [FromQuery] int size, [FromQuery] bool? isOwner, [FromQuery] string? clientId) =>
+        this.WithCompanyId(companyId => _logic.GetOwnCompanyServiceAccountsDataAsync(page, size, companyId, clientId, isOwner));
+
+
 
     /// <summary>
     /// Get all service account roles

--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -161,8 +161,8 @@ public class ServiceAccountController : ControllerBase
     /// </summary>
     /// <param name="page">the page of service account data</param>
     /// <param name="size">number of service account data</param>
-    /// <param name="isOwner">number of service account data</param>
-    /// <param name="clientId">number of service account data</param>
+    /// <param name="isOwner">isOwner either true or false</param>
+    /// <param name="clientId">clientId is string clientclientid</param>
     /// <returns>Returns the specific number of service account data for the given page.</returns>
     /// <remarks>Example: GET: api/administration/serviceaccount/owncompany/serviceaccounts</remarks>
     /// <response code="200">Returns the specific number of service account data for the given page.</response>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
@@ -39,6 +39,6 @@ public interface IServiceAccountRepository
     Task<CompanyServiceAccountWithRoleDataClientId?> GetOwnCompanyServiceAccountWithIamClientIdAsync(Guid serviceAccountId, Guid userCompanyId);
     Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId, ConnectorStatusId? statusId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId);
     Task<CompanyServiceAccountDetailedData?> GetOwnCompanyServiceAccountDetailedDataUntrackedAsync(Guid serviceAccountId, Guid companyId);
-    Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnCompanyServiceAccountsUntracked(Guid userCompanyId);
+    Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnCompanyServiceAccountsUntracked(Guid userCompanyId, string? clientId, bool? isOwner);
     Task<bool> CheckActiveServiceAccountExistsForCompanyAsync(Guid technicalUserId, Guid companyId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -19,12 +19,12 @@
  ********************************************************************************/
 
 using Microsoft.EntityFrameworkCore;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 
@@ -155,8 +155,8 @@ public class ServiceAccountRepository : IServiceAccountRepository
                 .Where(serviceAccount =>
                     serviceAccount.Identity!.CompanyId == userCompanyId &&
                     serviceAccount.Identity.UserStatusId == UserStatusId.ACTIVE &&
-                    (!isOwner.HasValue || (serviceAccount.CompaniesLinkedServiceAccount!.Provider == null) == isOwner) &&
-                    (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId!.EscapeForILike()}%")))
+                    (!isOwner.HasValue || (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == null) || (!isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider != null)) &&
+                    (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
                 .GroupBy(serviceAccount => serviceAccount.Identity!.CompanyId),
             serviceAccounts => serviceAccounts.OrderBy(serviceAccount => serviceAccount.Name),
             serviceAccount => new CompanyServiceAccountData(

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -372,14 +372,14 @@ public class ServiceAccountBusinessLogicTests
     {
         // Arrange
         var data = _fixture.CreateMany<CompanyServiceAccountData>(15);
-        A.CallTo(() => _serviceAccountRepository.GetOwnCompanyServiceAccountsUntracked(_identity.CompanyId))
+        A.CallTo(() => _serviceAccountRepository.GetOwnCompanyServiceAccountsUntracked(_identity.CompanyId, null, null))
             .Returns((int skip, int take) => Task.FromResult((Pagination.Source<CompanyServiceAccountData>?)new Pagination.Source<CompanyServiceAccountData>(data.Count(), data.Skip(skip).Take(take))));
 
         A.CallTo(() => _portalRepositories.GetInstance<IServiceAccountRepository>()).Returns(_serviceAccountRepository);
         var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!);
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsDataAsync(1, 10, _identity.CompanyId).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsDataAsync(1, 10, _identity.CompanyId, null, null).ConfigureAwait(false);
 
         // Assert
         result.Should().NotBeNull();

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -21,7 +21,8 @@
     "description": "SA with connector",
     "company_service_account_type_id": 1,
     "offer_subscription_id": null,
-    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542"
+    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
+    "client_client_id": "sa-x-1"
   },
   {
     "id": "93eecd4e-ca47-4dd2-85bf-775ea72eb000",
@@ -30,14 +31,5 @@
     "company_service_account_type_id": 1,
     "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5552",
     "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542"
-  },
-  {
-    "id": "cd436931-8399-4c1d-bd81-7dffb298c7ca",
-    "name": "test-clientid",
-    "description": "test-user-service-account-clientid",
-    "company_service_account_type_id": 2,
-    "offer_subscription_id": null,
-    "client_client_id":"test-client",
-    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -30,5 +30,14 @@
     "company_service_account_type_id": 1,
     "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5552",
     "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542"
+  },
+  {
+    "id": "cd436931-8399-4c1d-bd81-7dffb298c7ca",
+    "name": "test-clientid",
+    "description": "test-user-service-account-clientid",
+    "company_service_account_type_id": 2,
+    "offer_subscription_id": null,
+    "client_client_id":"test-client",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -213,9 +213,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
     {
         // Arrange
         var (sut, _) = await CreateSut().ConfigureAwait(false);
-
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId)(page, size).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId,null,null)(page, size).ConfigureAwait(false);
 
         // Assert
         result.Should().NotBeNull();
@@ -226,6 +225,26 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
             result.Data.First().CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN);
             result.Data.First().IsOwner.Should().BeTrue();
         }
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_ReturnsExpectedResultForClientIdandOwner()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+        var userCompanyId= new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87");
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(userCompanyId,"test-client",true)(0, 10).ConfigureAwait(false);
+
+        // Assert
+        result.Should().NotBeNull();
+        //result!.Count.Should().Be(count);
+        //result.Data.Should().HaveCount(expected);
+        //if (expected > 0)
+        //{
+            //result.Data.First().CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN);
+            //result.Data.First().IsOwner.Should().BeTrue();
+        //}
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -214,7 +214,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Arrange
         var (sut, _) = await CreateSut().ConfigureAwait(false);
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId,null,null)(page, size).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, null)(page, size).ConfigureAwait(false);
 
         // Assert
         result.Should().NotBeNull();
@@ -228,23 +228,62 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
     }
 
     [Fact]
-    public async Task GetOwnCompanyServiceAccountsUntracked_ReturnsExpectedResultForClientIdandOwner()
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithClientIdAndOwner_ReturnsExpectedResult()
     {
         // Arrange
         var (sut, _) = await CreateSut().ConfigureAwait(false);
-        var userCompanyId= new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87");
+
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(userCompanyId,"test-client",true)(0, 10).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-1", true)(0, 10).ConfigureAwait(false);
 
         // Assert
-        result.Should().NotBeNull();
-        //result!.Count.Should().Be(count);
-        //result.Data.Should().HaveCount(expected);
-        //if (expected > 0)
-        //{
-            //result.Data.First().CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN);
-            //result.Data.First().IsOwner.Should().BeTrue();
-        //}
+        result!.Count.Should().Be(1);
+        result.Data.Should().HaveCount(1)
+            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN);
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithClientIdAndProvider_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new("41fd2ab8-71cd-4546-9bef-a388d91b2542"), "sa-x-1", false)(0, 10).ConfigureAwait(false);
+
+        // Assert
+        result!.Count.Should().Be(1);
+        result.Data.Should().HaveCount(1)
+            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED);
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithOnlyClientId_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-1", null)(0, 10).ConfigureAwait(false);
+
+        // Assert
+        result!.Count.Should().Be(1);
+        result.Data.Should().HaveCount(1)
+            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN);
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithSearch_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null)(0, 10).ConfigureAwait(false);
+
+        // Assert
+        result!.Count.Should().Be(9);
+        result.Data.Should().HaveCount(9);
     }
 
     #endregion


### PR DESCRIPTION
## Description

Added clientId and isOwner to filter the record from serviceaccount

## Why

Added filter so that we can search based on specified clientclientId and if service account is of owner or provider 

## Issue
CPLP-3011.

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
