### PR TITLE
fix(connector): Handling Error message for Delete-Connector endpoint

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
@@ -59,3 +59,15 @@ public record ManagedConnectorData(
     ConnectorStatusId Status,
     string? ProviderCompanyName,
     Guid? SelfDescriptionDocumentId);
+
+/// <summary>
+/// connector information to delete
+/// </summary>
+public record DeleteConnectorData(
+    bool IsProvidingOrHostCompany,
+    Guid? SelfDescriptionDocumentId,
+    DocumentStatusId? DocumentStatusId,
+    ConnectorStatusId ConnectorStatus,
+    IEnumerable<ConnectorOfferSubscription> ConnectorOfferSubscriptions
+);
+public record ConnectorOfferSubscription(Guid AssignedOfferSubscriptionIds, OfferSubscriptionStatusId OfferSubscriptionStatus);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -137,16 +137,17 @@ public class ConnectorsRepository : IConnectorsRepository
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public Task<(bool IsValidConnectorId, bool IsProvidingOrHostCompany, Guid? SelfDescriptionDocumentId, DocumentStatusId? DocumentStatusId, ConnectorStatusId ConnectorStatus, IEnumerable<Guid> AssignedOfferSubscriptions)> GetConnectorDeleteDataAsync(Guid connectorId, Guid companyId) =>
+    public Task<DeleteConnectorData?> GetConnectorDeleteDataAsync(Guid connectorId, Guid companyId) =>
         _context.Connectors
             .Where(x => x.Id == connectorId)
-            .Select(connector => new ValueTuple<bool, bool, Guid?, DocumentStatusId?, ConnectorStatusId, IEnumerable<Guid>>(
-                true,
+            .Select(connector => new DeleteConnectorData(
                 connector.ProviderId == companyId || connector.HostId == companyId,
                 connector.SelfDescriptionDocumentId,
                 connector.SelfDescriptionDocument!.DocumentStatusId,
                 connector.StatusId,
-                connector.ConnectorAssignedOfferSubscriptions.Select(x => x.OfferSubscriptionId)
+                connector.ConnectorAssignedOfferSubscriptions.Select(x => new ConnectorOfferSubscription(
+                    x.OfferSubscriptionId, x.OfferSubscription!.OfferSubscriptionStatusId
+                ))
             )).SingleOrDefaultAsync();
 
     /// <inheritdoc />

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -146,7 +146,8 @@ public class ConnectorsRepository : IConnectorsRepository
                 connector.SelfDescriptionDocument!.DocumentStatusId,
                 connector.StatusId,
                 connector.ConnectorAssignedOfferSubscriptions.Select(x => new ConnectorOfferSubscription(
-                    x.OfferSubscriptionId, x.OfferSubscription!.OfferSubscriptionStatusId
+                    x.OfferSubscriptionId,
+                    x.OfferSubscription!.OfferSubscriptionStatusId
                 ))
             )).SingleOrDefaultAsync();
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
@@ -87,7 +87,7 @@ public interface IConnectorsRepository
     /// <param name="connectorId">Id of the connector</param>
     /// <param name="companyId">Id of the company</param>
     /// <returns>returns SelfDescriptionDocument Data/c></returns>
-    Task<(bool IsValidConnectorId, bool IsProvidingOrHostCompany, Guid? SelfDescriptionDocumentId, DocumentStatusId? DocumentStatusId, ConnectorStatusId ConnectorStatus, IEnumerable<Guid> AssignedOfferSubscriptions)> GetConnectorDeleteDataAsync(Guid connectorId, Guid companyId);
+    Task<DeleteConnectorData?> GetConnectorDeleteDataAsync(Guid connectorId, Guid companyId);
 
     /// <summary>
     /// Gets the data required for the connector update

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -478,7 +478,10 @@ public class ConnectorsBusinessLogicTests
         var connectorId = Guid.NewGuid();
         var connector = new Connector(connectorId, null!, null!, null!);
         var selfDescriptionDocumentId = Guid.NewGuid();
-        var connectorOfferSubscriptions = _fixture.CreateMany<ConnectorOfferSubscription>(2);
+        var connectorOfferSubscriptions = new[] {
+            new ConnectorOfferSubscription(_fixture.Create<Guid>(), OfferSubscriptionStatusId.PENDING),
+            new ConnectorOfferSubscription(_fixture.Create<Guid>(), OfferSubscriptionStatusId.PENDING),
+        };
         A.CallTo(() => _connectorsRepository.GetConnectorDeleteDataAsync(A<Guid>._, _identity.CompanyId))
             .Returns(new DeleteConnectorData(true, selfDescriptionDocumentId, DocumentStatusId, ConnectorStatusId.ACTIVE, connectorOfferSubscriptions));
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -278,8 +278,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result.IsValidConnectorId.Should().BeTrue();
-        result.IsProvidingOrHostCompany.Should().BeTrue();
+        result!.IsProvidingOrHostCompany.Should().BeTrue();
         result.SelfDescriptionDocumentId.Should().BeNull();
     }
 
@@ -294,8 +293,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result.IsValidConnectorId.Should().BeTrue();
-        result.IsProvidingOrHostCompany.Should().BeTrue();
+        result!.IsProvidingOrHostCompany.Should().BeTrue();
         result.SelfDescriptionDocumentId.Should().Be(new Guid("e020787d-1e04-4c0b-9c06-bd1cd44724b3"));
         result.DocumentStatusId.Should().Be(DocumentStatusId.LOCKED);
     }
@@ -311,8 +309,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result.IsValidConnectorId.Should().BeTrue();
-        result.IsProvidingOrHostCompany.Should().BeFalse();
+        result!.IsProvidingOrHostCompany.Should().BeFalse();
     }
 
     [Fact]
@@ -325,9 +322,24 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetConnectorDeleteDataAsync(new Guid(), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87")).ConfigureAwait(false);
 
         // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSelfDescriptionDocumentDataAsync_WithConnectorOfferSubscription_ReturnsExpected()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetConnectorDeleteDataAsync(new Guid("4618c650-709c-4580-956a-85b76eecd4b8"), new Guid("41fd2ab8-71cd-4546-9bef-a388d91b2542")).ConfigureAwait(false);
+
+        // Assert
         result.Should().NotBeNull();
-        result.IsValidConnectorId.Should().BeFalse();
-        result.SelfDescriptionDocumentId.Should().BeNull();
+        result!.ConnectorStatus.Should().Be(ConnectorStatusId.PENDING);
+        result!.ConnectorOfferSubscriptions.Should().Satisfy(
+            x => x.AssignedOfferSubscriptionIds == new Guid("014afd09-e51a-4ecf-83ab-a5380d9af832")
+            && x.OfferSubscriptionStatus == OfferSubscriptionStatusId.PENDING);
     }
 
     #endregion


### PR DESCRIPTION
## Description

Handling error message for delete-connector endpoint

## Why

when we hit the deleteConnector endpoint, error message was not handled properly, now it was handled

## Issue

[CPLP-3050](https://jira.catena-x.net/browse/CPLP-3050)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
