### PR TITLE
fix(ssi): adjust external type value

### DIFF
--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/VerifiedCredentialExternalTypeId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/VerifiedCredentialExternalTypeId.cs
@@ -16,6 +16,6 @@ public enum VerifiedCredentialExternalTypeId
     [EnumMember(Value = "vehicleDismantle")]
     VEHICLE_DISMANTLE = 4,
 
-    [EnumMember(Value = "Sustainability_Credential")]
+    [EnumMember(Value = "SustainabilityCredential")]
     SUSTAINABILITY_CREDENTIAL = 5,
 }


### PR DESCRIPTION
## Description

Adjust the VerifiedCredentialExternalTypeId for Sustainability Credential

## Why

currently the wrong value is send to the external service

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
