### PR TITLE
feat(app) : added subscriptionId field to activeSubscription Endpoint

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionStatusData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionStatusData.cs
@@ -51,7 +51,8 @@ public record ActiveOfferSubscriptionStatusData(
     [property: JsonPropertyName("offerId")] Guid OfferId,
     [property: JsonPropertyName("name")] string? OfferName,
     [property: JsonPropertyName("provider")] string Provider,
-    [property: JsonPropertyName("image")] Guid? DocumentId
+    [property: JsonPropertyName("image")] Guid? DocumentId,
+    [property: JsonPropertyName("subscriptionId")] Guid OfferSubscriptionId
 );
 
 /// <summary>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -523,7 +523,8 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                     .Where(document =>
                         document.DocumentTypeId == documentTypeId
                         && document.DocumentStatusId == DocumentStatusId.LOCKED)
-                    .Select(document => document.Id).FirstOrDefault()
+                    .Select(document => document.Id).FirstOrDefault(),
+                os.Id
             )).ToAsyncEnumerable();
 
     /// <inheritdoc>

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -996,7 +996,8 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
             x => x.OfferId == new Guid("ac1cf001-7fbc-1f2f-817f-bce0572c0007") &&
                 x.OfferName == "Trace-X" &&
                 x.Provider == "Catena-X" &&
-                x.DocumentId == new Guid("e020787d-1e04-4c0b-9c06-bd1cd44724b1"));
+                x.DocumentId == new Guid("e020787d-1e04-4c0b-9c06-bd1cd44724b1") &&
+                x.OfferSubscriptionId == new Guid("ed4de48d-fd4b-4384-a72f-ecae3c6cc5ba"));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

added subscriptionId field to activeSubscription Endpoint

## Why

added subscriptionId field to activeSubscription Endpoint for FE

## Issue

[CPLP-3233](https://jira.catena-x.net/browse/CPLP-3233)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
