### PR TITLE
feat(serviceaccount): enhance delete serviceaccount

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -101,7 +101,7 @@ public class ServiceAccountRepository : IServiceAccountRepository
             .Where(serviceAccount =>
                 serviceAccount.Id == serviceAccountId &&
                 serviceAccount.Identity!.UserStatusId == UserStatusId.ACTIVE &&
-                serviceAccount.Identity!.CompanyId == companyId)
+                (serviceAccount.CompaniesLinkedServiceAccount!.Owners == companyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == companyId))
             .Select(sa => new ValueTuple<IEnumerable<Guid>, Guid?, string?, ConnectorStatusId?>(
                 sa.Identity!.IdentityAssignedRoles.Select(r => r.UserRoleId),
                 sa.Connector!.Id,

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionViewTests.cs
@@ -50,7 +50,7 @@ public class OfferSubscriptionViewTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var result = await sut.OfferSubscriptionView.ToListAsync().ConfigureAwait(false);
-        result.Should().HaveCount(11);
+        result.Should().HaveCount(12);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -22,5 +22,13 @@
     "company_service_account_type_id": 1,
     "offer_subscription_id": null,
     "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542"
+  },
+  {
+    "id": "93eecd4e-ca47-4dd2-85bf-775ea72eb000",
+    "name": "test-user-service-account",
+    "description": "test-user-service-account-desc",
+    "company_service_account_type_id": 1,
+    "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5552",
+    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
@@ -118,5 +118,13 @@
     "user_status_id": 3,
     "user_entity_id": null,
     "identity_type_id": 1
+  },
+  {
+    "id": "93eecd4e-ca47-4dd2-85bf-775ea72eb000",
+    "date_created": "2022-06-01 18:01:33.439000 +00:00",
+    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
+    "user_status_id": 1,
+    "user_entity_id": null,
+    "identity_type_id": 2
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -149,6 +149,20 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         result.Should().Be(default);
     }
 
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync_WithValidProviderWithDifferentOwner_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+        Guid companyServiceAccountId = new("93eecd4e-ca47-4dd2-85bf-775ea72eb000");
+        Guid companyId = new("41fd2ab8-71cd-4546-9bef-a388d91b2542");
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(companyServiceAccountId, companyId).ConfigureAwait(false);
+
+        // Assert
+        result.Should().NotBeNull();
+    }
+
     #endregion
 
     #region GetOwnCompanyServiceAccountDetailedDataUntrackedAsync

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -158,7 +158,6 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         Guid companyId = new("41fd2ab8-71cd-4546-9bef-a388d91b2542");
         // Act
         var result = await sut.GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(companyServiceAccountId, companyId).ConfigureAwait(false);
-
         // Assert
         result.Should().NotBeNull();
     }


### PR DESCRIPTION
## Description
added validation for companyserviceaccount while deleting account whether  serviceaccount is of provider or owner

## Why
If companyuser account is not of provider or owner then don't allow to execute the endpoint and throw messages

## GitHub Issue

N/A - Jira Issue: CPLP-3034

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
