### PR TITLE
bugfix (unittests): remove asserts depending on db's timing of execution.

### DIFF
--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalDbContextTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalDbContextTests.cs
@@ -67,7 +67,7 @@ public class PortalDbContextTests : IAssemblyFixture<TestDbFixture>
         var auditEntries = await sut.AuditCompanyApplication20230214.Where(x => x.Id == ca.Id).ToListAsync();
         auditEntries.Should().HaveCount(2).And.Satisfy(
             x => x.ApplicationStatusId == CompanyApplicationStatusId.CONFIRMED && x.AuditV1OperationId == AuditOperationId.INSERT,
-            x => x.ApplicationStatusId == CompanyApplicationStatusId.SELECT_COMPANY_ROLE && x.AuditV1OperationId == AuditOperationId.UPDATE && (x.AuditV1DateLastChanged - now) < TimeSpan.FromSeconds(1) && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"));
+            x => x.ApplicationStatusId == CompanyApplicationStatusId.SELECT_COMPANY_ROLE && x.AuditV1OperationId == AuditOperationId.UPDATE && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"));
         await trans.RollbackAsync().ConfigureAwait(false);
     }
 
@@ -94,7 +94,7 @@ public class PortalDbContextTests : IAssemblyFixture<TestDbFixture>
         ca.DateLastChanged.Should().Be(now);
         var auditEntries = await sut.AuditCompanyApplication20230214.Where(x => x.Id == id).ToListAsync();
         auditEntries.Should().ContainSingle().Which.Should().Match<AuditCompanyApplication20230214>(
-            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(1) && x.AuditV1OperationId == AuditOperationId.INSERT && (x.AuditV1DateLastChanged - now) < TimeSpan.FromSeconds(1) && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"));
+            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(1) && x.AuditV1OperationId == AuditOperationId.INSERT && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"));
         await trans.RollbackAsync().ConfigureAwait(false);
     }
 
@@ -124,7 +124,7 @@ public class PortalDbContextTests : IAssemblyFixture<TestDbFixture>
         ca.DateLastChanged.Should().Be(later);
         var auditEntries = await sut.AuditCompanyApplication20230214.Where(x => x.Id == id).ToListAsync();
         auditEntries.Should().HaveCount(2).And.Satisfy(
-            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(1) && x.AuditV1OperationId == AuditOperationId.INSERT && (x.AuditV1DateLastChanged - now) < TimeSpan.FromSeconds(1) && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"),
+            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(1) && x.AuditV1OperationId == AuditOperationId.INSERT && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"),
             x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(1) && x.AuditV1OperationId == AuditOperationId.DELETE && (x.AuditV1DateLastChanged - later) < TimeSpan.FromSeconds(1) && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"));
         await trans.RollbackAsync().ConfigureAwait(false);
     }


### PR DESCRIPTION
## Description

removed asserts in db-unittests that depend on synchronization of clocks in unit-test and database-container and .

## Why

in PR #203 unit-tests were added for the trigger-framework. While those tests run fine most of the time they eventually fail whenever the trigger on the database runs more than 1 second later than the point in time the unit-tests creates a new entiy in the dotnet-runtime.

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
