### PR TITLE
chore(sa): adjust naming of service account for process worker

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
@@ -65,10 +65,10 @@
   },
   {
     "id": "d21d2e8a-fe35-483c-b2b8-4100ed7f0953",
-    "name": "sa-cl2-04",
+    "name": "system-internal",
     "description": "Technical User for Portal ProccessWorker",
     "company_service_account_type_id": 2,
     "client_id": "c5709899-0415-4385-be80-76d2bfd31724",
-    "client_client_id": "sa-cl2-04"
+    "client_client_id": "system-internal"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -282,8 +282,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null)(0, 10).ConfigureAwait(false);
 
         // Assert
-        result!.Count.Should().Be(9);
-        result.Data.Should().HaveCount(9);
+        result!.Count.Should().Be(8);
+        result.Data.Should().HaveCount(8);
     }
 
     #endregion


### PR DESCRIPTION
## Description

Adjust naming for the technical user which is used to run the process worker to system-internal

## Why

To not get confused with same naming schema for the technical user

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
