### PR TITLE
fix(serviceaccount): get owncompany serviceaccount

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -153,8 +153,8 @@ public class ServiceAccountRepository : IServiceAccountRepository
             _dbContext.CompanyServiceAccounts
                 .AsNoTracking()
                 .Where(serviceAccount =>
-                    serviceAccount.Identity!.CompanyId == userCompanyId &&
-                    serviceAccount.Identity.UserStatusId == UserStatusId.ACTIVE &&
+                    (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) &&
+                    serviceAccount.Identity!.UserStatusId == UserStatusId.ACTIVE &&
                     (!isOwner.HasValue || (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == null) || (!isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider != null)) &&
                     (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
                 .GroupBy(serviceAccount => serviceAccount.Identity!.CompanyId),

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -153,11 +153,11 @@ public class ServiceAccountRepository : IServiceAccountRepository
             _dbContext.CompanyServiceAccounts
                 .AsNoTracking()
                 .Where(serviceAccount =>
-                    (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) &&
+                    (!isOwner.HasValue && (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) ||
+                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId)) &&
                     serviceAccount.Identity!.UserStatusId == UserStatusId.ACTIVE &&
-                    (!isOwner.HasValue || (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == null) || (!isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider != null)) &&
                     (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
-                .GroupBy(serviceAccount => serviceAccount.Identity!.CompanyId),
+                .GroupBy(serviceAccount => serviceAccount.Identity!.UserStatusId),
             serviceAccounts => serviceAccounts.OrderBy(serviceAccount => serviceAccount.Name),
             serviceAccount => new CompanyServiceAccountData(
                 serviceAccount.Id,

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferRepositoryTests.cs
@@ -136,14 +136,15 @@ public class OfferRepositoryTests : IAssemblyFixture<TestDbFixture>
         var offers = await sut.GetAllActiveAppsAsync(null!, Constants.DefaultLanguage).ToListAsync().ConfigureAwait(false);
 
         // Assert
-        offers.Should().HaveCount(7).And.Satisfy(
+        offers.Should().HaveCount(8).And.Satisfy(
             x => x.Name == "Test App",
             x => x.Name == "Test App 3",
             x => x.Name == "Trace-X",
             x => x.Name == "Project Implementation: Earth Commerce",
             x => x.Name == "Top App",
             x => x.Name == "Test App 1",
-            x => x.Name == "Test App 2"
+            x => x.Name == "Test App 2",
+            x => x.Name == "Test App Tech User"
         );
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionViewTests.cs
@@ -50,7 +50,7 @@ public class OfferSubscriptionViewTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var result = await sut.OfferSubscriptionView.ToListAsync().ConfigureAwait(false);
-        result.Should().HaveCount(12);
+        result.Should().HaveCount(13);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/companies.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/companies.test.json
@@ -58,5 +58,15 @@
     "company_status_id": 2,
     "address_id": "86da3e1c-a634-1234-ad44-988074612999",
     "self_description_document_id": null
+  },
+  {
+    "id": "41fd2ab8-71cd-4546-9bef-a388d91b2543",
+    "date_created": "2022-03-24 18:01:33.438000 +00:00",
+    "business_partner_number": "BPNL00000003LLHN",
+    "name": "Security Companies",
+    "shortname": "Security Companirs",
+    "company_status_id": 1,
+    "address_id": "86da3e1c-a634-41a6-ad44-9880746123e4",
+    "self_description_document_id": null
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -31,5 +31,15 @@
     "company_service_account_type_id": 1,
     "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5552",
     "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542"
+  },
+  {
+    "id": "93eecd4e-ca47-4dd2-85bf-775ea72eb009",
+    "name": "test-user-service-accounts",
+    "description": "test-user-service-account-descs",
+    "company_service_account_type_id": 1,
+    "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5562",
+    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2543",
+    "client_client_id": "sa-x-2"
   }
+
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
@@ -126,5 +126,13 @@
     "user_status_id": 1,
     "user_entity_id": null,
     "identity_type_id": 2
+  },
+  {
+    "id": "93eecd4e-ca47-4dd2-85bf-775ea72eb009",
+    "date_created": "2022-06-01 18:01:33.439000 +00:00",
+    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2543",
+    "user_status_id": 1,
+    "user_entity_id": null,
+    "identity_type_id": 2
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offer_subscriptions.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offer_subscriptions.test.json
@@ -109,5 +109,15 @@
     "last_editor_id": null,
     "display_name": null,
     "description": null
+  },
+  {
+    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2543",
+    "offer_id": "19e05734-9b1f-1234-b961-8ffa1d7b6979",
+    "offer_subscription_status_id": 1,
+    "requester_id": "ac1cf001-7fbc-1f2f-817f-bce0575a0011",
+    "id": "0b2ca541-206d-48ad-bc02-fb61fbcb5562",
+    "last_editor_id": null,
+    "display_name": null,
+    "description": null
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offers.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offers.test.json
@@ -253,5 +253,22 @@
     "offer_type_id": 1,
     "last_editor_id": null,
     "license_type_id":1
+  },
+  {
+    "id": "19e05734-9b1f-1234-b961-8ffa1d7b6979",
+    "name": "Test App Tech User",
+    "date_created": "2022-10-01 00:00:00.000000 +00:00",
+    "date_released": "2022-10-01 00:00:00.000005 +00:00",
+    "marketing_url": null,
+    "contact_email": null,
+    "contact_number": null,
+    "provider": "Test Company Tech",
+    "provider_company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2543",
+    "offer_status_id": 3,
+    "date_last_changed": "2022-10-01 00:00:00.000000 +00:00",
+    "sales_manager_id": "ac1cf001-7fbc-1f2f-817f-bce058020005",
+    "offer_type_id": 1,
+    "last_editor_id": null,
+    "license_type_id":1
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -212,18 +212,18 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
     public async Task GetOwnCompanyServiceAccountsUntracked_ReturnsExpectedResult(int count, int page, int size, int expected)
     {
         // Arrange
+        var newvalidCompanyId = new Guid("41fd2ab8-71cd-4546-9bef-a388d91b2542");
         var (sut, _) = await CreateSut().ConfigureAwait(false);
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, null)(page, size).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(newvalidCompanyId, null, null)(page, size).ConfigureAwait(false);
 
         // Assert
         result.Should().NotBeNull();
-        result!.Count.Should().Be(count);
-        result.Data.Should().HaveCount(expected);
+        result!.Count.Should().Be(3);
         if (expected > 0)
         {
-            result.Data.First().CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN);
-            result.Data.First().IsOwner.Should().BeTrue();
+            result.Data.First().CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.MANAGED);
+            result.Data.First().IsOwner.Should().BeFalse();
         }
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -250,7 +250,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new("41fd2ab8-71cd-4546-9bef-a388d91b2542"), "sa-x-1", false)(0, 10).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new("41fd2ab8-71cd-4546-9bef-a388d91b2543"), "sa-x-2", false)(0, 10).ConfigureAwait(false);
 
         // Assert
         result!.Count.Should().Be(1);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -207,8 +207,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
     #region GetOwnCompanyServiceAccountDetailedDataUntrackedAsync
 
     [Theory]
-    [InlineData(10, 0, 10, 10)]
-    [InlineData(10, 1, 9, 9)]
+    [InlineData(3, 0, 10, 3)]
+    [InlineData(3, 1, 9, 2)]
     public async Task GetOwnCompanyServiceAccountsUntracked_ReturnsExpectedResult(int count, int page, int size, int expected)
     {
         // Arrange

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -219,7 +219,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result!.Count.Should().Be(3);
+        result!.Count.Should().Be(count);
+        result.Data.Should().HaveCount(expected);
         if (expected > 0)
         {
             result.Data.First().CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.MANAGED);


### PR DESCRIPTION
## Description

Added provider and owner instead of identity companyid in query
## Why

Response was returning serviceaccounts only for logged in user company not for provider and owner.

## Issue

CPLP-3113.

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
