### PR TITLE
fix(autosetup): add validation for hash

### DIFF
--- a/src/marketplace/Offers.Library/Service/OfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSetupService.cs
@@ -83,6 +83,11 @@ public class OfferSetupService : IOfferSetupService
     public async Task<OfferAutoSetupResponseData> AutoSetupOfferAsync(OfferAutoSetupData data, IEnumerable<UserRoleConfig> itAdminRoles, (Guid UserId, Guid CompanyId) identity, OfferTypeId offerTypeId, string basePortalAddress, IEnumerable<UserRoleConfig> serviceManagerRoles)
     {
         _logger.LogDebug("AutoSetup started from Company {CompanyId} for {RequestId} with OfferUrl: {OfferUrl}", identity.CompanyId, data.RequestId, data.OfferUrl);
+        if (data.OfferUrl.Contains('#', StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ControllerArgumentException($"OfferUrl {data.OfferUrl} must not contain #");
+        }
+
         var offerSubscriptionsRepository = _portalRepositories.GetInstance<IOfferSubscriptionsRepository>();
         var offerDetails = await GetAndValidateOfferDetails(data.RequestId, identity.CompanyId, offerTypeId, offerSubscriptionsRepository).ConfigureAwait(false);
 
@@ -391,6 +396,11 @@ public class OfferSetupService : IOfferSetupService
     public async Task StartAutoSetupAsync(OfferAutoSetupData data, Guid companyId, OfferTypeId offerTypeId)
     {
         _logger.LogDebug("AutoSetup Process started from Company {CompanyId} for {RequestId} with OfferUrl: {OfferUrl}", companyId, data.RequestId, data.OfferUrl);
+        if (data.OfferUrl.Contains('#', StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ControllerArgumentException($"OfferUrl {data.OfferUrl} must not contain #");
+        }
+
         var offerSubscriptionRepository = _portalRepositories.GetInstance<IOfferSubscriptionsRepository>();
         var details = await GetAndValidateOfferDetails(data.RequestId, companyId, offerTypeId, offerSubscriptionRepository).ConfigureAwait(false);
         if (details.InstanceData.IsSingleInstance)

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
@@ -286,6 +286,23 @@ public class OfferSetupServiceTests
         ex.Message.Should().Be($"There should only be one or none technical user profile configured for {data.RequestId}");
     }
 
+    [Theory]
+    [InlineData("#")]
+    [InlineData("https://test.com/#/app")]
+    [InlineData("https://test.com/#")]
+    public async Task AutoSetup_WithHasAsUrl_ThrowsException(string url)
+    {
+        // Arrange
+        var data = new OfferAutoSetupData(_pendingSubscriptionId, url);
+
+        // Act
+        async Task Act() => await _sut.AutoSetupOfferAsync(data, Enumerable.Empty<UserRoleConfig>(), (_identity.UserId, _identity.CompanyId), OfferTypeId.APP, "https://base-address.com", Enumerable.Empty<UserRoleConfig>()).ConfigureAwait(false);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+        ex.Message.Should().Be($"OfferUrl {data.OfferUrl} must not contain #");
+    }
+
     [Fact]
     public async Task AutoSetup_WithNoTechnicalUsersRole_ThrowsException()
     {
@@ -660,6 +677,26 @@ public class OfferSetupServiceTests
     #endregion
 
     #region StartAutoSetupAsync
+
+    [Theory]
+    [InlineData(OfferTypeId.APP, "#")]
+    [InlineData(OfferTypeId.SERVICE, "#")]
+    [InlineData(OfferTypeId.APP, "https://test.com/#/app")]
+    [InlineData(OfferTypeId.SERVICE, "https://test.com/#/app")]
+    [InlineData(OfferTypeId.APP, "https://test.com/#")]
+    [InlineData(OfferTypeId.SERVICE, "https://test.com/#")]
+    public async Task StartAutoSetupAsync_WithHasAsUrl_ThrowsException(OfferTypeId offerTypeId, string url)
+    {
+        // Arrange
+        var data = new OfferAutoSetupData(Guid.NewGuid(), url);
+
+        // Act
+        async Task Act() => await _sut.StartAutoSetupAsync(data, _identity.UserId, offerTypeId).ConfigureAwait(false);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+        ex.Message.Should().Be($"OfferUrl {data.OfferUrl} must not contain #");
+    }
 
     [Theory]
     [InlineData(OfferTypeId.APP)]


### PR DESCRIPTION
## Description

adding validation for offerUrl to not contain hash

## Why

keycloak can't handle urls with hashes

## Issue

N/A - Jira Issue: CPLP-1189

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
