### PR TITLE
bugfix(custodian): fix runtime-dependency of unit-test-assert

### DIFF
--- a/tests/externalsystems/Custodian.Library.Tests/CustodianServiceTests.cs
+++ b/tests/externalsystems/Custodian.Library.Tests/CustodianServiceTests.cs
@@ -78,7 +78,7 @@ public class CustodianServiceTests
         const string bpn = "123";
         const string name = "test";
         const string did = "did:sov:GamAMqXnXr1chS4viYXoxB";
-        var now = DateTimeOffset.UtcNow;
+        var now = DateTimeOffset.Parse("2023-09-04T07:11:21.2022371+00:00");
         A.CallTo(() => _dateTimeProvider.OffsetNow)
             .Returns(now);
         var data = JsonSerializer.Serialize(new WalletCreationResponse(did), JsonOptions);


### PR DESCRIPTION
## Description

remove a dependency on 'DateTimeOffset.OffsetNow()' in custodian unit-test by replacing that dynamic testdata by a constant value.

## Why

The unit-test CreateWallet_WithValidData_DoesNotThrowException() would eventually fail because Json-formating and assert would not produce the same string in case the dateTimeOffset would have trailing zeros. This breaks the build.

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
