### PR TITLE
bugfix (docker): fix docker dependencies

### DIFF
--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -31,6 +31,7 @@ COPY src/framework/Framework.Models/ src/framework/Framework.Models/
 COPY src/framework/Framework.Logging/ src/framework/Framework.Logging/
 COPY src/framework/Framework.ErrorHandling.Library/ src/framework/Framework.ErrorHandling.Library/
 COPY src/framework/Framework.ProcessIdentity/ src/framework/Framework.ProcessIdentity/
+COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 RUN dotnet restore "src/maintenance/Maintenance.App/Maintenance.App.csproj"
 WORKDIR /src/maintenance/Maintenance.App
 RUN dotnet build "Maintenance.App.csproj" -c Release -o /app/build

--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -31,6 +31,7 @@ COPY /src/framework/Framework.ErrorHandling.Library /src/framework/Framework.Err
 COPY /src/framework/Framework.BaseDependencies /src/framework/Framework.BaseDependencies
 COPY /src/framework/Framework.ProcessIdentity /src/framework/Framework.ProcessIdentity/
 COPY /src/framework/Framework.Seeding /src/framework/Framework.Seeding
+COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 WORKDIR /src/portalbackend/PortalBackend.Migrations
 RUN dotnet build "PortalBackend.Migrations.csproj" -c Release -o /migrations/build
 


### PR DESCRIPTION
## Description

the dependency to framework.DateTimeProvider was added to dockerfiles of modules 'Migrations' and 'Maintenance'

## Why

PR #203 (CPLP-2897) did add new dependencies to modules 'maintenance' and 'migrations'. The respective dockerfiles were not adjusted accordingly. Therefore the github-action 'build-and-push-image' of 'migrations' and 'maintenance' fails.

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes