### PR TITLE
feat(n2n): add osp callback endpoints

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IRegistrationStatusBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IRegistrationStatusBusinessLogic.cs
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
+
+public interface IRegistrationStatusBusinessLogic
+{
+    Task<OnboardingServiceProviderCallbackResponseData> GetCallbackAddress();
+    Task SetCallbackAddress(OnboardingServiceProviderCallbackData data);
+}

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationStatusBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationStatusBusinessLogic.cs
@@ -1,0 +1,58 @@
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
+
+public class RegistrationStatusBusinessLogic : IRegistrationStatusBusinessLogic
+{
+    private readonly IPortalRepositories _portalRepositories;
+    private readonly IIdentityService _identityService;
+
+    public RegistrationStatusBusinessLogic(IPortalRepositories portalRepositories, IIdentityService identityService)
+    {
+        _portalRepositories = portalRepositories;
+        _identityService = identityService;
+    }
+
+    public Task<OnboardingServiceProviderCallbackResponseData> GetCallbackAddress() =>
+        _portalRepositories.GetInstance<ICompanyRepository>().GetCallbackData(_identityService.IdentityData.CompanyId);
+
+    public async Task SetCallbackAddress(OnboardingServiceProviderCallbackData data)
+    {
+        var companyId = _identityService.IdentityData.CompanyId;
+        var companyRepository = _portalRepositories.GetInstance<ICompanyRepository>();
+        var (isOnboardingServiceProvider, ospDetailsExist, callbackUrl) = await companyRepository
+            .GetCallbackEditData(companyId)
+            .ConfigureAwait(false);
+
+        if (!isOnboardingServiceProvider)
+        {
+            throw new ForbiddenException($"Only {CompanyRoleId.ONBOARDING_SERVICE_PROVIDER} are allowed to set the callback url");
+        }
+
+        if (ospDetailsExist)
+        {
+            companyRepository.AttachAndModifyOnboardingServiceProvider(companyId, osp =>
+                {
+                    if (!string.IsNullOrEmpty(callbackUrl))
+                    {
+                        osp.CallbackUrl = callbackUrl;
+                    }
+                },
+                osp =>
+                {
+                    osp.CallbackUrl = data.CallbackUrl;
+                });    
+        }
+        else
+        {
+            companyRepository.CreateOnboardingServiceProviderDetails(companyId, data.CallbackUrl);
+        }
+        
+        await _portalRepositories.SaveAsync().ConfigureAwait(false);
+    }
+}

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationStatusBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationStatusBusinessLogic.cs
@@ -1,3 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
@@ -25,11 +45,11 @@ public class RegistrationStatusBusinessLogic : IRegistrationStatusBusinessLogic
     {
         var companyId = _identityService.IdentityData.CompanyId;
         var companyRepository = _portalRepositories.GetInstance<ICompanyRepository>();
-        var (isOnboardingServiceProvider, ospDetailsExist, callbackUrl) = await companyRepository
-            .GetCallbackEditData(companyId)
+        var (hasCompanyRole, ospDetailsExist, callbackUrl) = await companyRepository
+            .GetCallbackEditData(companyId, CompanyRoleId.ONBOARDING_SERVICE_PROVIDER)
             .ConfigureAwait(false);
 
-        if (!isOnboardingServiceProvider)
+        if (!hasCompanyRole)
         {
             throw new ForbiddenException($"Only {CompanyRoleId.ONBOARDING_SERVICE_PROVIDER} are allowed to set the callback url");
         }
@@ -38,10 +58,7 @@ public class RegistrationStatusBusinessLogic : IRegistrationStatusBusinessLogic
         {
             companyRepository.AttachAndModifyOnboardingServiceProvider(companyId, osp =>
                 {
-                    if (!string.IsNullOrEmpty(callbackUrl))
-                    {
-                        osp.CallbackUrl = callbackUrl;
-                    }
+                    osp.CallbackUrl = callbackUrl ?? throw new UnexpectedConditionException("callbackUrl should never be null here");
                 },
                 osp =>
                 {

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationStatusBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationStatusBusinessLogic.cs
@@ -46,13 +46,13 @@ public class RegistrationStatusBusinessLogic : IRegistrationStatusBusinessLogic
                 osp =>
                 {
                     osp.CallbackUrl = data.CallbackUrl;
-                });    
+                });
         }
         else
         {
             companyRepository.CreateOnboardingServiceProviderDetails(companyId, data.CallbackUrl);
         }
-        
+
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
 }

--- a/src/administration/Administration.Service/Controllers/RegistrationStatusController.cs
+++ b/src/administration/Administration.Service/Controllers/RegistrationStatusController.cs
@@ -1,0 +1,77 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Microsoft.AspNetCore.Mvc;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Controllers;
+
+[ApiController]
+[Route("api/administration/[controller]")]
+[Produces("application/json")]
+[Consumes("application/json")]
+public class RegistrationStatusController : ControllerBase
+{
+    private readonly IRegistrationStatusBusinessLogic _logic;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="RegistrationStatusController"/>
+    /// </summary>
+    /// <param name="logic">The business logic for the registration</param>
+    public RegistrationStatusController(IRegistrationStatusBusinessLogic logic)
+    {
+        _logic = logic;
+    }
+
+    /// <summary>
+    /// Gets the callback address of the onboarding service provider
+    /// </summary>
+    /// <returns>the callback data of the osp</returns>
+    /// <remarks>Example: GET: api/administration/registrationstatus/callback</remarks>
+    /// <response code="200">Returns the company with its address.</response>
+    /// <response code="400">Company is no onboarding service provider.</response>
+    [HttpGet]
+    // [Authorize(Roles = "view_submitted_applications")]
+    [Route("callback")]
+    [ProducesResponseType(typeof(OnboardingServiceProviderCallbackData), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public Task<OnboardingServiceProviderCallbackResponseData> GetCallbackAddress() =>
+        _logic.GetCallbackAddress();
+
+    /// <summary>
+    /// Sets the callback address of the onboarding service provider
+    /// </summary>
+    /// <returns>NoContent</returns>
+    /// <remarks>Example: POST: api/administration/registrationstatus/callback</remarks>
+    /// <response code="204">Returns no content.</response>
+    [HttpPost]
+    // [Authorize(Roles = "view_submitted_applications")]
+    [Route("callback")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<NoContentResult> SetCallbackAddress(OnboardingServiceProviderCallbackData data)
+    {
+        await _logic.SetCallbackAddress(data).ConfigureAwait(false);
+        return NoContent();
+    }
+}

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OnboardingServiceProviderCallbackData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OnboardingServiceProviderCallbackData.cs
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+
+public record OnboardingServiceProviderCallbackResponseData(string? CallbackUrl);
+
+public record OnboardingServiceProviderCallbackData(string CallbackUrl);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -319,12 +319,12 @@ public class CompanyRepository : ICompanyRepository
                 ))
             .SingleOrDefaultAsync();
 
-    public Task<OnboardingServiceProviderCallbackResponseData> GetCallbackData(Guid companyId) => 
+    public Task<OnboardingServiceProviderCallbackResponseData> GetCallbackData(Guid companyId) =>
         _context.Companies.Where(c => c.Id == companyId)
             .Select(c => new OnboardingServiceProviderCallbackResponseData(c.OnboardingServiceProviderDetail!.CallbackUrl))
             .SingleAsync();
 
-    public Task<(bool isOnboardingServiceProvider, bool ospDetailsExist, string? callbackUrl)> GetCallbackEditData(Guid companyId) => 
+    public Task<(bool isOnboardingServiceProvider, bool ospDetailsExist, string? callbackUrl)> GetCallbackEditData(Guid companyId) =>
         _context.Companies.Where(c => c.Id == companyId)
             .Select(c => new ValueTuple<bool, bool, string?>(
                 c.CompanyAssignedRoles.Any(role => role.CompanyRoleId == CompanyRoleId.ONBOARDING_SERVICE_PROVIDER),

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -324,10 +324,10 @@ public class CompanyRepository : ICompanyRepository
             .Select(c => new OnboardingServiceProviderCallbackResponseData(c.OnboardingServiceProviderDetail!.CallbackUrl))
             .SingleAsync();
 
-    public Task<(bool isOnboardingServiceProvider, bool ospDetailsExist, string? callbackUrl)> GetCallbackEditData(Guid companyId) =>
+    public Task<(bool hasCompanyRole, bool ospDetailsExist, string? callbackUrl)> GetCallbackEditData(Guid companyId, CompanyRoleId companyRoleId) =>
         _context.Companies.Where(c => c.Id == companyId)
             .Select(c => new ValueTuple<bool, bool, string?>(
-                c.CompanyAssignedRoles.Any(role => role.CompanyRoleId == CompanyRoleId.ONBOARDING_SERVICE_PROVIDER),
+                c.CompanyAssignedRoles.Any(role => role.CompanyRoleId == companyRoleId),
                 c.OnboardingServiceProviderDetail != null,
                 c.OnboardingServiceProviderDetail!.CallbackUrl))
             .SingleOrDefaultAsync();

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -166,4 +166,8 @@ public interface ICompanyRepository
     IAsyncEnumerable<OperatorBpnData> GetOperatorBpns();
 
     Task<(bool IsValidCompany, string CompanyName, bool IsAllowed)> CheckCompanyAndCompanyRolesAsync(Guid companyId, IEnumerable<CompanyRoleId> companyRoles);
+    Task<OnboardingServiceProviderCallbackResponseData> GetCallbackData(Guid companyId);
+    Task<(bool isOnboardingServiceProvider, bool ospDetailsExist, string? callbackUrl)> GetCallbackEditData(Guid companyId);
+    void AttachAndModifyOnboardingServiceProvider(Guid companyId, Action<OnboardingServiceProviderDetail>? initialize, Action<OnboardingServiceProviderDetail> setOptionalFields);
+    OnboardingServiceProviderDetail CreateOnboardingServiceProviderDetails(Guid companyId, string callbackUrl);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -167,7 +167,7 @@ public interface ICompanyRepository
 
     Task<(bool IsValidCompany, string CompanyName, bool IsAllowed)> CheckCompanyAndCompanyRolesAsync(Guid companyId, IEnumerable<CompanyRoleId> companyRoles);
     Task<OnboardingServiceProviderCallbackResponseData> GetCallbackData(Guid companyId);
-    Task<(bool isOnboardingServiceProvider, bool ospDetailsExist, string? callbackUrl)> GetCallbackEditData(Guid companyId);
+    Task<(bool hasCompanyRole, bool ospDetailsExist, string? callbackUrl)> GetCallbackEditData(Guid companyId, CompanyRoleId companyRoleId);
     void AttachAndModifyOnboardingServiceProvider(Guid companyId, Action<OnboardingServiceProviderDetail>? initialize, Action<OnboardingServiceProviderDetail> setOptionalFields);
     OnboardingServiceProviderDetail CreateOnboardingServiceProviderDetails(Guid companyId, string callbackUrl);
 }

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchInsertSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchInsertSeeder.cs
@@ -105,6 +105,7 @@ public class BatchInsertSeeder : ICustomSeeder
         await SeedTable<UseCaseDescription>("use_case_descriptions", x => new { x.UseCaseId, x.LanguageShortName }, cancellationToken).ConfigureAwait(false);
         await SeedTable<VerifiedCredentialTypeAssignedUseCase>("verified_credential_type_assigned_use_cases", x => new { x.VerifiedCredentialTypeId, x.UseCaseId }, cancellationToken).ConfigureAwait(false);
         await SeedTable<VerifiedCredentialTypeAssignedExternalType>("verified_credential_type_assigned_external_types", x => new { x.VerifiedCredentialTypeId, x.VerifiedCredentialExternalTypeId }, cancellationToken).ConfigureAwait(false);
+        await SeedTable<OnboardingServiceProviderDetail>("onboarding_service_provider_details", x => x.CompanyId, cancellationToken).ConfigureAwait(false);
 
         await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("Finished BaseEntityBatch Seeder");

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationStatusBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationStatusBusinessLogicTest.cs
@@ -41,10 +41,10 @@ public class RegistrationStatusBusinessLogicTest
     {
         var identityService = A.Fake<IIdentityService>();
         A.CallTo(() => identityService.IdentityData).Returns(_identity);
-        
+
         _portalRepositories = A.Fake<IPortalRepositories>();
         _companyRepository = A.Fake<ICompanyRepository>();
-        
+
         A.CallTo(() => _portalRepositories.GetInstance<ICompanyRepository>()).Returns(_companyRepository);
 
         _logic = new RegistrationStatusBusinessLogic(_portalRepositories, identityService);
@@ -81,7 +81,7 @@ public class RegistrationStatusBusinessLogicTest
     }
 
     #endregion
-    
+
     #region SetCallbackAddress
 
     [Fact]
@@ -131,7 +131,7 @@ public class RegistrationStatusBusinessLogicTest
                 initialize?.Invoke(osp);
                 setOptionalFields.Invoke(osp);
             });
-        
+
         //Act
         await _logic.SetCallbackAddress(new OnboardingServiceProviderCallbackData("https://test-new.de")).ConfigureAwait(false);
 

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationStatusBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationStatusBusinessLogicTest.cs
@@ -1,0 +1,145 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.BusinessLogic;
+
+public class RegistrationStatusBusinessLogicTest
+{
+    private readonly IdentityData _identity = new("4C1A6851-D4E7-4E10-A011-3732CD045E8A", Guid.NewGuid(), IdentityTypeId.COMPANY_USER, Guid.NewGuid());
+
+    private readonly IPortalRepositories _portalRepositories;
+    private readonly ICompanyRepository _companyRepository;
+    private readonly IRegistrationStatusBusinessLogic _logic;
+
+    public RegistrationStatusBusinessLogicTest()
+    {
+        var identityService = A.Fake<IIdentityService>();
+        A.CallTo(() => identityService.IdentityData).Returns(_identity);
+        
+        _portalRepositories = A.Fake<IPortalRepositories>();
+        _companyRepository = A.Fake<ICompanyRepository>();
+        
+        A.CallTo(() => _portalRepositories.GetInstance<ICompanyRepository>()).Returns(_companyRepository);
+
+        _logic = new RegistrationStatusBusinessLogic(_portalRepositories, identityService);
+    }
+
+    #region GetCallbackAddress
+
+    [Fact]
+    public async Task GetCallbackAddress_WithExistingOspData_ReturnsExpectedCallbackUrl()
+    {
+        //Arrange
+        A.CallTo(() => _companyRepository.GetCallbackData(_identity.CompanyId))
+            .Returns(new OnboardingServiceProviderCallbackResponseData("https://callback-url.com"));
+
+        //Act
+        var result = await _logic.GetCallbackAddress().ConfigureAwait(false);
+
+        //Assert
+        result.CallbackUrl.Should().Be("https://callback-url.com");
+    }
+
+    [Fact]
+    public async Task GetCallbackAddress_WithoutOspData_ReturnsNull()
+    {
+        //Arrange
+        A.CallTo(() => _companyRepository.GetCallbackData(_identity.CompanyId))
+            .Returns(new OnboardingServiceProviderCallbackResponseData(null));
+
+        //Act
+        var result = await _logic.GetCallbackAddress().ConfigureAwait(false);
+
+        //Assert
+        result.CallbackUrl.Should().Be(null);
+    }
+
+    #endregion
+    
+    #region SetCallbackAddress
+
+    [Fact]
+    public async Task SetCallbackAddress_WithCompanyNotOsp_ReturnsExpectedCallbackUrl()
+    {
+        //Arrange
+        A.CallTo(() => _companyRepository.GetCallbackEditData(_identity.CompanyId))
+            .Returns(new ValueTuple<bool, bool, string?>());
+
+        //Act
+        async Task Act() => await _logic.SetCallbackAddress(new OnboardingServiceProviderCallbackData("https://test.de")).ConfigureAwait(false);
+
+        //Assert
+        var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
+        ex.Message.Should().Be($"Only {CompanyRoleId.ONBOARDING_SERVICE_PROVIDER} are allowed to set the callback url");
+    }
+
+    [Fact]
+    public async Task SetCallbackAddress_WithNonExistingOspData_InsertExpected()
+    {
+        //Arrange
+        A.CallTo(() => _companyRepository.GetCallbackEditData(_identity.CompanyId))
+            .Returns(new ValueTuple<bool, bool, string?>(true, false, null));
+
+        //Act
+        await _logic.SetCallbackAddress(new OnboardingServiceProviderCallbackData("https://test.de")).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _companyRepository.CreateOnboardingServiceProviderDetails(_identity.CompanyId, "https://test.de"))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _portalRepositories.SaveAsync())
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Theory]
+    [InlineData("https://test-old.de")]
+    [InlineData(null)]
+    public async Task SetCallbackAddress_WithOspData_UpdatesEntry(string? existingUrl)
+    {
+        //Arrange
+        var osp = new OnboardingServiceProviderDetail(_identity.CompanyId, null!);
+        A.CallTo(() => _companyRepository.GetCallbackEditData(_identity.CompanyId))
+            .Returns(new ValueTuple<bool, bool, string?>(true, true, existingUrl));
+        A.CallTo(() => _companyRepository.AttachAndModifyOnboardingServiceProvider(_identity.CompanyId, A<Action<OnboardingServiceProviderDetail>>._, A<Action<OnboardingServiceProviderDetail>>._))
+            .Invokes((Guid _, Action<OnboardingServiceProviderDetail>? initialize, Action<OnboardingServiceProviderDetail> setOptionalFields) =>
+            {
+                initialize?.Invoke(osp);
+                setOptionalFields.Invoke(osp);
+            });
+        
+        //Act
+        await _logic.SetCallbackAddress(new OnboardingServiceProviderCallbackData("https://test-new.de")).ConfigureAwait(false);
+
+        //Assert
+        osp.CallbackUrl.Should().Be("https://test-new.de");
+        A.CallTo(() => _portalRepositories.SaveAsync())
+            .MustHaveHappenedOnceExactly();
+    }
+
+    #endregion
+}

--- a/tests/administration/Administration.Service.Tests/Controllers/RegistrationStatusControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/RegistrationStatusControllerTest.cs
@@ -1,0 +1,65 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Microsoft.AspNetCore.Mvc;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Controllers;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Controllers;
+
+public class RegistrationStatusControllerTest
+{
+    private readonly IRegistrationStatusBusinessLogic _logic;
+    private readonly RegistrationStatusController _controller;
+
+    public RegistrationStatusControllerTest()
+    {
+        _logic = A.Fake<IRegistrationStatusBusinessLogic>();
+        _controller = new RegistrationStatusController(_logic);
+        _controller.AddControllerContextWithClaim("1234");
+    }
+
+    [Fact]
+    public async Task GetCallbackAddress_ReturnsExpectedCallbackUrl()
+    {
+        //Arrange
+        A.CallTo(() => _logic.GetCallbackAddress())
+                  .Returns(new OnboardingServiceProviderCallbackResponseData("https://callback-url.com"));
+
+        //Act
+        var result = await this._controller.GetCallbackAddress().ConfigureAwait(false);
+
+        //Assert
+        result.CallbackUrl.Should().Be("https://callback-url.com");
+    }
+
+    [Fact]
+    public async Task GetCompanyWithAddressAsync_ReturnsExpectedResult()
+    {
+        //Act
+        var result = await this._controller.SetCallbackAddress(new OnboardingServiceProviderCallbackData("https://callback-url.com")).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.SetCallbackAddress(A<OnboardingServiceProviderCallbackData>._)).MustHaveHappenedOnceExactly();
+        result.Should().BeOfType<NoContentResult>();
+    }
+}

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -718,7 +718,7 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
     {
         // Arrange
         const string url = "https://service-url.com";
-        var (sut, context) = await CreateSut().ConfigureAwait(false);
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
         var result = await sut.GetCallbackEditData(_validOspCompanyId).ConfigureAwait(false);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -698,19 +698,21 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #region GetCallbackEditData
 
-    [Fact]
-    public async Task GetCallbackEditData_WithNotExistingOspData_ReturnsExpectedResult()
+    [Theory]
+    [InlineData(CompanyRoleId.ACTIVE_PARTICIPANT, true)]
+    [InlineData(CompanyRoleId.ONBOARDING_SERVICE_PROVIDER, false)]
+    public async Task GetCallbackEditData_WithNotExistingOspData_ReturnsExpectedResult(CompanyRoleId companyRoleId, bool hasRole)
     {
         // Arrange
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetCallbackEditData(_validCompanyId).ConfigureAwait(false);
+        var result = await sut.GetCallbackEditData(_validCompanyId, companyRoleId).ConfigureAwait(false);
 
         // Assert
-        result.callbackUrl.Should().Be(null);
-        result.ospDetailsExist.Should().Be(false);
-        result.isOnboardingServiceProvider.Should().Be(false);
+        result.callbackUrl.Should().BeNull();
+        result.ospDetailsExist.Should().BeFalse();
+        result.hasCompanyRole.Should().Be(hasRole);
     }
 
     [Fact]
@@ -721,12 +723,12 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetCallbackEditData(_validOspCompanyId).ConfigureAwait(false);
+        var result = await sut.GetCallbackEditData(_validOspCompanyId, CompanyRoleId.ONBOARDING_SERVICE_PROVIDER).ConfigureAwait(false);
 
         // Assert
         result.callbackUrl.Should().Be(url);
-        result.ospDetailsExist.Should().Be(true);
-        result.isOnboardingServiceProvider.Should().Be(true);
+        result.ospDetailsExist.Should().BeTrue();
+        result.hasCompanyRole.Should().BeTrue();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/addresses.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/addresses.test.json
@@ -70,5 +70,17 @@
     "streetnumber": "6",
     "zipcode": "00001",
     "country_alpha2code": "DE"
+  },
+  {
+    "id": "c2b23d31-3666-42e6-bba2-bb550c2cc7f6",
+    "date_created": "2022-03-24 18:01:33.435000 +00:00",
+    "date_last_changed": "2022-03-24 18:01:33.435000 +00:00",
+    "city": "Munich",
+    "region": null,
+    "streetadditional": null,
+    "streetname": "Street",
+    "streetnumber": "6",
+    "zipcode": "00001",
+    "country_alpha2code": "DE"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/companies.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/companies.test.json
@@ -68,5 +68,15 @@
     "company_status_id": 1,
     "address_id": "86da3e1c-a634-41a6-ad44-9880746123e4",
     "self_description_document_id": null
+  },
+  {
+    "id": "a45f3b2e-29f7-4b52-8bb2-15b204849d87",
+    "date_created": "2022-03-24 18:01:33.438000 +00:00",
+    "business_partner_number": "BPNL000000001OSP",
+    "name": "OSP Company",
+    "shortname": "OSP",
+    "company_status_id": 1,
+    "address_id": "c2b23d31-3666-42e6-bba2-bb550c2cc7f6",
+    "self_description_document_id": null
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_assigned_roles.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_assigned_roles.test.json
@@ -34,5 +34,9 @@
   {
     "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
     "company_role_id": 1
+  },
+  {
+    "company_id": "a45f3b2e-29f7-4b52-8bb2-15b204849d87",
+    "company_role_id": 5
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/onboarding_service_provider_details.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/onboarding_service_provider_details.test.json
@@ -1,0 +1,6 @@
+[
+  {
+    "company_id": "a45f3b2e-29f7-4b52-8bb2-15b204849d87",
+    "callback_url": "https://service-url.com"
+  }
+]


### PR DESCRIPTION
## Description

add endpoint to get the callback url of an osp
add endpoint to set the callback url of an osp

## Why

To enable the osps to set a callback url. If the callback url is set the osp will be informed when the status of an application changed

## Issue

N/A - Jira Issue: CPLP-2638

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
