### PR TITLE
fix(custodian): log custodian response

### DIFF
--- a/src/externalsystems/Custodian.Library/Custodian.Library.csproj
+++ b/src/externalsystems/Custodian.Library/Custodian.Library.csproj
@@ -29,6 +29,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\framework\Framework.DateTimeProvider\Framework.DateTimeProvider.csproj" />
         <ProjectReference Include="..\..\framework\Framework.HttpClient\Framework.HttpClient.csproj" />
         <ProjectReference Include="..\..\framework\Framework.Logging\Framework.Logging.csproj" />
         <ProjectReference Include="..\..\framework\Framework.Token\Framework.Token.csproj" />

--- a/src/externalsystems/Custodian.Library/CustodianService.cs
+++ b/src/externalsystems/Custodian.Library/CustodianService.cs
@@ -20,6 +20,7 @@
 
 using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Custodian.Library.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.IO;
@@ -36,11 +37,13 @@ public class CustodianService : ICustodianService
 {
     private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
     private readonly ITokenService _tokenService;
+    private readonly IDateTimeProvider _dateTimeProvider;
     private readonly CustodianSettings _settings;
 
-    public CustodianService(ITokenService tokenService, IOptions<CustodianSettings> settings)
+    public CustodianService(ITokenService tokenService, IDateTimeProvider dateTimeProvider, IOptions<CustodianSettings> settings)
     {
         _tokenService = tokenService;
+        _dateTimeProvider = dateTimeProvider;
         _settings = settings.Value;
     }
 
@@ -89,7 +92,7 @@ public class CustodianService : ICustodianService
                 return "Service Response for custodian-post is null";
             }
 
-            return JsonSerializer.Serialize(walletResponse, Options);
+            return JsonSerializer.Serialize(new WalletCreationLogData(walletResponse.Did, _dateTimeProvider.OffsetNow), Options);
         }
         catch (JsonException)
         {

--- a/src/externalsystems/Custodian.Library/Models/WalletErrorResponse.cs
+++ b/src/externalsystems/Custodian.Library/Models/WalletErrorResponse.cs
@@ -26,4 +26,6 @@ public record WalletErrorResponse([property: JsonPropertyName("message")] string
 
 public record MembershipErrorResponse([property: JsonPropertyName("title")] string Title);
 
-public record WalletCreationResponse([property: JsonPropertyName("DID")] string Did, [property: JsonPropertyName("CreatedAt")] DateTimeOffset CreatedAt);
+public record WalletCreationResponse([property: JsonPropertyName("did")] string Did);
+
+public record WalletCreationLogData([property: JsonPropertyName("did")] string Did, [property: JsonPropertyName("createdAt")] DateTimeOffset CreatedAt);


### PR DESCRIPTION
## Description

Fixed the logging for the custodian response

## Why

Currently the did value is not saved in the comments

## Issue

N/A - Jira Issue: CPLP-3110

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
