### PR TITLE
feat(OfferService)! : unsubscribe OfferSubscription for apps and service

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -239,33 +239,8 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     }
 
     /// <inheritdoc/>
-    public async Task UnsubscribeOwnCompanyAppSubscriptionAsync(Guid subscriptionId, Guid companyId)
-    {
-        var offerSubscriptionsRepository = _portalRepositories.GetInstance<IOfferSubscriptionsRepository>();
-        var assignedAppData = await offerSubscriptionsRepository.GetCompanyAssignedAppDataForCompanyUserAsync(subscriptionId, companyId).ConfigureAwait(false);
-        if (assignedAppData == default)
-        {
-            throw new NotFoundException($"Subscription {subscriptionId} does not exist.");
-        }
-
-        var (status, isSubscribingCompany, _) = assignedAppData;
-
-        if (!isSubscribingCompany)
-        {
-            throw new ForbiddenException("the calling user does not belong to the subscribing company");
-        }
-
-        if (status != OfferSubscriptionStatusId.ACTIVE && status != OfferSubscriptionStatusId.PENDING)
-        {
-            throw new ConflictException($"There is no active or pending subscription for company '{companyId}' and subscriptionId '{subscriptionId}'");
-        }
-
-        offerSubscriptionsRepository.AttachAndModifyOfferSubscription(subscriptionId, os =>
-        {
-            os.OfferSubscriptionStatusId = OfferSubscriptionStatusId.INACTIVE;
-        });
-        await _portalRepositories.SaveAsync().ConfigureAwait(false);
-    }
+    public Task UnsubscribeOwnCompanyAppSubscriptionAsync(Guid subscriptionId, Guid companyId) =>
+        _offerService.UnsubscribeOwnCompanySubscriptionAsync(subscriptionId, companyId);
 
     /// <inheritdoc/>
     public IAsyncEnumerable<AllOfferData> GetCompanyProvidedAppsDataForUserAsync(Guid companyId) =>

--- a/src/marketplace/Offers.Library/Service/IOfferService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferService.cs
@@ -269,4 +269,12 @@ public interface IOfferService
     /// <param name="contactUserRoles">The roles of the users that will be listed as contact</param>
     /// <returns>Returns the details of the subscription</returns>
     Task<AppProviderSubscriptionDetailData> GetAppSubscriptionDetailsForProviderAsync(Guid offerId, Guid subscriptionId, Guid companyId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> contactUserRoles);
+
+    /// <summary>
+    /// Unsubscribe the Offer subscription by subscriptionId
+    /// </summary>
+    /// <param name="subscriptionId">Id of the subscription</param>
+    /// <param name="companyId">Identity of the user</param>
+    /// <param name="offerTypeId">Offer type</param>
+    Task UnsubscribeOwnCompanySubscriptionAsync(Guid subscriptionId, Guid companyId);
 }

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
@@ -151,4 +151,11 @@ public interface IServiceBusinessLogic
     /// <param name="companyId">Id of the company</param>
     /// <returns>Returns the response data</returns>
     Task StartAutoSetupAsync(OfferAutoSetupData data, Guid companyId);
+
+    /// <summary>
+    /// Unsubscribes an Service for the current users company.
+    /// </summary>
+    /// <param name="subscriptionId">ID of the subscription to unsubscribe from.</param>
+    /// <param name="companyId">Id of the users company that initiated app unsubscription.</param>
+    public Task UnsubscribeOwnCompanyServiceSubscriptionAsync(Guid subscriptionId, Guid companyId);
 }

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -199,4 +199,8 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
     /// <inheritdoc />
     public Task StartAutoSetupAsync(OfferAutoSetupData data, Guid companyId) =>
         _offerSetupService.StartAutoSetupAsync(data, companyId, OfferTypeId.SERVICE);
+
+    /// <inheritdoc/>
+    public Task UnsubscribeOwnCompanyServiceSubscriptionAsync(Guid subscriptionId, Guid companyId) =>
+        _offerService.UnsubscribeOwnCompanySubscriptionAsync(subscriptionId, companyId);
 }

--- a/src/marketplace/Services.Service/Controllers/ServicesController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServicesController.cs
@@ -300,4 +300,25 @@ public class ServicesController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync([FromQuery] int page = 0, [FromQuery] int size = 15) =>
         this.WithCompanyId(companyId => _serviceBusinessLogic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(page, size, companyId));
+
+    /// <summary>
+    /// Unsubscribes an service from the current user's company's subscriptions.
+    /// </summary>
+    /// <param name="subscriptionId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">ID of the subscription to unsubscribe from.</param>
+    /// <remarks>Example: PUT: /api/service/{subscriptionId}/unsubscribe</remarks>
+    /// <response code="204">The service was successfully unsubscribed from.</response>
+    /// <response code="400">Either the sub claim is empty/invalid, user does not exist or the subscription might not have the correct status or the companyID is incorrect.</response>
+    /// <response code="404">Service does not exist.</response>
+    [HttpPut]
+    [Route("{subscriptionId}/unsubscribe")]
+    [Authorize(Roles = "unsubscribe_apps")]
+    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UnsubscribeCompanyServiceSubscriptionAsync([FromRoute] Guid subscriptionId)
+    {
+        await this.WithCompanyId(companyId => _serviceBusinessLogic.UnsubscribeOwnCompanyServiceSubscriptionAsync(subscriptionId, companyId)).ConfigureAwait(false);
+        return NoContent();
+    }
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -52,7 +52,7 @@ public interface IOfferSubscriptionsRepository
 
     Task<(OfferSubscriptionStatusId SubscriptionStatusId, Guid RequestorId, Guid AppId, string? AppName, bool IsUserOfProvider, RequesterData Requester)> GetCompanyAssignedAppDataForProvidingCompanyUserAsync(Guid subscriptionId, Guid userCompanyId);
 
-    Task<(OfferSubscriptionStatusId OfferSubscriptionStatusId, bool IsSubscribingCompany, bool IsValidSubscriptionId)> GetCompanyAssignedAppDataForCompanyUserAsync(Guid subscriptionId, Guid userCompanyId);
+    Task<(OfferSubscriptionStatusId OfferSubscriptionStatusId, bool IsSubscribingCompany, bool IsValidSubscriptionId, IEnumerable<Guid> ConnectorIds, IEnumerable<Guid> ServiceAccounts)> GetCompanyAssignedOfferSubscriptionDataForCompanyUserAsync(Guid subscriptionId, Guid userCompanyId);
 
     Task<(Guid companyId, OfferSubscription? offerSubscription)> GetCompanyIdWithAssignedOfferForCompanyUserAndSubscriptionAsync(Guid subscriptionId, Guid userId, OfferTypeId offerTypeId);
 

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -2527,7 +2527,7 @@ public class OfferServiceTests
 
         foreach (var identity in identities)
         {
-            A.CallTo(() => _userRepository.AttachAndModifyIdentity(A<Guid>._, A<Action<Identity>>._, A<Action<Identity>>._))
+            A.CallTo(() => _userRepository.AttachAndModifyIdentity(identity.Id, A<Action<Identity>>._, A<Action<Identity>>._))
                 .Invokes((Guid _, Action<Identity>? initialize, Action<Identity> setFields) =>
                 {
                     initialize?.Invoke(identity);
@@ -2536,7 +2536,7 @@ public class OfferServiceTests
         }
         foreach (var connector in connectors)
         {
-            A.CallTo(() => _connectorsRepository.AttachAndModifyConnector(A<Guid>._, A<Action<Connector>>._, A<Action<Connector>>._))
+            A.CallTo(() => _connectorsRepository.AttachAndModifyConnector(connector.Id, A<Action<Connector>>._, A<Action<Connector>>._))
                 .Invokes((Guid _, Action<Connector>? initialize, Action<Connector> setOptionalFields) =>
                 {
                     initialize?.Invoke(connector);
@@ -2557,6 +2557,11 @@ public class OfferServiceTests
             .MustHaveHappenedTwiceExactly();
         A.CallTo(() => _userRepository.AttachAndModifyIdentity(A<Guid>._, A<Action<Identity>>._, A<Action<Identity>>._))
             .MustHaveHappenedTwiceExactly();
+
+        connectors.Should().AllSatisfy(x => x.StatusId.Should().Be(ConnectorStatusId.INACTIVE));
+        identities.Should().AllSatisfy(x => x.UserStatusId.Should().Be(UserStatusId.INACTIVE));
+        offerSubscription.OfferSubscriptionStatusId.Should().Be(OfferSubscriptionStatusId.INACTIVE);
+
     }
 
     #endregion

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
@@ -604,6 +604,23 @@ public class ServiceBusinessLogicTests
 
     #endregion
 
+    #region UnsubscribeOwnCompanyAppSubscriptionAsync
+
+    [Fact]
+    public async Task UnsubscribeOwnCompanyAppSubscriptionAsync_ExpectedCall()
+    {
+        // Arrange
+        var sut = new ServiceBusinessLogic(null!, _offerService, null!, null!, Options.Create(new ServiceSettings()));
+
+        //  Act
+        await sut.UnsubscribeOwnCompanyServiceSubscriptionAsync(_fixture.Create<Guid>(), _identity.CompanyId).ConfigureAwait(false);
+
+        // Assert
+        A.CallTo(() => _offerService.UnsubscribeOwnCompanySubscriptionAsync(A<Guid>._, A<Guid>._)).MustHaveHappened();
+    }
+
+    #endregion
+
     #region Setup
 
     private void SetupPagination(int count = 5)

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
@@ -313,4 +313,18 @@ public class ServiceControllerTest
     }
 
     #endregion
+
+    [Fact]
+    public async Task UnsubscribeCompanyServiceSubscription_ReturnsNoContent()
+    {
+        //Arrange
+        var serviceId = _fixture.Create<Guid>();
+
+        //Act
+        var result = await this._controller.UnsubscribeCompanyServiceSubscriptionAsync(serviceId).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.UnsubscribeOwnCompanyServiceSubscriptionAsync(serviceId, _identity.CompanyId)).MustHaveHappenedOnceExactly();
+        Assert.IsType<NoContentResult>(result);
+    }
 }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -971,6 +971,27 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
+    #region GetCompanyAssignedOfferSubscriptionDataForCompanyUser
+
+    [Fact]
+    public async Task GetCompanyAssignedOfferSubscriptionDataForCompanyUserAsync_ReturnsExpected()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetCompanyAssignedOfferSubscriptionDataForCompanyUserAsync(new Guid("e8886159-9258-44a5-88d8-f5735a197a09"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87")).ConfigureAwait(false);
+
+        // Assert
+        result.IsSubscribingCompany.Should().BeTrue();
+        result.IsValidSubscriptionId.Should().BeTrue();
+        result.OfferSubscriptionStatusId.Should().Be(OfferSubscriptionStatusId.PENDING);
+        result.ConnectorIds.Should().Contain(new Guid("bd644d9c-ca12-4488-ae38-6eb902c9bec0"));
+        result.ServiceAccounts.Should().BeEmpty();
+    }
+
+    #endregion
+
     #region Setup
 
     private async Task<(IOfferSubscriptionsRepository, PortalDbContext)> CreateSut()

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connector_assigned_offer_subscriptions.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connector_assigned_offer_subscriptions.test.json
@@ -7,4 +7,9 @@
     "connector_id": "bd644d9c-ca12-4488-ae38-6eb902c9bec0",
     "offer_subscription_id": "ed6065b1-0902-4d5e-9470-33a716022a1a"
   }
+  ,
+  {
+    "connector_id": "bd644d9c-ca12-4488-ae38-6eb902c9bec0",
+    "offer_subscription_id": "e8886159-9258-44a5-88d8-f5735a197a09"
+  }
 ]


### PR DESCRIPTION

## Description

unsubscribe OfferSubscription for apps and service

## Why

when we trigger unsubscribe endpoint for Apps and Service , we put offerSubscription to Inactive. 

## Issue

[CPLP-3027](https://jira.catena-x.net/browse/CPLP-3027)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
