### PR TITLE
fix(auth): change bearer check to case insensitive

### DIFF
--- a/src/keycloak/Keycloak.Authentication/ControllerExtensions.cs
+++ b/src/keycloak/Keycloak.Authentication/ControllerExtensions.cs
@@ -62,7 +62,7 @@ public static class ControllerExtensions
     private static string GetBearerToken(this ControllerBase controller)
     {
         var authorization = controller.Request.Headers.Authorization.FirstOrDefault();
-        if (authorization == null || !authorization.StartsWith("Bearer "))
+        if (authorization == null || !authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
         {
             throw new ControllerArgumentException("Request does not contain a Bearer-token in authorization-header",
                 nameof(authorization));


### PR DESCRIPTION
## Description

Changed the bearer check to get the access token for the user to case insensitive check

## Why

When requesting the API with an lowercase bearer Authorization header the endpoint throws an error.

## Issue

N/A - Jira Issue: CPLP-3131

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
