### PR TITLE
fix(seeding): change client_id of service accounts

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
@@ -117,6 +117,16 @@ public class BatchUpdateSeeder : ICustomSeeder
                 dbEntry.ValidFrom = entry.ValidFrom;
             }, cancellationToken).ConfigureAwait(false);
 
+        await SeedTable<CompanyServiceAccount>("company_service_accounts",
+            x => x.Id,
+            x => x.dataEntity.Description != x.dbEntity.Description || x.dataEntity.Name != x.dbEntity.Name || x.dataEntity.ClientId != x.dbEntity.ClientId,
+            (dbEntry, entry) =>
+            {
+                dbEntry.Description = entry.Description;
+                dbEntry.Name = entry.Name;
+                dbEntry.ClientId = entry.ClientId;
+            }, cancellationToken).ConfigureAwait(false);
+
         await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("Finished BaseEntityBatch Seeder");
     }

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
@@ -58,7 +58,7 @@
   {
     "id": "d21d2e8a-fe35-483c-b2b8-4100ed7f0953",
     "name": "system-internal",
-    "description": "Technical User for Portal ProccessWorker",
+    "description": "Technical User for Portal ProcessWorker",
     "company_service_account_type_id": 2,
     "client_id": "c5709899-0415-4385-be80-76d2bfd31724",
     "client_client_id": "system-internal"

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
@@ -62,5 +62,37 @@
     "company_service_account_type_id": 2,
     "client_id": "c5709899-0415-4385-be80-76d2bfd31724",
     "client_client_id": "system-internal"
+  },
+  {
+    "id": "7e85a0b8-0001-ab67-10d1-0ef508201029",
+    "name": "sa-cl1-reg-2",
+    "description": "Technical User for Portal-Backend to call Keycloak",
+    "company_service_account_type_id": 2,
+    "client_id": "cdf11dff-530a-4fd4-97b9-84e4d60ac21e",
+    "client_client_id": "sa-cl1-reg-2"
+  },
+  {
+    "id": "7e85a0b8-0001-ab67-10d1-0ef508201030",
+    "name": "sa-cl2-03",
+    "description": "Technical User AutoSetup trigger",
+    "company_service_account_type_id": 2,
+    "client_id": "cad1382b-0dd4-4ac7-8183-1c08386c84e8",
+    "client_client_id": "sa-cl2-03"
+  },
+  {
+    "id": "7e85a0b8-0001-ab67-10d1-0ef508201031",
+    "name": "sa-cl21-01",
+    "description": "Technical User Discovery Finder",
+    "company_service_account_type_id": 2,
+    "client_id": "b09392dd-8b0f-4a32-bb0b-d00a4091b890",
+    "client_client_id": "sa-cl21-01"
+  },
+  {
+    "id": "7e85a0b8-0001-ab67-10d1-0ef508201032",
+    "name": "sa-cl22-01",
+    "description": "Technical User BPN Discovery",
+    "company_service_account_type_id": 2,
+    "client_id": "f1806543-d0ca-41cb-b029-883cdfb11a8e",
+    "client_client_id": "sa-cl22-01"
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
@@ -32,14 +32,6 @@
     "client_client_id": "sa-cl7-cx-5"
   },
   {
-    "id": "7e85a0b8-0001-ab67-10d1-0ef508201025",
-    "name": "sa-cl6-cx-01",
-    "description": "Technical user for portal to call the daps registration as part of the connector registration service",
-    "company_service_account_type_id": 2,
-    "client_id": "7e85a0b8-0001-ab67-10d1-000000001025",
-    "client_client_id": "sa-cl6-cx-01"
-  },
-  {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201026",
     "name": "sa-cl2-01",
     "description": "Technical User GX-Clearinghouse to enable th CH to POST company application VC creation result",

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
@@ -4,7 +4,7 @@
     "name": "Service Account 01",
     "description": "Technical User for SD Hub Call to Custodian for SD signature",
     "company_service_account_type_id": 2,
-    "client_id": "7e85a0b8-0001-ab67-10d1-000000001006",
+    "client_id": "dab9dd17-0d31-46c7-b313-aca61225dcd1",
     "client_client_id": "sa-cl5-custodian-1"
   },
   {
@@ -12,7 +12,7 @@
     "name": "Service Account 02",
     "description": "Technical User for Portal to call Custodian Wallet",
     "company_service_account_type_id": 2,
-    "client_id": "7e85a0b8-0001-ab67-10d1-000000001007",
+    "client_id": "50fa6455-a775-4683-b407-57a33a9b9f3b",
     "client_client_id": "sa-cl5-custodian-2"
   },
   {
@@ -20,7 +20,7 @@
     "name": "sa-cl3-cx-1",
     "description": "Semantic Hub",
     "company_service_account_type_id": 2,
-    "client_id": "7e85a0b8-0001-ab67-10d1-000000001023",
+    "client_id": "7beaee76-d447-4531-9433-fd9ce19d1460",
     "client_client_id": "sa-cl3-cx-1"
   },
   {
@@ -28,7 +28,7 @@
     "name": "sa-cl7-cx-5",
     "description": "User for Portal to access BPDM for Company Address publishing into the BPDM",
     "company_service_account_type_id": 2,
-    "client_id": "7e85a0b8-0001-ab67-10d1-000000001024",
+    "client_id": "183aae87-c9cf-4d70-934b-629aa6974c54",
     "client_client_id": "sa-cl7-cx-5"
   },
   {
@@ -44,7 +44,7 @@
     "name": "sa-cl2-01",
     "description": "Technical User GX-Clearinghouse to enable th CH to POST company application VC creation result",
     "company_service_account_type_id": 2,
-    "client_id": "7e85a0b8-0001-ab67-10d1-000000001026",
+    "client_id": "6bf6f4e5-562c-4382-945f-e5fef59423e2",
     "client_client_id": "sa-cl2-01"
   },
   {
@@ -52,7 +52,7 @@
     "name": "sa-cl2-02",
     "description": "Technical User GX-Clearinghouse to enable th CH to POST Self-Description (SD) for LP and SO",
     "company_service_account_type_id": 2,
-    "client_id": "7e85a0b8-0001-ab67-10d1-000000001027",
+    "client_id": "2d19b59b-4970-4cc0-a561-a9dac9d49045",
     "client_client_id": "sa-cl2-02"
   },
   {
@@ -60,7 +60,7 @@
     "name": "sa-cl8-cx-1",
     "description": "Technical User created for the portal to call the self-description factory for SD creation LP and SO",
     "company_service_account_type_id": 2,
-    "client_id": "7e85a0b8-0001-ab67-10d1-000000001028",
+    "client_id": "c2bdc736-ca35-43c4-8e18-27e7425df9f0",
     "client_client_id": "sa-cl8-cx-1"
   },
   {

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
@@ -80,5 +80,37 @@
     "user_status_id": 1,
     "user_entity_id": "090c9121-7380-4bb0-bb10-fffd344f930a",
     "identity_type_id": 2
+  },
+  {
+    "id": "7e85a0b8-0001-ab67-10d1-0ef508201029",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "date_created": "2023-01-01 18:01:33.439000 +00:00",
+    "user_status_id": 1,
+    "user_entity_id": "e69c1397-eee8-434a-b83b-dc7944bb9bdd",
+    "identity_type_id": 2
+  },
+  {
+    "id": "7e85a0b8-0001-ab67-10d1-0ef508201030",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "date_created": "2023-01-01 18:01:33.439000 +00:00",
+    "user_status_id": 1,
+    "user_entity_id": "a0bbb8fa-cc40-44e3-828d-342e782fd284",
+    "identity_type_id": 2
+  },
+  {
+    "id": "7e85a0b8-0001-ab67-10d1-0ef508201031",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "date_created": "2023-01-01 18:01:33.439000 +00:00",
+    "user_status_id": 1,
+    "user_entity_id": "319d6b7f-bd88-4103-8124-e8ac4c791acf",
+    "identity_type_id": 2
+  },
+  {
+    "id": "7e85a0b8-0001-ab67-10d1-0ef508201032",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "date_created": "2023-01-01 18:01:33.439000 +00:00",
+    "user_status_id": 1,
+    "user_entity_id": "b52bd8e5-98ce-48b4-af43-0b43b45d0358",
+    "identity_type_id": 2
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
@@ -42,14 +42,6 @@
     "identity_type_id": 2
   },
   {
-    "id": "7e85a0b8-0001-ab67-10d1-0ef508201025",
-    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
-    "date_created": "2022-06-01 18:01:33.439000 +00:00",
-    "user_status_id": 1,
-    "user_entity_id": "50dfc73d-e0a1-4992-be95-75def1dadbfa",
-    "identity_type_id": 2
-  },
-  {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201026",
     "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
     "date_created": "2023-01-01 18:01:33.439000 +00:00",

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -283,8 +283,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null)(0, 10).ConfigureAwait(false);
 
         // Assert
-        result!.Count.Should().Be(7);
-        result.Data.Should().HaveCount(7);
+        result!.Count.Should().Be(11);
+        result.Data.Should().HaveCount(10);
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -127,7 +127,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBe(default);
-        result!.ClientId.Should().Be("7e85a0b8-0001-ab67-10d1-000000001006");
+        result!.ClientId.Should().Be("dab9dd17-0d31-46c7-b313-aca61225dcd1");
     }
 
     [Fact]
@@ -283,8 +283,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null)(0, 10).ConfigureAwait(false);
 
         // Assert
-        result!.Count.Should().Be(8);
-        result.Data.Should().HaveCount(8);
+        result!.Count.Should().Be(7);
+        result.Data.Should().HaveCount(7);
     }
 
     #endregion


### PR DESCRIPTION
## Description

- change client_id of service accounts in seeding data
sa-cl5-custodian-1 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L4366C14-L4366C50
sa-cl5-custodian-2 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L4486
sa-cl3-cx-1 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L4242C14-L4242C50
sa-cl7-cx-5 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L4606C14-L4606C50
sa-cl2-01 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L3681C14-L3681C50
sa-cl2-02 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L3789C14-L3789C50
sa-cl8-cx-1 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L4714C14-L4714C50
- add service accounts from cx-central base
service accounts that were not yet added to portal seeding but are part of cx-central realm base setup of keycloak:
sa-cl1-reg-2 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L3571
sa-cl2-03 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L3897C14-L3897C50
sa-cl21-01 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L4002
sa-cl22-01 https://github.com/eclipse-tractusx/portal-iam/blob/chores-3.2-release/import/realm-config/generic/catenax-central/CX-Central-realm.json#L4122

- remove service account for daps

## Why

align client_id of service accounts with id of client in cx-central realm of centralidp keycloak instance

## Issue

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally