### PR TITLE
fix(userprovisioning & Service) : namecreatedby null check handled and ServiceChange controller url fixed

### DIFF
--- a/src/marketplace/Services.Service/Controllers/ServiceChangeController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServiceChangeController.cs
@@ -30,7 +30,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.Controllers;
 /// Controller providing actions for updating applications.
 /// </summary>
 
-[Route("api/service/[controller]")]
+[Route("api/services/[controller]")]
 [ApiController]
 [Produces("application/json")]
 [Consumes("application/json")]

--- a/src/provisioning/Provisioning.Library/Service/UserProvisioningService.cs
+++ b/src/provisioning/Provisioning.Library/Service/UserProvisioningService.cs
@@ -190,7 +190,7 @@ public class UserProvisioningService : IUserProvisioningService
             throw new ConflictException($"assertion failed: companyName of company {company.CompanyId} should never be null here");
         }
 
-        var createdByName = CreateNameString(companyUser.FirstName, companyUser.LastName, companyUser.Email, companyUser.CompanyUserId);
+        var createdByName = CreateNameString(companyUser.FirstName, companyUser.LastName, companyUser.Email);
 
         return (new CompanyNameIdpAliasData(company.CompanyId, company.CompanyName, company.BusinessPartnerNumber, identityProvider.IdpAlias, identityProvider.IsSharedIdp), createdByName);
     }
@@ -218,12 +218,12 @@ public class UserProvisioningService : IUserProvisioningService
             throw new ConflictException($"user {companyUserId} is associated with more than one shared idp");
         }
 
-        var createdByName = CreateNameString(companyUser.FirstName, companyUser.LastName, companyUser.Email, companyUser.CompanyUserId);
+        var createdByName = CreateNameString(companyUser.FirstName, companyUser.LastName, companyUser.Email);
 
         return (new CompanyNameIdpAliasData(company.CompanyId, company.CompanyName, company.BusinessPartnerNumber, idpAliase.First(), true), createdByName);
     }
 
-    private static string CreateNameString(string? firstName, string? lastName, string? email, Guid companyUserId)
+    private static string CreateNameString(string? firstName, string? lastName, string? email)
     {
         var sb = new StringBuilder();
         if (firstName != null)
@@ -238,7 +238,7 @@ public class UserProvisioningService : IUserProvisioningService
         {
             sb.AppendFormat((firstName == null && lastName == null) ? "{0}" : " ({0})", email);
         }
-        return firstName == null && lastName == null && email == null ? companyUserId.ToString() : sb.ToString();
+        return firstName == null && lastName == null && email == null ? "Dear User" : sb.ToString();
     }
 
     public Task<string> GetIdentityProviderDisplayName(string idpAlias) =>

--- a/tests/provisioning/Provisioning.Library.Tests/UserProvisioningServiceAuxiliaryMethodsTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/UserProvisioningServiceAuxiliaryMethodsTests.cs
@@ -74,6 +74,26 @@ public class UserProvisioningServiceAuxiliaryMethodsTests
     }
 
     [Fact]
+    public async void TestCompanyNameIdpAliaswithNullCompanyNameAndEmailDataFixtureSetup()
+    {
+        A.CallTo(() => _identityProviderRepository.GetCompanyNameIdpAliasUntrackedAsync(A<Guid>._, A<Guid>._))
+            .Returns(_resultComposer.With(
+                x => x.CompanyUser,
+                    _fixture.Build<(Guid CompanyUserId, string? FirstName, string? LastName, string? Email)>()
+                        .With(x => x.FirstName, (string?)null)
+                        .With(x => x.LastName, (string?)null)
+                        .With(x => x.Email, (string?)null)
+                        .Create())
+                .Create());
+        var sut = new UserProvisioningService(null!, _portalRepositories);
+
+        var result = await sut.GetCompanyNameIdpAliasData(_identityProviderId, _companyUserId).ConfigureAwait(false);
+        A.CallTo(() => _portalRepositories.GetInstance<IIdentityProviderRepository>()).MustHaveHappened();
+        result.Should().NotBeNull();
+        result.NameCreatedBy.Should().Be("Dear User");
+    }
+
+    [Fact]
     public async void TestCompanyNameIdpAliasDataNotFound()
     {
         ((Guid, string?, string?), (Guid, string?, string?, string?), (string?, bool)) notfound = default;
@@ -144,6 +164,29 @@ public class UserProvisioningServiceAuxiliaryMethodsTests
         result.Should().NotBeNull();
     }
 
+    [Fact]
+    public async void TestGetCompanyNameSharedIdpwithNullCompanyNameAndEmailAliasDataFixtureSetup()
+    {
+        // Arrange
+        var data = new ValueTuple<(Guid, string?, string?), (Guid, string?, string?, string?), IEnumerable<string>>(
+            new ValueTuple<Guid, string?, string?>(Guid.NewGuid(), _fixture.Create<string>(), _fixture.Create<string>()),
+            new ValueTuple<Guid, string?, string?, string?>(Guid.NewGuid(), null, null, null),
+            _fixture.CreateMany<string>(1)
+
+        );
+
+        A.CallTo(() => _identityProviderRepository.GetCompanyNameIdpAliaseUntrackedAsync(A<Guid>._, A<Guid?>._, A<IdentityProviderCategoryId>._))
+            .Returns(data);
+
+        // Act
+        var sut = new UserProvisioningService(null!, _portalRepositories);
+
+        // Assert
+        var result = await sut.GetCompanyNameSharedIdpAliasData(_companyUserId).ConfigureAwait(false);
+        A.CallTo(() => _portalRepositories.GetInstance<IIdentityProviderRepository>()).MustHaveHappened();
+        result.Should().NotBeNull();
+        result.NameCreatedBy.Should().Be("Dear User");
+    }
     [Fact]
     public async void TestGetCompanyNameSharedIdpAliasDataNotFound()
     {


### PR DESCRIPTION
## Description

namecreatedby null check handled and ServiceChange controller url fixed

## Why

nameCreatedBy not handled for null value, in email template body the value is null, now it is handled
ServiceChange service url is mismatched, now it is fixed 

## Issue

[CPLP-2790](https://jira.catena-x.net/browse/CPLP-2790)
[TEST-1142](https://jira.catena-x.net/browse/TEST-1142)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
