### PR TITLE
feat:(apps and services) technical user creation in autosetup

### DIFF
--- a/src/marketplace/Offers.Library/Service/OfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSetupService.cs
@@ -141,7 +141,7 @@ public class OfferSetupService : IOfferSetupService
             throw new UnexpectedConditionException($"There should only be one or none technical user profile configured for {subscriptionId}");
         }
 
-        if (serviceAccountCreationInfo == null || !serviceAccountCreationInfo.UserRoleIds.Any())
+        if (serviceAccountCreationInfo == null || !serviceAccountCreationInfo!.UserRoleIds.Any())
         {
             return null;
         }

--- a/src/marketplace/Offers.Library/Service/OfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSetupService.cs
@@ -141,7 +141,7 @@ public class OfferSetupService : IOfferSetupService
             throw new UnexpectedConditionException($"There should only be one or none technical user profile configured for {subscriptionId}");
         }
 
-        if (serviceAccountCreationInfo == null)
+        if (serviceAccountCreationInfo == null || !serviceAccountCreationInfo.UserRoleIds.Any())
         {
             return null;
         }

--- a/src/marketplace/Offers.Library/Service/OfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSetupService.cs
@@ -141,7 +141,7 @@ public class OfferSetupService : IOfferSetupService
             throw new UnexpectedConditionException($"There should only be one or none technical user profile configured for {subscriptionId}");
         }
 
-        if (serviceAccountCreationInfo == null || !serviceAccountCreationInfo!.UserRoleIds.Any())
+        if (serviceAccountCreationInfo == null || !serviceAccountCreationInfo.UserRoleIds.Any())
         {
             return null;
         }

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
@@ -129,6 +129,7 @@ public class OfferSetupServiceTests
         var appInstances = new List<AppInstance>();
         var appSubscriptionDetails = new List<AppSubscriptionDetail>();
         var notifications = new List<Notification>();
+        var roleIds = _fixture.CreateMany<Guid>().AsEnumerable();
         A.CallTo(() => _clientRepository.CreateClient(A<string>._))
             .Invokes((string clientName) =>
             {
@@ -139,7 +140,7 @@ public class OfferSetupServiceTests
         if (technicalUserRequired)
         {
             A.CallTo(() => _technicalUserProfileService.GetTechnicalUserProfilesForOfferSubscription(A<Guid>._))
-                .Returns(new ServiceAccountCreationInfo[] { new(Guid.NewGuid().ToString(), "test", IamClientAuthMethod.SECRET, Enumerable.Empty<Guid>()) });
+                .Returns(new ServiceAccountCreationInfo[] { new(Guid.NewGuid().ToString(), "test", IamClientAuthMethod.SECRET, roleIds) });
         }
         var serviceManagerRoles = new[]
         {
@@ -1017,12 +1018,13 @@ public class OfferSetupServiceTests
         var companyServiceAccount = _fixture.Build<CompanyServiceAccount>()
             .With(x => x.OfferSubscriptionId, (Guid?)null)
             .Create();
+        var roleIds = _fixture.CreateMany<Guid>().AsEnumerable();
         A.CallTo(() => _offerSubscriptionsRepository.GetTechnicalUserCreationData(offerSubscriptionId))
             .Returns(data);
         A.CallTo(() => _userRolesRepository.GetUserRoleDataUntrackedAsync(A<IEnumerable<UserRoleConfig>>._))
             .Returns(userRoleData.ToAsyncEnumerable());
         A.CallTo(() => _technicalUserProfileService.GetTechnicalUserProfilesForOfferSubscription(A<Guid>._))
-            .Returns(new ServiceAccountCreationInfo[] { new(Guid.NewGuid().ToString(), "test", IamClientAuthMethod.SECRET, new List<Guid>()) });
+            .Returns(new ServiceAccountCreationInfo[] { new(Guid.NewGuid().ToString(), "test", IamClientAuthMethod.SECRET, roleIds) });
         A.CallTo(() => _serviceAccountCreation.CreateServiceAccountAsync(A<ServiceAccountCreationInfo>._, CompanyUserCompanyId, A<IEnumerable<string>>.That.Matches(x => x.Count() == 1 && x.Single() == Bpn), CompanyServiceAccountTypeId.MANAGED, false, A<Action<CompanyServiceAccount>>._))
             .Invokes((ServiceAccountCreationInfo _, Guid _, IEnumerable<string> _, CompanyServiceAccountTypeId _, bool _, Action<CompanyServiceAccount>? setOptionalParameter) =>
             {

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
@@ -286,6 +286,51 @@ public class OfferSetupServiceTests
     }
 
     [Fact]
+    public async Task AutoSetup_WithNoTechnicalUsersRole_ThrowsException()
+    {
+        // Arrange
+        var offerSubscription = new OfferSubscription(Guid.NewGuid(), Guid.Empty, Guid.Empty, OfferSubscriptionStatusId.PENDING, Guid.Empty);
+        var companyServiceAccount = new CompanyServiceAccount(Guid.NewGuid(), "test", "test", CompanyServiceAccountTypeId.OWN);
+        SetupAutoSetup(OfferTypeId.APP, offerSubscription, false, companyServiceAccount);
+        var clientId = Guid.NewGuid();
+        var appInstanceId = Guid.NewGuid();
+        var clients = new List<IamClient>();
+        A.CallTo(() => _clientRepository.CreateClient(A<string>._))
+            .Invokes((string clientName) =>
+            {
+                var client = new IamClient(clientId, clientName);
+                clients.Add(client);
+            })
+            .Returns(new IamClient(clientId, "cl1"));
+        A.CallTo(() => _technicalUserProfileService.GetTechnicalUserProfilesForOfferSubscription(A<Guid>._))
+            .Returns(new ServiceAccountCreationInfo[]
+            {
+                new(Guid.NewGuid().ToString(), "test", IamClientAuthMethod.SECRET, Enumerable.Empty<Guid>())
+            });
+
+        A.CallTo(() => _appInstanceRepository.CreateAppInstance(A<Guid>._, A<Guid>._))
+            .Returns(new AppInstance(appInstanceId, _existingServiceId, clientId));
+
+        var companyAdminRoles = new[]
+        {
+            new UserRoleConfig("Cl2-CX-Portal", new[] { "IT Admin" })
+        };
+        var serviceManagerAdminRoles = new[]
+        {
+            new UserRoleConfig("Cl2-CX-Portal", new[] { "Service Manager" })
+        };
+
+        var data = new OfferAutoSetupData(_pendingSubscriptionId, "https://new-url.com/");
+
+        // Act
+        //async Task Act() => await _sut.AutoSetupOfferAsync(data, companyAdminRoles, (_identity.UserId, _identity.CompanyId), OfferTypeId.APP, "https://base-address.com", serviceManagerAdminRoles).ConfigureAwait(false);
+        var result = await _sut.AutoSetupOfferAsync(data, companyAdminRoles, (_identity.UserId, _identity.CompanyId), OfferTypeId.APP, "https://base-address.com", serviceManagerAdminRoles).ConfigureAwait(false);
+         result.Should().NotBeNull();
+        result.TechnicalUserInfo.Should().BeNull();
+        A.CallTo(() => _serviceAccountCreation.CreateServiceAccountAsync(A<ServiceAccountCreationInfo>._, A<Guid>._, A<IEnumerable<string>>._, CompanyServiceAccountTypeId.MANAGED, false, A<Action<CompanyServiceAccount>>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
     public async Task AutoSetup_WithValidDataAndUserWithoutMail_NoMailIsSend()
     {
         // Arrange

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
@@ -325,7 +325,7 @@ public class OfferSetupServiceTests
         // Act
         //async Task Act() => await _sut.AutoSetupOfferAsync(data, companyAdminRoles, (_identity.UserId, _identity.CompanyId), OfferTypeId.APP, "https://base-address.com", serviceManagerAdminRoles).ConfigureAwait(false);
         var result = await _sut.AutoSetupOfferAsync(data, companyAdminRoles, (_identity.UserId, _identity.CompanyId), OfferTypeId.APP, "https://base-address.com", serviceManagerAdminRoles).ConfigureAwait(false);
-         result.Should().NotBeNull();
+        result.Should().NotBeNull();
         result.TechnicalUserInfo.Should().BeNull();
         A.CallTo(() => _serviceAccountCreation.CreateServiceAccountAsync(A<ServiceAccountCreationInfo>._, A<Guid>._, A<IEnumerable<string>>._, CompanyServiceAccountTypeId.MANAGED, false, A<Action<CompanyServiceAccount>>._)).MustNotHaveHappened();
     }


### PR DESCRIPTION
## Description

adrole assigned to technicaluser profile.
## Why

The check was added so that if technical user has role then allow to create the record elase return.

## Issue

CPLP-2829.

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
