### PR TITLE
updates(welcome email): show bpnl number next to user name

### DIFF
--- a/src/mailing/Mailing.Template/EmailTemplates/portal_welcome_email.html
+++ b/src/mailing/Mailing.Template/EmailTemplates/portal_welcome_email.html
@@ -92,7 +92,7 @@
                                   style="Margin:0;padding-top:20px;padding-bottom:20px;padding-left:30px;padding-right:30px;text-align: left;">
                                   <p
                                     style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                                    Dear {userName} {bpnl} <br /> Your company registration application for {companyName} has
+                                    Dear {userName} {bpn} <br /> Your company registration application for {companyName} has
                                     been successfully approved. <br /> You can now start to participate in the Catena-X
                                     Network.</p>
                                   <p

--- a/src/mailing/Mailing.Template/EmailTemplates/portal_welcome_email.html
+++ b/src/mailing/Mailing.Template/EmailTemplates/portal_welcome_email.html
@@ -92,7 +92,7 @@
                                   style="Margin:0;padding-top:20px;padding-bottom:20px;padding-left:30px;padding-right:30px;text-align: left;">
                                   <p
                                     style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                                    Dear {userName} <br /> Your company registration application for {companyName} has
+                                    Dear {userName} {bpnl} <br /> Your company registration application for {companyName} has
                                     been successfully approved. <br /> You can now start to participate in the Catena-X
                                     Network.</p>
                                   <p


### PR DESCRIPTION
## Description

show bpnl number next to user name in the email template

## Why

bpnl is missing

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
