### PR TITLE
fix(serviceAccount): set correct identityTypeId for serviceAccounts

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
@@ -33,7 +33,7 @@ public interface IUserRepository
 {
     IAsyncEnumerable<CompanyApplicationWithStatus> GetApplicationsWithStatusUntrackedAsync(Guid companyId);
     CompanyUser CreateCompanyUser(Guid identityId, string? firstName, string? lastName, string email);
-    Identity CreateIdentity(Guid companyId, UserStatusId userStatusId);
+    Identity CreateIdentity(Guid companyId, UserStatusId userStatusId, IdentityTypeId identityTypeId);
     void AttachAndModifyCompanyUser(Guid companyUserId, Action<CompanyUser>? initialize, Action<CompanyUser> setOptionalParameters);
     IQueryable<CompanyUser> GetOwnCompanyUserQuery(Guid companyId, Guid? companyUserId = null, string? userEntityId = null, string? firstName = null, string? lastName = null, string? email = null, IEnumerable<UserStatusId>? statusIds = null);
     Task<(string UserEntityId, string? FirstName, string? LastName, string? Email)> GetUserEntityDataAsync(Guid companyUserId, Guid companyId);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -63,14 +63,14 @@ public class UserRepository : IUserRepository
         }).Entity;
 
     /// <inheritdoc />
-    public Identity CreateIdentity(Guid companyId, UserStatusId userStatusId) =>
+    public Identity CreateIdentity(Guid companyId, UserStatusId userStatusId, IdentityTypeId identityTypeId) =>
         _dbContext.Identities.Add(
             new Identity(
                 Guid.NewGuid(),
                 DateTimeOffset.UtcNow,
                 companyId,
                 userStatusId,
-                IdentityTypeId.COMPANY_USER)).Entity;
+                identityTypeId)).Entity;
 
     public void AttachAndModifyCompanyUser(Guid companyUserId, Action<CompanyUser>? initialize, Action<CompanyUser> setOptionalParameters)
     {

--- a/src/provisioning/Provisioning.Library/Service/ServiceAccountCreation.cs
+++ b/src/provisioning/Provisioning.Library/Service/ServiceAccountCreation.cs
@@ -103,7 +103,7 @@ public class ServiceAccountCreation : IServiceAccountCreation
             await _provisioningManager.AddProtocolMapperAsync(serviceAccountData.InternalClientId).ConfigureAwait(false);
         }
 
-        var identity = _portalRepositories.GetInstance<IUserRepository>().CreateIdentity(companyId, UserStatusId.ACTIVE);
+        var identity = _portalRepositories.GetInstance<IUserRepository>().CreateIdentity(companyId, UserStatusId.ACTIVE, IdentityTypeId.COMPANY_SERVICE_ACCOUNT);
         var serviceAccount = serviceAccountsRepository.CreateCompanyServiceAccount(
             identity.Id,
             enhancedName,

--- a/src/provisioning/Provisioning.Library/Service/UserProvisioningService.cs
+++ b/src/provisioning/Provisioning.Library/Service/UserProvisioningService.cs
@@ -138,7 +138,7 @@ public class UserProvisioningService : IUserProvisioningService
             return (identity, companyUserId);
         }
 
-        identity = userRepository.CreateIdentity(companyId, UserStatusId.ACTIVE);
+        identity = userRepository.CreateIdentity(companyId, UserStatusId.ACTIVE, IdentityTypeId.COMPANY_USER);
         companyUserId = userRepository.CreateCompanyUser(identity.Id, user.FirstName, user.LastName, user.Email).Id;
         if (businessPartnerNumber != null)
         {

--- a/tests/provisioning/Provisioning.Library.Tests/Extensions/ServiceAccountCreationTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/Extensions/ServiceAccountCreationTests.cs
@@ -166,10 +166,10 @@ public class ServiceAccountCreationTests
         A.CallTo(() => _provisioningManager.SetupCentralServiceAccountClientAsync(A<string>._, A<ClientConfigRolesData>._))
             .Returns(new ServiceAccountData("internal-sa1", _iamUserId, new ClientAuthData(IamClientAuthMethod.SECRET)));
 
-        A.CallTo(() => _userRepository.CreateIdentity(_companyId, A<UserStatusId>._))
-            .Invokes((Guid companyId, UserStatusId userStatusId) =>
+        A.CallTo(() => _userRepository.CreateIdentity(_companyId, A<UserStatusId>._, IdentityTypeId.COMPANY_SERVICE_ACCOUNT))
+            .Invokes((Guid companyId, UserStatusId userStatusId, IdentityTypeId identityTypeId) =>
             {
-                var identity = new Identity(Guid.NewGuid(), DateTimeOffset.UtcNow, companyId, userStatusId, IdentityTypeId.COMPANY_SERVICE_ACCOUNT);
+                var identity = new Identity(Guid.NewGuid(), DateTimeOffset.UtcNow, companyId, userStatusId, identityTypeId);
                 identities?.Add(identity);
             })
             .Returns(new Identity(_identityId, default, default, default, default));

--- a/tests/provisioning/Provisioning.Library.Tests/UserProvisioningServiceCreateUsersTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/UserProvisioningServiceCreateUsersTests.cs
@@ -257,8 +257,8 @@ public class UserProvisioningServiceCreateUsersTests
         A.CallTo(() => _userRepository.GetMatchingCompanyIamUsersByNameEmail(A<string>.That.IsEqualTo(userInfo.FirstName), A<string>._, A<string>._, A<Guid>._, A<IEnumerable<UserStatusId>>._))
             .Returns(new[] { (UserEntityId: (string?)null, CompanyUserId: Guid.Empty) }.ToAsyncEnumerable());
 
-        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, A<UserStatusId>._))
-            .ReturnsLazily((Guid companyId, UserStatusId userStatusId) => new Identity(Guid.NewGuid(), DateTimeOffset.UtcNow, companyId, userStatusId, IdentityTypeId.COMPANY_USER)
+        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, A<UserStatusId>._, IdentityTypeId.COMPANY_USER))
+            .ReturnsLazily((Guid companyId, UserStatusId userStatusId, IdentityTypeId identityId) => new Identity(Guid.NewGuid(), DateTimeOffset.UtcNow, companyId, userStatusId, identityId)
             {
                 UserEntityId = centralUserId
             });
@@ -277,7 +277,7 @@ public class UserProvisioningServiceCreateUsersTests
         A.CallTo(() => _provisioningManager.GetProviderUserLinkDataForCentralUserIdAsync(A<string>._)).MustNotHaveHappened();
         A.CallTo(() => _provisioningManager.CreateCentralUserAsync(A<UserProfile>._, A<IEnumerable<(string, IEnumerable<string>)>>._)).MustHaveHappened(userCreationInfoIdp.Count, Times.Exactly);
         A.CallTo(() => _provisioningManager.CreateCentralUserAsync(A<UserProfile>.That.Matches(u => u.FirstName == userInfo.FirstName), A<IEnumerable<(string, IEnumerable<string>)>>._)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _userRepository.CreateIdentity(_companyNameIdpAliasData.CompanyId, UserStatusId.ACTIVE)).MustHaveHappened(userCreationInfoIdp.Count, Times.Exactly);
+        A.CallTo(() => _userRepository.CreateIdentity(_companyNameIdpAliasData.CompanyId, UserStatusId.ACTIVE, IdentityTypeId.COMPANY_USER)).MustHaveHappened(userCreationInfoIdp.Count, Times.Exactly);
         A.CallTo(() => _userRepository.CreateCompanyUser(A<Guid>._, A<string?>._, A<string?>._, A<string>._)).MustHaveHappened(userCreationInfoIdp.Count, Times.Exactly);
         A.CallTo(() => _userRepository.CreateCompanyUser(A<Guid>._, userInfo.FirstName, userInfo.LastName, userInfo.Email)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _businessPartnerRepository.CreateCompanyUserAssignedBusinessPartner(A<Guid>._, _companyNameIdpAliasData.BusinessPartnerNumber!)).MustHaveHappened(userCreationInfoIdp.Count, Times.Exactly);
@@ -313,7 +313,7 @@ public class UserProvisioningServiceCreateUsersTests
         A.CallTo(() => _provisioningManager.GetProviderUserLinkDataForCentralUserIdAsync(A<string>._)).MustNotHaveHappened();
         A.CallTo(() => _provisioningManager.CreateCentralUserAsync(A<UserProfile>._, A<IEnumerable<(string, IEnumerable<string>)>>._)).MustHaveHappened(userCreationInfoIdp.Count, Times.Exactly);
         A.CallTo(() => _provisioningManager.CreateCentralUserAsync(A<UserProfile>.That.Matches(u => u.FirstName == userInfo.FirstName), A<IEnumerable<(string, IEnumerable<string>)>>._)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, UserStatusId.ACTIVE)).MustHaveHappened(userCreationInfoIdp.Count - 1, Times.Exactly);
+        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, UserStatusId.ACTIVE, IdentityTypeId.COMPANY_USER)).MustHaveHappened(userCreationInfoIdp.Count - 1, Times.Exactly);
         A.CallTo(() => _userRepository.CreateCompanyUser(A<Guid>._, A<string?>._, A<string?>._, A<string>._)).MustHaveHappened(userCreationInfoIdp.Count - 1, Times.Exactly);
         A.CallTo(() => _userRepository.CreateCompanyUser(A<Guid>._, userInfo.FirstName, A<string?>._, A<string>._)).MustNotHaveHappened();
         A.CallTo(() => _businessPartnerRepository.CreateCompanyUserAssignedBusinessPartner(A<Guid>._, _companyNameIdpAliasData.BusinessPartnerNumber!)).MustHaveHappened(userCreationInfoIdp.Count - 1, Times.Exactly);
@@ -407,14 +407,14 @@ public class UserProvisioningServiceCreateUsersTests
         A.CallTo(() => _portalRepositories.GetInstance<IUserBusinessPartnerRepository>()).Returns(_businessPartnerRepository);
         A.CallTo(() => _portalRepositories.GetInstance<IUserRolesRepository>()).Returns(_userRolesRepository);
 
-        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, A<UserStatusId>._))
-            .ReturnsLazily((Guid companyId, UserStatusId userStatusId) =>
+        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, A<UserStatusId>._, IdentityTypeId.COMPANY_USER))
+            .ReturnsLazily((Guid companyId, UserStatusId userStatusId, IdentityTypeId identityTypeId) =>
                 new Identity(
                     Guid.NewGuid(),
                     DateTimeOffset.UtcNow,
                     companyId,
                     userStatusId,
-                    IdentityTypeId.COMPANY_USER));
+                    identityTypeId));
 
         A.CallTo(() => _userRepository.CreateCompanyUser(A<Guid>._, A<string>._, A<string>._, A<string>._))
             .ReturnsLazily((Guid _, string firstName, string _, string _) =>


### PR DESCRIPTION
## Description

The correct identity Type Id is now set for serviceAccounts

## Why

Currently the serviceAccounts are created with identityTypeId = 1 (companyUser), with that Pr the correct identityTypeId (2 - serviceAccount) is set.

## Issue

N/A - Jira Ticket: CPLP-3112

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
