### PR TITLE
fix(app): add single app subscription activation

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -280,6 +280,10 @@ public class AppsBusinessLogic : IAppsBusinessLogic
         _offerSetupService.StartAutoSetupAsync(data, companyId, OfferTypeId.APP);
 
     /// <inheritdoc />
+    public Task ActivateSingleInstance(Guid offerSubscriptionId, Guid companyId) =>
+        _offerSetupService.CreateSingleInstanceSubscriptionDetail(offerSubscriptionId, companyId);
+
+    /// <inheritdoc />
     public IAsyncEnumerable<AgreementData> GetAppAgreement(Guid appId) =>
         _offerService.GetOfferAgreementsAsync(appId, OfferTypeId.APP);
 

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -138,8 +138,14 @@ public interface IAppsBusinessLogic
     /// </summary>
     /// <param name="data">The offer subscription id and url for the service</param>
     /// <param name="companyId">Id of the company</param>
-    /// <returns>Returns the response data</returns>
     Task StartAutoSetupAsync(OfferAutoSetupData data, Guid companyId);
+
+    /// <summary>
+    /// Triggers the activation of a single instance app subscription.
+    /// </summary>
+    /// <param name="offerSubscriptionId">The offer subscription id</param>
+    /// <param name="companyId">Id of the company</param>
+    Task ActivateSingleInstance(Guid offerSubscriptionId, Guid companyId);
 
     /// <summary>
     /// Gets the app agreement data

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -321,6 +321,26 @@ public class AppsController : ControllerBase
     }
 
     /// <summary>
+    /// Triggers the activation of a single instance app subscription
+    /// </summary>
+    /// <remarks>Example: POST: /api/apps/subscription/activate-single-instance</remarks>
+    /// <response code="204">The activation of the subscription has successfully been started.</response>
+    /// <response code="400">Offer Subscription is pending or not the providing company.</response>
+    /// <response code="404">Offer Subscription not found.</response>
+    [HttpPost]
+    [Route("subscription/{offerSubscriptionId}/activate-single-instance")]
+    [Authorize(Roles = "activate_subscription")]
+    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    public async Task<NoContentResult> ActivateSingleInstance([FromRoute] Guid offerSubscriptionId)
+    {
+        await this.WithCompanyId(companyId => _appsBusinessLogic.ActivateSingleInstance(offerSubscriptionId, companyId)).ConfigureAwait(false);
+        return NoContent();
+    }
+
+    /// <summary>
     /// Retrieve Document Content for document type "App Lead Image" and "App Image" by ID
     /// </summary>
     /// <param name="appId"></param>

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -323,11 +323,11 @@ public class AppsController : ControllerBase
     /// <summary>
     /// Triggers the activation of a single instance app subscription
     /// </summary>
-    /// <remarks>Example: POST: /api/apps/subscription/activate-single-instance</remarks>
+    /// <remarks>Example: PUT: /api/apps/subscription/{offerSubscriptionId}/activate-single-instance</remarks>
     /// <response code="204">The activation of the subscription has successfully been started.</response>
     /// <response code="400">Offer Subscription is pending or not the providing company.</response>
     /// <response code="404">Offer Subscription not found.</response>
-    [HttpPost]
+    [HttpPut]
     [Route("subscription/{offerSubscriptionId}/activate-single-instance")]
     [Authorize(Roles = "activate_subscription")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]

--- a/src/marketplace/Offers.Library/Service/IOfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferSetupService.cs
@@ -75,11 +75,14 @@ public interface IOfferSetupService
     /// <param name="data">The offer subscription id and url for the service</param>
     /// <param name="companyId">Id of the company</param>
     /// <param name="offerTypeId">OfferTypeId of offer to be created</param>
-    /// <returns>Returns the response data</returns>
     Task StartAutoSetupAsync(OfferAutoSetupData data, Guid companyId, OfferTypeId offerTypeId);
 
-    /// <inheritdoc />
-    Task<(IEnumerable<ProcessStepTypeId>? nextStepTypeIds, ProcessStepStatusId stepStatusId, bool modified, string? processMessage)> CreateSingleInstanceSubscriptionDetail(Guid offerSubscriptionId);
+    /// <summary>
+    /// Creates the single instance subscription detail and creates the activation step.
+    /// </summary>
+    /// <param name="offerSubscriptionId">The offer subscription id and url for the service</param>
+    /// <param name="companyId">Id of the company</param>
+    Task CreateSingleInstanceSubscriptionDetail(Guid offerSubscriptionId, Guid companyId);
 
     Task<(IEnumerable<ProcessStepTypeId>? nextStepTypeIds, ProcessStepStatusId stepStatusId, bool modified, string? processMessage)> CreateClient(Guid offerSubscriptionId);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Models/TriggerProviderInformation.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/TriggerProviderInformation.cs
@@ -48,5 +48,6 @@ public record SubscriptionActivationData(
     (bool IsSingleInstance, string? InstanceUrl) InstanceData,
     IEnumerable<Guid> AppInstanceIds,
     bool HasOfferSubscriptionProcessData,
-    Guid? SalesManagerId
+    Guid? SalesManagerId,
+    Guid? ProviderCompanyId
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -384,7 +384,8 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                     : new ValueTuple<bool, string?>(x.Offer.AppInstanceSetup.IsSingleInstance, x.Offer.AppInstanceSetup.InstanceUrl),
                 x.Offer.AppInstances.Select(ai => ai.Id),
                 x.OfferSubscriptionProcessData != null,
-                x.Offer.SalesManagerId
+                x.Offer.SalesManagerId,
+                x.Offer.ProviderCompanyId
             ))
             .SingleOrDefaultAsync();
 

--- a/src/processes/OfferSubscription.Executor/OfferSubscriptionProcessTypeExecutor.cs
+++ b/src/processes/OfferSubscription.Executor/OfferSubscriptionProcessTypeExecutor.cs
@@ -47,7 +47,6 @@ public class OfferSubscriptionProcessTypeExecutor : IProcessTypeExecutor
 
     private readonly IEnumerable<ProcessStepTypeId> _executableProcessSteps = ImmutableArray.Create(
         ProcessStepTypeId.TRIGGER_PROVIDER,
-        ProcessStepTypeId.SINGLE_INSTANCE_SUBSCRIPTION_DETAILS_CREATION,
         ProcessStepTypeId.OFFERSUBSCRIPTION_CLIENT_CREATION,
         ProcessStepTypeId.OFFERSUBSCRIPTION_TECHNICALUSER_CREATION,
         ProcessStepTypeId.ACTIVATE_SUBSCRIPTION,
@@ -105,9 +104,6 @@ public class OfferSubscriptionProcessTypeExecutor : IProcessTypeExecutor
             {
                 ProcessStepTypeId.TRIGGER_PROVIDER => await _offerProviderBusinessLogic
                     .TriggerProvider(_offerSubscriptionId, cancellationToken)
-                    .ConfigureAwait(false),
-                ProcessStepTypeId.SINGLE_INSTANCE_SUBSCRIPTION_DETAILS_CREATION => await _offerSetupService
-                    .CreateSingleInstanceSubscriptionDetail(_offerSubscriptionId)
                     .ConfigureAwait(false),
                 ProcessStepTypeId.OFFERSUBSCRIPTION_CLIENT_CREATION => await _offerSetupService
                     .CreateClient(_offerSubscriptionId)

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
@@ -241,6 +241,26 @@ public class AppBusinessLogicTests
 
     #endregion
 
+    #region ActivateSingleInstance
+
+    [Fact]
+    public async Task ActivateSingleInstance_ReturnsExcepted()
+    {
+        // Arrange
+        var offerSetupService = A.Fake<IOfferSetupService>();
+        var offerSubscriptionId = Guid.NewGuid();
+
+        var sut = new AppsBusinessLogic(null!, null!, null!, offerSetupService, _fixture.Create<IOptions<AppsSettings>>(), A.Fake<MailingService>());
+
+        // Act
+        await sut.ActivateSingleInstance(offerSubscriptionId, _identity.CompanyId).ConfigureAwait(false);
+
+        // Assert
+        A.CallTo(() => offerSetupService.CreateSingleInstanceSubscriptionDetail(offerSubscriptionId, _identity.CompanyId)).MustHaveHappenedOnceExactly();
+    }
+
+    #endregion
+
     #region GetCompanyProvidedAppSubscriptionStatusesForUser
 
     [Theory]

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
@@ -311,6 +311,20 @@ public class AppsControllerTests
     }
 
     [Fact]
+    public async Task ActivateSingleInstance_ReturnsExpected()
+    {
+        //Arrange
+        var offerSubscriptionId = Guid.NewGuid();
+
+        //Act
+        var result = await this._controller.ActivateSingleInstance(offerSubscriptionId).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.ActivateSingleInstance(offerSubscriptionId, _identity.CompanyId)).MustHaveHappenedOnceExactly();
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
     public async Task GetAppImageDocumentContentAsync_ReturnsExpected()
     {
         //Arrange

--- a/tests/processes/OfferSubscription.Executor.Tests/OfferSubscriptionProcessTypeExecutorTests.cs
+++ b/tests/processes/OfferSubscription.Executor.Tests/OfferSubscriptionProcessTypeExecutorTests.cs
@@ -203,7 +203,6 @@ public class OfferSubscriptionProcessTypeExecutorTests
 
     [Theory]
     [InlineData(ProcessStepTypeId.TRIGGER_PROVIDER, ProcessStepTypeId.START_AUTOSETUP)]
-    [InlineData(ProcessStepTypeId.SINGLE_INSTANCE_SUBSCRIPTION_DETAILS_CREATION, ProcessStepTypeId.ACTIVATE_SUBSCRIPTION)]
     [InlineData(ProcessStepTypeId.OFFERSUBSCRIPTION_CLIENT_CREATION, ProcessStepTypeId.OFFERSUBSCRIPTION_TECHNICALUSER_CREATION)]
     [InlineData(ProcessStepTypeId.OFFERSUBSCRIPTION_TECHNICALUSER_CREATION, ProcessStepTypeId.ACTIVATE_SUBSCRIPTION)]
     [InlineData(ProcessStepTypeId.ACTIVATE_SUBSCRIPTION, ProcessStepTypeId.TRIGGER_PROVIDER_CALLBACK)]
@@ -270,11 +269,11 @@ public class OfferSubscriptionProcessTypeExecutorTests
 
     [Theory]
     [InlineData(ProcessStepTypeId.TRIGGER_PROVIDER, true)]
-    [InlineData(ProcessStepTypeId.SINGLE_INSTANCE_SUBSCRIPTION_DETAILS_CREATION, true)]
     [InlineData(ProcessStepTypeId.OFFERSUBSCRIPTION_CLIENT_CREATION, true)]
     [InlineData(ProcessStepTypeId.OFFERSUBSCRIPTION_TECHNICALUSER_CREATION, true)]
     [InlineData(ProcessStepTypeId.ACTIVATE_SUBSCRIPTION, true)]
     [InlineData(ProcessStepTypeId.TRIGGER_PROVIDER_CALLBACK, true)]
+    [InlineData(ProcessStepTypeId.SINGLE_INSTANCE_SUBSCRIPTION_DETAILS_CREATION, false)]
     [InlineData(ProcessStepTypeId.START_AUTOSETUP, false)]
     [InlineData(ProcessStepTypeId.END_CLEARING_HOUSE, false)]
     [InlineData(ProcessStepTypeId.START_CLEARING_HOUSE, false)]
@@ -300,10 +299,9 @@ public class OfferSubscriptionProcessTypeExecutorTests
         var result = _executor.GetExecutableStepTypeIds();
 
         // Assert
-        result.Should().HaveCount(6)
+        result.Should().HaveCount(5)
             .And.Satisfy(
                 x => x == ProcessStepTypeId.TRIGGER_PROVIDER,
-                x => x == ProcessStepTypeId.SINGLE_INSTANCE_SUBSCRIPTION_DETAILS_CREATION,
                 x => x == ProcessStepTypeId.OFFERSUBSCRIPTION_CLIENT_CREATION,
                 x => x == ProcessStepTypeId.OFFERSUBSCRIPTION_TECHNICALUSER_CREATION,
                 x => x == ProcessStepTypeId.ACTIVATE_SUBSCRIPTION,
@@ -326,8 +324,6 @@ public class OfferSubscriptionProcessTypeExecutorTests
 
         A.CallTo(() => _offerProviderBusinessLogic.TriggerProvider(_subscriptionId, A<CancellationToken>._))
             .ReturnsLazily(() => new ValueTuple<IEnumerable<ProcessStepTypeId>?, ProcessStepStatusId, bool, string?>(new[] { ProcessStepTypeId.START_AUTOSETUP }, ProcessStepStatusId.DONE, true, null));
-        A.CallTo(() => _offerSetupService.CreateSingleInstanceSubscriptionDetail(_subscriptionId))
-            .ReturnsLazily(() => new ValueTuple<IEnumerable<ProcessStepTypeId>?, ProcessStepStatusId, bool, string?>(new[] { ProcessStepTypeId.ACTIVATE_SUBSCRIPTION }, ProcessStepStatusId.DONE, true, null));
         A.CallTo(() => _offerSetupService.CreateClient(_subscriptionId))
             .ReturnsLazily(() => new ValueTuple<IEnumerable<ProcessStepTypeId>?, ProcessStepStatusId, bool, string?>(new[] { ProcessStepTypeId.OFFERSUBSCRIPTION_TECHNICALUSER_CREATION }, ProcessStepStatusId.DONE, true, null));
         A.CallTo(() => _offerSetupService.CreateTechnicalUser(_subscriptionId, A<IEnumerable<UserRoleConfig>>._))


### PR DESCRIPTION
## Description

ckanged app activation process for single instance apps.
add enpoint PUT: /api/apps/subscription/activate-single-instance to manually activate single instance apps.

## Why

currently the activation off the app subscription happens automatically, now the provider needs to trigger it manually.

## Issue

N/A - Jira Issue: CPLP-3046

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
