### PR TITLE
fix(seeding): make TestDataEnvironments in the seeder settings optional

### DIFF
--- a/src/framework/Framework.Seeding/SeederSettings.cs
+++ b/src/framework/Framework.Seeding/SeederSettings.cs
@@ -27,23 +27,16 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding;
 
 public class SeederSettings
 {
-    public SeederSettings()
-    {
-        TestDataEnvironments = null!;
-        DataPaths = null!;
-    }
-
     /// <summary>
     /// Configurable paths where to check for the seeding data
     /// </summary>
     [Required]
-    public IEnumerable<string> DataPaths { get; set; }
+    public IEnumerable<string> DataPaths { get; set; } = null!;
 
     /// <summary>
     /// Configurable environments for the testdata
     /// </summary>
-    [Required]
-    public IEnumerable<string> TestDataEnvironments { get; set; }
+    public IEnumerable<string>? TestDataEnvironments { get; set; }
 }
 
 public static class SeederSettingsExtensions

--- a/src/portalbackend/PortalBackend.Migrations/PortalBackend.Migrations.csproj
+++ b/src/portalbackend/PortalBackend.Migrations/PortalBackend.Migrations.csproj
@@ -20,6 +20,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations</AssemblyName>
+    <RootNamespace>Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -30,7 +31,6 @@
     <OutputType>Exe</OutputType>
     <!-- Exclude the project from analysis -->
     <SonarQubeExclude>true</SonarQubeExclude>
-    <RootNamespace>Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Laraue.EfCoreTriggers.PostgreSql" Version="6.3.6" />
@@ -51,27 +51,19 @@
     <ProjectReference Include="..\PortalBackend.PortalEntities\PortalBackend.PortalEntities.csproj" />
     <ProjectReference Include="..\..\framework\Framework.BaseDependencies\Framework.BaseDependencies.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Update="secrets\appsettings.json">
+    <None Remove="appsettings.json" />
+    <Content Include="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Remove="efbundle.exe" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Update="appsettings.json">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
+    
     <None Remove="Seeder\Data" />
     <Content Include="Seeder\Data\**" LinkBase="Seeder\Data" CopyToOutputDirectory="Always" />
-    <Content Update="Seeder\Data\verified_credential_external_type_use_case_detail_versions.consortia.json">
-      <LinkBase>Seeder\Data\</LinkBase>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
+
     <Folder Include="Migrations" />
   </ItemGroup>
+
   <ItemGroup>
     <Content Include="../../../LICENSE">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchInsertSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchInsertSeeder.cs
@@ -151,7 +151,8 @@ public class BatchInsertSeeder : ICustomSeeder
     private async Task SeedTable<T>(string fileName, Func<T, object> keySelector, CancellationToken cancellationToken) where T : class
     {
         _logger.LogInformation("Start seeding {Filename}", fileName);
-        var data = await SeederHelper.GetSeedData<T>(_logger, fileName, _settings.DataPaths, cancellationToken, _settings.TestDataEnvironments.ToArray()).ConfigureAwait(false);
+        var additionalEnvironments = _settings.TestDataEnvironments ?? Enumerable.Empty<string>();
+        var data = await SeederHelper.GetSeedData<T>(_logger, fileName, _settings.DataPaths, cancellationToken, additionalEnvironments.ToArray()).ConfigureAwait(false);
         _logger.LogInformation("Found {ElementCount} data", data.Count);
         if (data.Any())
         {

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
@@ -134,7 +134,8 @@ public class BatchUpdateSeeder : ICustomSeeder
     private async Task SeedTable<T>(string fileName, Func<T, object> keySelector, Func<(T dataEntity, T dbEntity), bool> whereClause, Action<T, T> updateEntries, CancellationToken cancellationToken) where T : class
     {
         _logger.LogInformation("Start seeding {Filename}", fileName);
-        var data = await SeederHelper.GetSeedData<T>(_logger, fileName, _settings.DataPaths, cancellationToken, _settings.TestDataEnvironments.ToArray()).ConfigureAwait(false);
+        var additionalEnvironments = _settings.TestDataEnvironments ?? Enumerable.Empty<string>();
+        var data = await SeederHelper.GetSeedData<T>(_logger, fileName, _settings.DataPaths, cancellationToken, additionalEnvironments.ToArray()).ConfigureAwait(false);
         _logger.LogInformation("Found {ElementCount} data", data.Count);
         if (data.Any())
         {

--- a/src/portalbackend/PortalBackend.Migrations/appsettings.json
+++ b/src/portalbackend/PortalBackend.Migrations/appsettings.json
@@ -28,14 +28,16 @@
     "PortalDb": "Server=placeholder;Database=placeholder;Port=5432;User Id=placeholder;Password=placeholder;Ssl Mode=Disable;"
   },
   "DeleteIntervalInDays": 80,
-  "Seeding":{
-    "DataPaths":[],
+  "Seeding": {
+    "DataPaths": [
+      "Seeder/Data"
+    ],
     "TestDataEnvironments": []
   },
   "ProcessIdentity": {
-    "UserEntityId": "",
-    "ProcessUserId": "",
-    "IdentityTypeId": 0,
-    "ProcessUserCompanyId": ""
+    "UserEntityId": "090c9121-7380-4bb0-bb10-fffd344f930a",
+    "ProcessUserId": "d21d2e8a-fe35-483c-b2b8-4100ed7f0953",
+    "IdentityTypeId": 2,
+    "ProcessUserCompanyId": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"
   }
 }

--- a/src/provisioning/Provisioning.Migrations/Provisioning.Migrations.csproj
+++ b/src/provisioning/Provisioning.Migrations/Provisioning.Migrations.csproj
@@ -56,9 +56,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="secrets\appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Remove="appsettings.json" />
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Remove="efbundle.exe" />
   </ItemGroup>
 

--- a/src/provisioning/Provisioning.Migrations/appsettings.json
+++ b/src/provisioning/Provisioning.Migrations/appsettings.json
@@ -27,6 +27,7 @@
     "ProvisioningDb": "Server=placeholder;Database=placeholder;Port=5432;User Id=placeholder;Password=placeholder;Ssl Mode=Disable;"
   },
   "Seeding":{
+    "DataPaths": [],
     "TestDataEnvironments": []
   }
 }


### PR DESCRIPTION
## Description

changed TestDataEnvironments to be optional

## Why

Currently the seeding runs into an error when the TestDataEnvironments are not set

## Issue

N/A

## Corresponding CD PR

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
