### PR TITLE
feat(certificates): fix get certificates endpoint

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -275,7 +275,6 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     /// <inheritdoc />
     public async Task CreateUseCaseParticipation(UseCaseParticipationCreationData data, CancellationToken cancellationToken)
     {
-        var identity = _identityService.IdentityData;
         var (verifiedCredentialExternalTypeDetailId, credentialTypeId, document) = data;
         var documentContentType = document.ContentType.ParseMediaTypeId();
         documentContentType.CheckDocumentContentType(_settings.UseCaseParticipationMediaTypes);
@@ -286,13 +285,12 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
             throw new ControllerArgumentException($"VerifiedCredentialExternalTypeDetail {verifiedCredentialExternalTypeDetailId} does not exist");
         }
 
-        await HandleSsiCreationAsync(identity, new(credentialTypeId, VerifiedCredentialTypeKindId.USE_CASE, verifiedCredentialExternalTypeDetailId, document, documentContentType), companyCredentialDetailsRepository, cancellationToken).ConfigureAwait(false);
+        await HandleSsiCreationAsync(credentialTypeId, VerifiedCredentialTypeKindId.USE_CASE, verifiedCredentialExternalTypeDetailId, document, documentContentType, companyCredentialDetailsRepository, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task CreateSsiCertificate(SsiCertificateCreationData data, CancellationToken cancellationToken)
     {
-        var identity = _identityService.IdentityData;
         var (credentialTypeId, document) = data;
         var documentContentType = document.ContentType.ParseMediaTypeId();
         documentContentType.CheckDocumentContentType(_settings.SsiCertificateMediaTypes);
@@ -303,16 +301,15 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
             throw new ControllerArgumentException($"{credentialTypeId} is not assigned to a certificate");
         }
 
-        await HandleSsiCreationAsync(identity, new(credentialTypeId, VerifiedCredentialTypeKindId.CERTIFICATE, null, document, documentContentType), companyCredentialDetailsRepository, cancellationToken).ConfigureAwait(false);
+        await HandleSsiCreationAsync(credentialTypeId, VerifiedCredentialTypeKindId.CERTIFICATE, null, document, documentContentType, companyCredentialDetailsRepository, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task HandleSsiCreationAsync(
-        IdentityData identity,
-        (VerifiedCredentialTypeId CredentialTypeId, VerifiedCredentialTypeKindId kindId, Guid? VerifiedCredentialExternalTypeDetailId, IFormFile Document, MediaTypeId MediaTypeId) creationData,
+        VerifiedCredentialTypeId credentialTypeId, VerifiedCredentialTypeKindId kindId, Guid? verifiedCredentialExternalTypeDetailId, IFormFile document, MediaTypeId mediaTypeId,
         ICompanySsiDetailsRepository companyCredentialDetailsRepository,
         CancellationToken cancellationToken)
     {
-        var (credentialTypeId, kindId, verifiedCredentialExternalTypeDetailId, document, mediaTypeId) = creationData;
+        var identity = _identityService.IdentityData;
         if (await companyCredentialDetailsRepository.CheckSsiDetailsExistsForCompany(identity.CompanyId, credentialTypeId, kindId, verifiedCredentialExternalTypeDetailId).ConfigureAwait(false))
         {
             throw new ControllerArgumentException("Credential request already existing");

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -166,7 +166,7 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
         {
             return;
         }
-        
+
         var identity = _identityService.IdentityData;
         var companyRepositories = _portalRepositories.GetInstance<ICompanyRepository>();
         var result = await companyRepositories.GetCompanyRolesDataAsync(identity.CompanyId, companyRoleConsentDetails.Select(x => x.CompanyRole)).ConfigureAwait(false);

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -34,6 +34,7 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 using System.Globalization;
 using System.Text.Json;
 
@@ -47,6 +48,7 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     private readonly IMailingService _mailingService;
     private readonly ICustodianService _custodianService;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly IIdentityService _identityService;
     private readonly CompanyDataSettings _settings;
 
     /// <summary>
@@ -56,19 +58,22 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     /// <param name="mailingService"></param>
     /// <param name="custodianService"></param>
     /// <param name="dateTimeProvider"></param>
+    /// <param name="identityService"></param>
     /// <param name="options"></param>
-    public CompanyDataBusinessLogic(IPortalRepositories portalRepositories, IMailingService mailingService, ICustodianService custodianService, IDateTimeProvider dateTimeProvider, IOptions<CompanyDataSettings> options)
+    public CompanyDataBusinessLogic(IPortalRepositories portalRepositories, IMailingService mailingService, ICustodianService custodianService, IDateTimeProvider dateTimeProvider, IIdentityService identityService, IOptions<CompanyDataSettings> options)
     {
         _portalRepositories = portalRepositories;
         _mailingService = mailingService;
         _custodianService = custodianService;
         _dateTimeProvider = dateTimeProvider;
+        _identityService = identityService;
         _settings = options.Value;
     }
 
     /// <inheritdoc/>
-    public async Task<CompanyAddressDetailData> GetCompanyDetailsAsync(Guid companyId)
+    public async Task<CompanyAddressDetailData> GetCompanyDetailsAsync()
     {
+        var companyId = _identityService.IdentityData.CompanyId;
         var result = await _portalRepositories.GetInstance<ICompanyRepository>().GetCompanyDetailsAsync(companyId).ConfigureAwait(false);
         if (result == null)
         {
@@ -78,12 +83,13 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     /// <inheritdoc/>
-    public IAsyncEnumerable<CompanyAssignedUseCaseData> GetCompanyAssigendUseCaseDetailsAsync(Guid companyId) =>
-        _portalRepositories.GetInstance<ICompanyRepository>().GetCompanyAssigendUseCaseDetailsAsync(companyId);
+    public IAsyncEnumerable<CompanyAssignedUseCaseData> GetCompanyAssigendUseCaseDetailsAsync() =>
+        _portalRepositories.GetInstance<ICompanyRepository>().GetCompanyAssigendUseCaseDetailsAsync(_identityService.IdentityData.CompanyId);
 
     /// <inheritdoc/>
-    public async Task<bool> CreateCompanyAssignedUseCaseDetailsAsync(Guid companyId, Guid useCaseId)
+    public async Task<bool> CreateCompanyAssignedUseCaseDetailsAsync(Guid useCaseId)
     {
+        var companyId = _identityService.IdentityData.CompanyId;
         var companyRepositories = _portalRepositories.GetInstance<ICompanyRepository>();
         var useCaseDetails = await companyRepositories.GetCompanyStatusAndUseCaseIdAsync(companyId, useCaseId).ConfigureAwait(false);
         if (!useCaseDetails.IsActiveCompanyStatus)
@@ -100,8 +106,9 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     /// <inheritdoc/>
-    public async Task RemoveCompanyAssignedUseCaseDetailsAsync(Guid companyId, Guid useCaseId)
+    public async Task RemoveCompanyAssignedUseCaseDetailsAsync(Guid useCaseId)
     {
+        var companyId = _identityService.IdentityData.CompanyId;
         var companyRepositories = _portalRepositories.GetInstance<ICompanyRepository>();
         var useCaseDetails = await companyRepositories.GetCompanyStatusAndUseCaseIdAsync(companyId, useCaseId).ConfigureAwait(false);
         if (!useCaseDetails.IsActiveCompanyStatus)
@@ -116,8 +123,9 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
 
-    public async IAsyncEnumerable<CompanyRoleConsentViewData> GetCompanyRoleAndConsentAgreementDetailsAsync(Guid companyId, string? languageShortName)
+    public async IAsyncEnumerable<CompanyRoleConsentViewData> GetCompanyRoleAndConsentAgreementDetailsAsync(string? languageShortName)
     {
+        var companyId = _identityService.IdentityData.CompanyId;
         if (languageShortName != null && !await _portalRepositories.GetInstance<ILanguageRepository>().IsValidLanguageCode(languageShortName).ConfigureAwait(false))
         {
             throw new ControllerArgumentException($"language {languageShortName} is not a valid languagecode");
@@ -152,12 +160,14 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     /// <inheritdoc/>
-    public async Task CreateCompanyRoleAndConsentAgreementDetailsAsync((Guid UserId, Guid CompanyId) identity, IEnumerable<CompanyRoleConsentDetails> companyRoleConsentDetails)
+    public async Task CreateCompanyRoleAndConsentAgreementDetailsAsync(IEnumerable<CompanyRoleConsentDetails> companyRoleConsentDetails)
     {
         if (!companyRoleConsentDetails.Any())
         {
             return;
         }
+        
+        var identity = _identityService.IdentityData;
         var companyRepositories = _portalRepositories.GetInstance<ICompanyRepository>();
         var result = await companyRepositories.GetCompanyRolesDataAsync(identity.CompanyId, companyRoleConsentDetails.Select(x => x.CompanyRole)).ConfigureAwait(false);
         if (!result.IsValidCompany)
@@ -221,10 +231,10 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<UseCaseParticipationData>> GetUseCaseParticipationAsync(Guid companyId, string? language) =>
+    public async Task<IEnumerable<UseCaseParticipationData>> GetUseCaseParticipationAsync(string? language) =>
         await _portalRepositories
             .GetInstance<ICompanySsiDetailsRepository>()
-            .GetUseCaseParticipationForCompany(companyId, language ?? Constants.DefaultLanguage)
+            .GetUseCaseParticipationForCompany(_identityService.IdentityData.CompanyId, language ?? Constants.DefaultLanguage)
             .Select(x => new UseCaseParticipationData(
                 x.UseCase,
                 x.Description,
@@ -247,28 +257,25 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
             .ConfigureAwait(false);
 
     /// <inheritdoc />
-    public async Task<IEnumerable<SsiCertificateData>> GetSsiCertificatesAsync(Guid companyId) =>
+    public async Task<IEnumerable<SsiCertificateData>> GetSsiCertificatesAsync() =>
         await _portalRepositories
             .GetInstance<ICompanySsiDetailsRepository>()
-            .GetSsiCertificates(companyId)
+            .GetSsiCertificates(_identityService.IdentityData.CompanyId)
             .Select(x => new SsiCertificateData(
                 x.CredentialType,
-                x.SsiDetailData.CatchingInto(
-                    data => data
-                        .Select(d => new CompanySsiDetailData(
+                x.SsiDetailData.Select(d => new CompanySsiDetailData(
                             d.CredentialId,
                             d.ParticipationStatus,
                             d.ExpiryDate,
-                            d.Document))
-                        .SingleOrDefault(),
-                    (InvalidOperationException _) => new ConflictException("There should only be one pending or active ssi detail be assigned")
+                            d.Document)
                 )))
             .ToListAsync()
             .ConfigureAwait(false);
 
     /// <inheritdoc />
-    public async Task CreateUseCaseParticipation((Guid UserId, Guid CompanyId) identity, UseCaseParticipationCreationData data, CancellationToken cancellationToken)
+    public async Task CreateUseCaseParticipation(UseCaseParticipationCreationData data, CancellationToken cancellationToken)
     {
+        var identity = _identityService.IdentityData;
         var (verifiedCredentialExternalTypeDetailId, credentialTypeId, document) = data;
         var documentContentType = document.ContentType.ParseMediaTypeId();
         documentContentType.CheckDocumentContentType(_settings.UseCaseParticipationMediaTypes);
@@ -283,8 +290,9 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     /// <inheritdoc />
-    public async Task CreateSsiCertificate((Guid UserId, Guid CompanyId) identity, SsiCertificateCreationData data, CancellationToken cancellationToken)
+    public async Task CreateSsiCertificate(SsiCertificateCreationData data, CancellationToken cancellationToken)
     {
+        var identity = _identityService.IdentityData;
         var (credentialTypeId, document) = data;
         var documentContentType = document.ContentType.ParseMediaTypeId();
         documentContentType.CheckDocumentContentType(_settings.SsiCertificateMediaTypes);
@@ -299,7 +307,7 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     private async Task HandleSsiCreationAsync(
-        (Guid UserId, Guid CompanyId) identity,
+        IdentityData identity,
         (VerifiedCredentialTypeId CredentialTypeId, VerifiedCredentialTypeKindId kindId, Guid? VerifiedCredentialExternalTypeDetailId, IFormFile Document, MediaTypeId MediaTypeId) creationData,
         ICompanySsiDetailsRepository companyCredentialDetailsRepository,
         CancellationToken cancellationToken)
@@ -372,9 +380,10 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     /// <inheritdoc />
-    public async Task ApproveCredential(Guid userId, Guid credentialId, CancellationToken cancellationToken)
+    public async Task ApproveCredential(Guid credentialId, CancellationToken cancellationToken)
     {
         var companySsiRepository = _portalRepositories.GetInstance<ICompanySsiDetailsRepository>();
+        var userId = _identityService.IdentityData.UserId;
         var (exists, data) = await companySsiRepository.GetSsiApprovalData(credentialId).ConfigureAwait(false);
         if (!exists)
         {
@@ -445,9 +454,10 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     /// <inheritdoc />
-    public async Task RejectCredential(Guid userId, Guid credentialId)
+    public async Task RejectCredential(Guid credentialId)
     {
         var companySsiRepository = _portalRepositories.GetInstance<ICompanySsiDetailsRepository>();
+        var userId = _identityService.IdentityData.UserId;
         var (exists, status, type, requesterId, requesterEmail, requesterFirstname, requesterLastname) = await companySsiRepository.GetSsiRejectionData(credentialId).ConfigureAwait(false);
         if (!exists)
         {

--- a/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
@@ -27,29 +27,30 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLog
 
 public interface ICompanyDataBusinessLogic
 {
-    Task<CompanyAddressDetailData> GetCompanyDetailsAsync(Guid companyId);
+    Task<CompanyAddressDetailData> GetCompanyDetailsAsync();
 
-    IAsyncEnumerable<CompanyAssignedUseCaseData> GetCompanyAssigendUseCaseDetailsAsync(Guid companyId);
+    IAsyncEnumerable<CompanyAssignedUseCaseData> GetCompanyAssigendUseCaseDetailsAsync();
 
-    Task<bool> CreateCompanyAssignedUseCaseDetailsAsync(Guid companyId, Guid useCaseId);
+    Task<bool> CreateCompanyAssignedUseCaseDetailsAsync(Guid useCaseId);
 
-    Task RemoveCompanyAssignedUseCaseDetailsAsync(Guid companyId, Guid useCaseId);
+    Task RemoveCompanyAssignedUseCaseDetailsAsync(Guid useCaseId);
 
-    IAsyncEnumerable<CompanyRoleConsentViewData> GetCompanyRoleAndConsentAgreementDetailsAsync(Guid companyId, string? languageShortName);
+    IAsyncEnumerable<CompanyRoleConsentViewData> GetCompanyRoleAndConsentAgreementDetailsAsync(string? languageShortName);
 
-    Task CreateCompanyRoleAndConsentAgreementDetailsAsync((Guid UserId, Guid CompanyId) identity, IEnumerable<CompanyRoleConsentDetails> companyRoleConsentDetails);
+    Task CreateCompanyRoleAndConsentAgreementDetailsAsync(IEnumerable<CompanyRoleConsentDetails> companyRoleConsentDetails);
 
-    Task<IEnumerable<UseCaseParticipationData>> GetUseCaseParticipationAsync(Guid companyId, string? language);
+    Task<IEnumerable<UseCaseParticipationData>> GetUseCaseParticipationAsync(string? language);
 
-    Task<IEnumerable<SsiCertificateData>> GetSsiCertificatesAsync(Guid companyId);
+    Task<IEnumerable<SsiCertificateData>> GetSsiCertificatesAsync();
 
-    Task CreateUseCaseParticipation((Guid UserId, Guid CompanyId) identity, UseCaseParticipationCreationData data, CancellationToken cancellationToken);
-    Task CreateSsiCertificate((Guid UserId, Guid CompanyId) identity, SsiCertificateCreationData data, CancellationToken cancellationToken);
+    Task CreateUseCaseParticipation(UseCaseParticipationCreationData data, CancellationToken cancellationToken);
+    Task CreateSsiCertificate(SsiCertificateCreationData data, CancellationToken cancellationToken);
 
     Task<Pagination.Response<CredentialDetailData>> GetCredentials(int page, int size, CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId, string? companyName, CompanySsiDetailSorting? sorting);
 
-    Task ApproveCredential(Guid userId, Guid credentialId, CancellationToken cancellationToken);
+    Task ApproveCredential(Guid credentialId, CancellationToken cancellationToken);
 
-    Task RejectCredential(Guid userId, Guid credentialId);
+    Task RejectCredential(Guid credentialId);
+
     IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes();
 }

--- a/src/administration/Administration.Service/Controllers/CompanyDataController.cs
+++ b/src/administration/Administration.Service/Controllers/CompanyDataController.cs
@@ -65,7 +65,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(typeof(CompanyAddressDetailData), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
     public Task<CompanyAddressDetailData> GetOwnCompanyDetailsAsync() =>
-        this.WithCompanyId(companyId => _logic.GetCompanyDetailsAsync(companyId));
+        _logic.GetCompanyDetailsAsync();
 
     /// <summary>
     /// Gets the CompanyAssigned UseCase details
@@ -79,7 +79,7 @@ public class CompanyDataController : ControllerBase
     [Route("preferredUseCases")]
     [ProducesResponseType(typeof(CompanyAssignedUseCaseData), StatusCodes.Status200OK)]
     public IAsyncEnumerable<CompanyAssignedUseCaseData> GetCompanyAssigendUseCaseDetailsAsync() =>
-       this.WithCompanyId(companyId => _logic.GetCompanyAssigendUseCaseDetailsAsync(companyId));
+       _logic.GetCompanyAssigendUseCaseDetailsAsync();
 
     /// <summary>
     /// Create the CompanyAssigned UseCase details
@@ -96,7 +96,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
     public async Task<StatusCodeResult> CreateCompanyAssignedUseCaseDetailsAsync([FromBody] UseCaseIdDetails data) =>
-        await this.WithCompanyId(companyId => _logic.CreateCompanyAssignedUseCaseDetailsAsync(companyId, data.useCaseId)).ConfigureAwait(false)
+        await _logic.CreateCompanyAssignedUseCaseDetailsAsync(data.useCaseId).ConfigureAwait(false)
             ? StatusCode((int)HttpStatusCode.Created)
             : NoContent();
 
@@ -115,7 +115,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
     public async Task<NoContentResult> RemoveCompanyAssignedUseCaseDetailsAsync([FromBody] UseCaseIdDetails data)
     {
-        await this.WithCompanyId(companyId => _logic.RemoveCompanyAssignedUseCaseDetailsAsync(companyId, data.useCaseId)).ConfigureAwait(false);
+        await _logic.RemoveCompanyAssignedUseCaseDetailsAsync(data.useCaseId).ConfigureAwait(false);
         return NoContent();
     }
 
@@ -134,7 +134,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
     public IAsyncEnumerable<CompanyRoleConsentViewData> GetCompanyRoleAndConsentAgreementDetailsAsync([FromQuery] string? languageShortName = null) =>
-        this.WithCompanyId(companyId => _logic.GetCompanyRoleAndConsentAgreementDetailsAsync(companyId, languageShortName));
+        _logic.GetCompanyRoleAndConsentAgreementDetailsAsync(languageShortName);
 
     /// <summary>
     /// Post the companyrole and Consent Details
@@ -153,7 +153,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
     public async Task<NoContentResult> CreateCompanyRoleAndConsentAgreementDetailsAsync([FromBody] IEnumerable<CompanyRoleConsentDetails> companyRoleConsentDetails)
     {
-        await this.WithUserIdAndCompanyId(identity => _logic.CreateCompanyRoleAndConsentAgreementDetailsAsync(identity, companyRoleConsentDetails));
+        await _logic.CreateCompanyRoleAndConsentAgreementDetailsAsync(companyRoleConsentDetails);
         return NoContent();
     }
 
@@ -169,7 +169,7 @@ public class CompanyDataController : ControllerBase
     [Route("useCaseParticipation")]
     [ProducesResponseType(typeof(IEnumerable<UseCaseParticipationData>), StatusCodes.Status200OK)]
     public Task<IEnumerable<UseCaseParticipationData>> GetUseCaseParticipation([FromQuery] string? language) =>
-        this.WithCompanyId(companyId => _logic.GetUseCaseParticipationAsync(companyId, language));
+        _logic.GetUseCaseParticipationAsync(language);
 
     /// <summary>
     /// Gets the Ssi certifications for the own company
@@ -183,7 +183,7 @@ public class CompanyDataController : ControllerBase
     [Route("certificates")]
     [ProducesResponseType(typeof(IEnumerable<SsiCertificateTransferData>), StatusCodes.Status200OK)]
     public Task<IEnumerable<SsiCertificateData>> GetSsiCertificationData() =>
-        this.WithCompanyId(companyId => _logic.GetSsiCertificatesAsync(companyId));
+        _logic.GetSsiCertificatesAsync();
 
     /// <summary>
     /// Gets the Ssi certifications for the own company
@@ -214,7 +214,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<NoContentResult> CreateUseCaseParticipation([FromForm] UseCaseParticipationCreationData data, CancellationToken cancellationToken)
     {
-        await this.WithUserIdAndCompanyId(identity => _logic.CreateUseCaseParticipation(identity, data, cancellationToken)).ConfigureAwait(false);
+        await _logic.CreateUseCaseParticipation(data, cancellationToken).ConfigureAwait(false);
         return NoContent();
     }
 
@@ -234,7 +234,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<NoContentResult> CreateSsiCertificate([FromForm] SsiCertificateCreationData data, CancellationToken cancellationToken)
     {
-        await this.WithUserIdAndCompanyId(identity => _logic.CreateSsiCertificate(identity, data, cancellationToken)).ConfigureAwait(false);
+        await _logic.CreateSsiCertificate(data, cancellationToken).ConfigureAwait(false);
         return NoContent();
     }
 
@@ -278,7 +278,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<NoContentResult> ApproveCredential([FromRoute] Guid credentialId, CancellationToken cts)
     {
-        await this.WithUserId(userId => _logic.ApproveCredential(userId, credentialId, cts)).ConfigureAwait(false);
+        await _logic.ApproveCredential(credentialId, cts).ConfigureAwait(false);
         return NoContent();
     }
 
@@ -296,7 +296,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<NoContentResult> RejectCredential([FromRoute] Guid credentialId)
     {
-        await this.WithUserId(userId => _logic.RejectCredential(userId, credentialId)).ConfigureAwait(false);
+        await _logic.RejectCredential(credentialId).ConfigureAwait(false);
         return NoContent();
     }
 }

--- a/src/administration/Administration.Service/Models/SsiCertificateData.cs
+++ b/src/administration/Administration.Service/Models/SsiCertificateData.cs
@@ -5,5 +5,5 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 public record SsiCertificateData
 (
     VerifiedCredentialTypeId CredentialType,
-    CompanySsiDetailData? SsiDetailData
+    IEnumerable<CompanySsiDetailData> SsiDetailData
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanySsiDetailsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanySsiDetailsRepository.cs
@@ -111,7 +111,6 @@ public class CompanySsiDetailsRepository : ICompanySsiDetailsRepository
                                 : new DocumentData(
                                     ssi.Document!.Id,
                                     ssi.Document.DocumentName)))
-                    .Take(2)
              ))
             .ToAsyncEnumerable();
 

--- a/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
@@ -34,8 +34,6 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Contr
 
 public class CompanyDataControllerTests
 {
-    private const string IamUserId = "4C1A6851-D4E7-4E10-A011-3732CD045E8A";
-    private readonly IdentityData _identity = new(IamUserId, Guid.NewGuid(), IdentityTypeId.COMPANY_USER, Guid.NewGuid());
     private readonly ICompanyDataBusinessLogic _logic;
     private readonly CompanyDataController _controller;
     private readonly Fixture _fixture;
@@ -45,7 +43,6 @@ public class CompanyDataControllerTests
         _fixture = new Fixture();
         _logic = A.Fake<ICompanyDataBusinessLogic>();
         this._controller = new CompanyDataController(_logic);
-        _controller.AddControllerContextWithClaim(IamUserId, _identity);
     }
 
     [Fact]
@@ -53,7 +50,7 @@ public class CompanyDataControllerTests
     {
         // Arrange
         var companyAddressDetailData = _fixture.Create<CompanyAddressDetailData>();
-        A.CallTo(() => _logic.GetCompanyDetailsAsync(A<Guid>._))
+        A.CallTo(() => _logic.GetCompanyDetailsAsync())
             .Returns(companyAddressDetailData);
 
         // Act
@@ -61,7 +58,7 @@ public class CompanyDataControllerTests
 
         // Assert
         result.Should().BeOfType<CompanyAddressDetailData>();
-        A.CallTo(() => _logic.GetCompanyDetailsAsync(_identity.CompanyId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetCompanyDetailsAsync()).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -69,14 +66,14 @@ public class CompanyDataControllerTests
     {
         // Arrange
         var companyRoleConsentDatas = _fixture.CreateMany<CompanyAssignedUseCaseData>(2).ToAsyncEnumerable();
-        A.CallTo(() => _logic.GetCompanyAssigendUseCaseDetailsAsync(A<Guid>._))
+        A.CallTo(() => _logic.GetCompanyAssigendUseCaseDetailsAsync())
             .Returns(companyRoleConsentDatas);
 
         // Act
         await this._controller.GetCompanyAssigendUseCaseDetailsAsync().ToListAsync();
 
         // Assert
-        A.CallTo(() => _logic.GetCompanyAssigendUseCaseDetailsAsync(_identity.CompanyId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetCompanyAssigendUseCaseDetailsAsync()).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -84,14 +81,14 @@ public class CompanyDataControllerTests
     {
         // Arrange
         var useCaseData = _fixture.Create<UseCaseIdDetails>();
-        A.CallTo(() => _logic.CreateCompanyAssignedUseCaseDetailsAsync(A<Guid>._, A<Guid>._))
+        A.CallTo(() => _logic.CreateCompanyAssignedUseCaseDetailsAsync(A<Guid>._))
             .Returns(true);
 
         // Act
         var result = await this._controller.CreateCompanyAssignedUseCaseDetailsAsync(useCaseData).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.CreateCompanyAssignedUseCaseDetailsAsync(_identity.CompanyId, useCaseData.useCaseId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.CreateCompanyAssignedUseCaseDetailsAsync(useCaseData.useCaseId)).MustHaveHappenedOnceExactly();
         result.Should().BeOfType<StatusCodeResult>();
         result.StatusCode.Should().Be((int)HttpStatusCode.Created);
     }
@@ -101,14 +98,14 @@ public class CompanyDataControllerTests
     {
         // Arrange
         var useCaseData = _fixture.Create<UseCaseIdDetails>();
-        A.CallTo(() => _logic.CreateCompanyAssignedUseCaseDetailsAsync(A<Guid>._, A<Guid>._))
+        A.CallTo(() => _logic.CreateCompanyAssignedUseCaseDetailsAsync(A<Guid>._))
             .Returns(false);
 
         // Act
         var result = await this._controller.CreateCompanyAssignedUseCaseDetailsAsync(useCaseData).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.CreateCompanyAssignedUseCaseDetailsAsync(_identity.CompanyId, useCaseData.useCaseId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.CreateCompanyAssignedUseCaseDetailsAsync(useCaseData.useCaseId)).MustHaveHappenedOnceExactly();
         result.Should().BeOfType<NoContentResult>();
         result.StatusCode.Should().Be((int)HttpStatusCode.NoContent);
     }
@@ -123,7 +120,7 @@ public class CompanyDataControllerTests
         var result = await this._controller.RemoveCompanyAssignedUseCaseDetailsAsync(useCaseData).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.RemoveCompanyAssignedUseCaseDetailsAsync(_identity.CompanyId, useCaseData.useCaseId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.RemoveCompanyAssignedUseCaseDetailsAsync(useCaseData.useCaseId)).MustHaveHappenedOnceExactly();
         result.Should().BeOfType<NoContentResult>();
     }
 
@@ -133,14 +130,14 @@ public class CompanyDataControllerTests
         // Arrange
         var languageShortName = "en";
         var companyRoleConsentDatas = _fixture.CreateMany<CompanyRoleConsentViewData>(2).ToAsyncEnumerable();
-        A.CallTo(() => _logic.GetCompanyRoleAndConsentAgreementDetailsAsync(A<Guid>._, A<string>._))
+        A.CallTo(() => _logic.GetCompanyRoleAndConsentAgreementDetailsAsync(A<string>._))
             .Returns(companyRoleConsentDatas);
 
         // Act
         await this._controller.GetCompanyRoleAndConsentAgreementDetailsAsync(languageShortName).ToListAsync().ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.GetCompanyRoleAndConsentAgreementDetailsAsync(_identity.CompanyId, languageShortName)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetCompanyRoleAndConsentAgreementDetailsAsync(languageShortName)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -153,7 +150,7 @@ public class CompanyDataControllerTests
         var result = await this._controller.CreateCompanyRoleAndConsentAgreementDetailsAsync(companyRoleConsentDetails).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.CreateCompanyRoleAndConsentAgreementDetailsAsync(new(_identity.UserId, _identity.CompanyId), companyRoleConsentDetails)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.CreateCompanyRoleAndConsentAgreementDetailsAsync(companyRoleConsentDetails)).MustHaveHappenedOnceExactly();
         result.Should().BeOfType<NoContentResult>();
     }
 
@@ -161,14 +158,14 @@ public class CompanyDataControllerTests
     public async Task GetUseCaseParticipation_WithValidRequest_ReturnsExpected()
     {
         // Arrange
-        A.CallTo(() => _logic.GetUseCaseParticipationAsync(_identity.CompanyId, null))
+        A.CallTo(() => _logic.GetUseCaseParticipationAsync(null))
             .Returns(_fixture.CreateMany<UseCaseParticipationData>(5));
 
         // Act
         var result = await _controller.GetUseCaseParticipation(null).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.GetUseCaseParticipationAsync(_identity.CompanyId, null)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetUseCaseParticipationAsync(null)).MustHaveHappenedOnceExactly();
         result.Should().HaveCount(5);
     }
 
@@ -176,14 +173,14 @@ public class CompanyDataControllerTests
     public async Task GetUseCaseParticipation_WithLanguageExplicitlySet_ReturnsExpected()
     {
         // Arrange
-        A.CallTo(() => _logic.GetUseCaseParticipationAsync(_identity.CompanyId, "de"))
+        A.CallTo(() => _logic.GetUseCaseParticipationAsync("de"))
             .Returns(_fixture.CreateMany<UseCaseParticipationData>(5));
 
         // Act
         var result = await _controller.GetUseCaseParticipation("de").ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.GetUseCaseParticipationAsync(_identity.CompanyId, "de")).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetUseCaseParticipationAsync("de")).MustHaveHappenedOnceExactly();
         result.Should().HaveCount(5);
     }
 
@@ -191,14 +188,14 @@ public class CompanyDataControllerTests
     public async Task GetSsiCertificationData_WithValidData_ReturnsExpected()
     {
         // Arrange
-        A.CallTo(() => _logic.GetSsiCertificatesAsync(_identity.CompanyId))
+        A.CallTo(() => _logic.GetSsiCertificatesAsync())
             .Returns(_fixture.CreateMany<SsiCertificateData>(5));
 
         // Act
         var result = await _controller.GetSsiCertificationData().ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.GetSsiCertificatesAsync(_identity.CompanyId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetSsiCertificatesAsync()).MustHaveHappenedOnceExactly();
         result.Should().HaveCount(5);
     }
 
@@ -213,7 +210,7 @@ public class CompanyDataControllerTests
         await _controller.CreateUseCaseParticipation(data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.CreateUseCaseParticipation(A<ValueTuple<Guid, Guid>>.That.Matches(x => x.Item1 == _identity.UserId && x.Item2 == _identity.CompanyId), data, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.CreateUseCaseParticipation(data, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -227,7 +224,7 @@ public class CompanyDataControllerTests
         await _controller.CreateSsiCertificate(data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.CreateSsiCertificate(A<ValueTuple<Guid, Guid>>.That.Matches(x => x.Item1 == _identity.UserId && x.Item2 == _identity.CompanyId), data, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.CreateSsiCertificate(data, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -240,7 +237,7 @@ public class CompanyDataControllerTests
         await _controller.ApproveCredential(credentialId, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.ApproveCredential(_identity.UserId, credentialId, A<CancellationToken>._))
+        A.CallTo(() => _logic.ApproveCredential(credentialId, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -254,7 +251,7 @@ public class CompanyDataControllerTests
         await _controller.RejectCredential(credentialId).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _logic.RejectCredential(_identity.UserId, credentialId))
+        A.CallTo(() => _logic.RejectCredential(credentialId))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanySsiDetailsRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanySsiDetailsRepositoryTests.cs
@@ -83,13 +83,15 @@ public class CompanySsiDetailsRepositoryTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Count.Should().Be(5);
-        result.Should().HaveCount(5);
-        result.Where(x => x.CompanyId == _validCompanyId).Should().HaveCount(4)
+        result.Count.Should().Be(7);
+        result.Should().HaveCount(7);
+        result.Where(x => x.CompanyId == _validCompanyId).Should().HaveCount(6)
             .And.Satisfy(
                 x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.PENDING,
                 x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.PCF_FRAMEWORK && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.PENDING,
                 x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.PENDING,
+                x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.INACTIVE,
+                x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.INACTIVE,
                 x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.BEHAVIOR_TWIN_FRAMEWORK && x.CompanySsiDetailStatusId == CompanySsiDetailStatusId.INACTIVE);
         result.Where(x => x.CompanyId == new Guid("3390c2d7-75c1-4169-aa27-6ce00e1f3cdd")).Should().ContainSingle()
             .And.Satisfy(x => x.VerifiedCredentialTypeId == VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK);
@@ -161,9 +163,9 @@ public class CompanySsiDetailsRepositoryTests
         result.Should().ContainSingle()
             .Which.Should().Match<Models.SsiCertificateTransferData>(x =>
                 x.CredentialType == VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE &&
-                x.SsiDetailData != null &&
-                x.SsiDetailData.Count() == 1 &&
-                x.SsiDetailData.Single().ParticipationStatus == CompanySsiDetailStatusId.PENDING);
+                x.SsiDetailData.Count() == 3 &&
+                x.SsiDetailData.Count(x => x.ParticipationStatus == CompanySsiDetailStatusId.PENDING) == 1 &&
+                x.SsiDetailData.Count(x => x.ParticipationStatus == CompanySsiDetailStatusId.INACTIVE) == 2);
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_ssi_details.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_ssi_details.test.json
@@ -52,5 +52,25 @@
     "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020006",
     "date_created": "2023-06-01 00:00:00.000000 +00:00",
     "verified_credential_external_type_use_case_detail_id": "1268a76a-ca19-4dd8-b932-01f24071d562"
+  },
+  {
+    "id": "9f5b9934-4014-4099-91e9-7b1aee696b08",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "verified_credential_type_id": 4,
+    "company_ssi_detail_status_id": 3,
+    "document_id": "9685f744-9d90-4102-a949-fcd0bb86f954",
+    "expiry_date": null,
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020006",
+    "date_created": "2023-06-01 00:00:00.000000 +00:00"
+  },
+  {
+    "id": "9f5b9934-4014-4099-91e9-7b1aee696b09",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "verified_credential_type_id": 4,
+    "company_ssi_detail_status_id": 3,
+    "document_id": "88793f9f-c5a4-4621-847b-3d47cd839283",
+    "expiry_date": null,
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020006",
+    "date_created": "2023-06-01 00:00:00.000000 +00:00"
   }
 ]


### PR DESCRIPTION
## Description

fix Get: api/administration/companydata/certificates when multiple certificates are in the database for a specific company introduce IIdentityService to CompanyDataController

## Why

currently an error is thrown if more than one certificate is in the database for a specific company when executing the Get: api/administration/companydata/certificates endpoint

## Issue

N/A - Jira Issue: CPLP-3124

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
