### PR TITLE
fix(appRelease) : fixed validation of offerStatus

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -500,8 +500,8 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
         if (!result.IsUserOfProvidingCompany)
             throw new ForbiddenException($"Company {companyId} is not the provider company");
 
-        if (result.OfferStatus is not (OfferStatusId.CREATED or OfferStatusId.IN_REVIEW))
-            throw new ConflictException($"App {appId} is not in Status {OfferStatusId.CREATED} or {OfferStatusId.IN_REVIEW}");
+        if (result.OfferStatus is not OfferStatusId.CREATED)
+            throw new ConflictException($"App {appId} is not in Status {OfferStatusId.CREATED}");
 
         await (result.SetupTransferData == null
             ? HandleAppInstanceCreation(appId, data)

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -896,7 +896,7 @@ public class AppReleaseBusinessLogicTest
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be($"App {appId} is not in Status {OfferStatusId.CREATED} or {OfferStatusId.IN_REVIEW}");
+        ex.Message.Should().Be($"App {appId} is not in Status {OfferStatusId.CREATED}");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

fixed validation of offerStatus

## Why

For Instance-type endpoint , it did not validate for IN_REVIEW offerStatus. now it is fixed

## Issue

[CPLP-3043](https://jira.catena-x.net/browse/CPLP-3043)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
