### PR TITLE
fix(bpdm): add errormessage for bpdm fetch

### DIFF
--- a/src/externalsystems/Bpdm.Library/IBpdmService.cs
+++ b/src/externalsystems/Bpdm.Library/IBpdmService.cs
@@ -35,4 +35,5 @@ public interface IBpdmService
     /// <returns>Returns <c>true</c> if the service call was successful, otherwise <c>false</c></returns>
     Task<bool> PutInputLegalEntity(BpdmTransferData data, CancellationToken cancellationToken);
     Task<BpdmLegalEntityOutputData> FetchInputLegalEntity(string externalId, CancellationToken cancellationToken);
+    Task<BpdmSharingState> GetSharingState(Guid applicationId, CancellationToken cancellationToken);
 }

--- a/src/externalsystems/Bpdm.Library/Models/BpdmSharingState.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmSharingState.cs
@@ -1,0 +1,30 @@
+namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Models;
+
+public record BpdmPaginationSharingStateOutput(
+    IEnumerable<BpdmSharingState>? Content
+);
+
+public record BpdmSharingState(
+    BpdmSharingStateBusinessPartnerType BusinessPartnerType,
+    Guid ExternalId,
+    BpdmSharingStateType SharingStateType,
+    string? SharingErrorCode,
+    string? SharingErrorMessage,
+    string? Bpn,
+    DateTimeOffset SharingProcessStarted
+);
+
+public enum BpdmSharingStateType
+{
+    Pending = 1,
+    Success = 2,
+    Error = 3,
+    Initial = 4
+}
+
+public enum BpdmSharingStateBusinessPartnerType
+{
+    LEGAL_ENTITY = 1,
+    SITE = 2,
+    ADDRESS = 3
+}

--- a/tests/externalsystems/Bpdm.Library/BPNAccessTest.cs
+++ b/tests/externalsystems/Bpdm.Library/BPNAccessTest.cs
@@ -25,12 +25,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Tests;
 
 public class BPNAccessTest
 {
-    private readonly IFixture _fixture;
-
-    public BPNAccessTest()
-    {
-        _fixture = new Fixture().Customize(new AutoFakeItEasyCustomization { ConfigureMembers = true });
-    }
+    private readonly IFixture _fixture = new Fixture().Customize(new AutoFakeItEasyCustomization { ConfigureMembers = true });
 
     private void ConfigureHttpClientFactoryFixture(HttpResponseMessage httpResponseMessage, Action<HttpRequestMessage?>? setMessage = null)
     {


### PR DESCRIPTION
## Description

add sharing-state request before pulling the bpn from bpdm service

## Why

To be able to display the error message from bpdm we first request the sharing-state endpoint to get the state of the bpn creation, if an error happend we're saving the error inside the process step and application checklist entry.

## Issue

N/A - Jira Issue: CPLP-3160

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
