### PR TITLE
fix: correction spelling mistake in seeder file

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/agreements.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/agreements.json
@@ -93,7 +93,7 @@
     "date_created": "2022-01-01 00:00:00.388000 +00:00",
     "date_last_changed": "2022-01-01 00:00:00.388000 +00:00",
     "agreement_type": null,
-    "name": "I confirm that my company has successfully received a Catena-X onboarding certificate issued by an official Conformity Assessment Body (CAB). I awknowledge to upload the certificate. For more information visit the association homepage (Link)",
+    "name": "I confirm that my company has successfully received a Catena-X onboarding certificate issued by an official Conformity Assessment Body (CAB). I acknowledge to upload the certificate. For more information visit the association homepage (Link)",
     "issuer_company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
     "use_case_id": "1aacde78-35ec-4df3-ba1e-f988cddcbbd9",
     "document_id": null

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_role_descriptions.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_role_descriptions.json
@@ -27,7 +27,7 @@
   {
     "company_role_id": 3,
     "language_short_name": "en",
-    "description": "The Service Provider is able to offer 3rd party services, such as dataspace service offerings to CX Members. CX members can subscribe for those services."
+    "description": "The Service Provider is able to offer 3rd party services, such as dataspace service offerings to Catena-X Members. Catena-X members can subscribe for those services."
   },
   {
     "company_role_id": 4,

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -493,7 +493,7 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, context) = await CreateSut().ConfigureAwait(false);
         var companyId = new Guid("3390c2d7-75c1-4169-aa27-6ce00e1f3cdd");
         var activeDescription = "The participant role is covering the data provider, data consumer or app user scenario. As participant you are an active member of the network with enabled services to particiapte as contributer and user.";
-        var serviceDscription = "The Service Provider is able to offer 3rd party services, such as dataspace service offerings to CX Members. CX members can subscribe for those services.";
+        var serviceDscription = "The Service Provider is able to offer 3rd party services, such as dataspace service offerings to Catena-X Members. Catena-X members can subscribe for those services.";
         var appDescription = "The App Provider is a company which is providing application software via the CX marketplace. As app provider you can participate and use the developer hub, release and offer applications to the network and manage your applications.";
 
         var result = await sut.GetCompanyRoleAndConsentAgreementDataAsync(companyId, Constants.DefaultLanguage).ToListAsync().ConfigureAwait(false);


### PR DESCRIPTION
Spelling mistake correction in seed data.

## Why

While rendering it should display correct information.

## Issue

CPLP-1177

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
