### PR TITLE
fix(autoSetup): adjust autoSetup query

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -155,7 +155,7 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                 x.Requester!.Email,
                 x.Requester.Firstname,
                 x.Requester.Lastname,
-                new ValueTuple<bool, string?>(x.Offer.AppInstanceSetup!.IsSingleInstance, x.Offer.AppInstanceSetup.InstanceUrl),
+                new ValueTuple<bool, string?>(x.Offer.AppInstanceSetup != null && x.Offer.AppInstanceSetup.IsSingleInstance, x.Offer.AppInstanceSetup!.InstanceUrl),
                 x.Offer.AppInstances.Select(ai => ai.Id),
                 x.Offer.SalesManagerId
             ))

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -388,7 +388,7 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                 x.Requester.Firstname,
                 x.Requester.Lastname,
                 x.RequesterId,
-                new ValueTuple<bool, string?>(x.Offer.AppInstanceSetup!.IsSingleInstance, x.Offer.AppInstanceSetup.InstanceUrl),
+                new ValueTuple<bool, string?>(x.Offer.AppInstanceSetup != null && x.Offer.AppInstanceSetup.IsSingleInstance, x.Offer.AppInstanceSetup!.InstanceUrl),
                 x.Offer!.AppInstances.Select(ai => ai.Id),
                 x.OfferSubscriptionProcessData != null,
                 x.Offer.SalesManagerId,

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -177,7 +177,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
     #region GetOfferDetailsAndCheckUser
 
     [Fact]
-    public async Task GetOfferDetailsAndCheckUser_WithValidUserandSubscriptionId_ReturnsExpectedResult()
+    public async Task GetOfferDetailsAndCheckUser_WithValidUserAndSubscriptionId_ReturnsExpectedResult()
     {
         // Arrange
         var (sut, _) = await CreateSut().ConfigureAwait(false);
@@ -195,6 +195,31 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         result.IsProviderCompany.Should().BeTrue();
         result.Bpn.Should().Be("BPNL00000003CRHK");
         result.OfferName.Should().Be("Trace-X");
+        result.InstanceData.IsSingleInstance.Should().BeTrue();
+        result.InstanceData.InstanceUrl.Should().Be("https://test.com");
+    }
+
+    [Fact]
+    public async Task GetOfferDetailsAndCheckUser_WithSubscriptionForOfferWithoutAppInstanceSetup_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOfferDetailsAndCheckProviderCompany(new Guid("e80b5f5c-3a16-480b-b82e-1cc06a71fddc"), new("3390c2d7-75c1-4169-aa27-6ce00e1f3cdd"), OfferTypeId.SERVICE).ConfigureAwait(false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotBe(default);
+        result!.OfferId.Should().Be(new Guid("a16e73b9-5277-4b69-9f8d-3b227495dfae"));
+        result.Status.Should().Be(OfferSubscriptionStatusId.ACTIVE);
+        result.CompanyId.Should().Be(new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+        result.CompanyName.Should().Be("Catena-X");
+        result.IsProviderCompany.Should().BeTrue();
+        result.Bpn.Should().Be("BPNL00000003CRHK");
+        result.OfferName.Should().Be("Service Test 123");
+        result.InstanceData.IsSingleInstance.Should().BeFalse();
+        result.InstanceData.InstanceUrl.Should().BeNull();
     }
 
     #endregion


### PR DESCRIPTION
## Description

no error is thrown when the appInstanceSetup is missing

## Why

Currently the autoSetup throws an 500 error when trying to start the autoSetup for an subscription with an offer that doesn't have an appInstanceSetup configured.

## Issue

N/A - Jira Issue: CPLP-3238

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
