### PR TITLE
feat(kc): add configurable auth path for keycloak requests

### DIFF
--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -31,13 +31,15 @@
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     },
     "shared": {
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     }
   },
   "ConnectionStrings": {

--- a/src/keycloak/Keycloak.Factory/IKeycloakFactory.cs
+++ b/src/keycloak/Keycloak.Factory/IKeycloakFactory.cs
@@ -26,5 +26,5 @@ public interface IKeycloakFactory
 {
     KeycloakClient CreateKeycloakClient(string instance);
 
-    KeycloakClient CreateKeycloakClient(string instance, string clientId, string secret);
+    KeycloakClient CreateKeycloakClient(string instance, string clientId, string secret, bool useAuthTrail);
 }

--- a/src/keycloak/Keycloak.Factory/KeycloakFactory.cs
+++ b/src/keycloak/Keycloak.Factory/KeycloakFactory.cs
@@ -42,11 +42,11 @@ public class KeycloakFactory : IKeycloakFactory
 
         var settings = _settings.Single(x => x.Key.Equals(instance, StringComparison.InvariantCultureIgnoreCase)).Value;
         return settings.ClientSecret == null
-            ? new KeycloakClient(settings.ConnectionString, settings.User, settings.Password, settings.AuthRealm)
-            : KeycloakClient.CreateWithClientId(settings.ConnectionString, settings.ClientId, settings.ClientSecret, settings.AuthRealm);
+            ? new KeycloakClient(settings.ConnectionString, settings.User, settings.Password, settings.AuthRealm, settings.UseAuthTrail)
+            : KeycloakClient.CreateWithClientId(settings.ConnectionString, settings.ClientId, settings.ClientSecret, settings.UseAuthTrail, settings.AuthRealm);
     }
 
-    public KeycloakClient CreateKeycloakClient(string instance, string clientId, string secret)
+    public KeycloakClient CreateKeycloakClient(string instance, string clientId, string secret, bool useAuthTrail)
     {
         if (!_settings.Keys.Contains(instance, StringComparer.InvariantCultureIgnoreCase))
         {
@@ -54,6 +54,6 @@ public class KeycloakFactory : IKeycloakFactory
         }
 
         var settings = _settings.Single(x => x.Key.Equals(instance, StringComparison.InvariantCultureIgnoreCase)).Value;
-        return KeycloakClient.CreateWithClientId(settings.ConnectionString, clientId, secret, settings.AuthRealm);
+        return KeycloakClient.CreateWithClientId(settings.ConnectionString, clientId, secret, useAuthTrail, settings.AuthRealm);
     }
 }

--- a/src/keycloak/Keycloak.Factory/KeycloakSettingData.cs
+++ b/src/keycloak/Keycloak.Factory/KeycloakSettingData.cs
@@ -27,19 +27,20 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Keycloak.Factory;
 
 public class KeycloakSettings
 {
-    public KeycloakSettings()
-    {
-        ConnectionString = null!;
-    }
+    public string ConnectionString { get; set; } = null!;
 
-    public string ConnectionString { get; set; }
     public string? User { get; set; }
-    public string? Password { get; set; }
-    public string? ClientId { get; set; }
-    public string? ClientSecret { get; set; }
-    public string? AuthRealm { get; set; }
 
-    public void Validate(string key)
+    public string? Password { get; set; }
+
+    public string? ClientId { get; set; }
+
+    public string? ClientSecret { get; set; }
+
+    public string? AuthRealm { get; set; }
+    public bool UseAuthTrail { get; set; }
+
+    public void Validate()
     {
         if (ConnectionString == null)
         {
@@ -78,9 +79,9 @@ public sealed class KeycloakSettingsMap : Dictionary<string, KeycloakSettings>
             throw new ConfigurationException();
         }
 
-        foreach (var (key, settings) in this)
+        foreach (var (_, settings) in this)
         {
-            settings.Validate(key);
+            settings.Validate();
         }
 
         return true;

--- a/src/keycloak/Keycloak.Library/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/KeycloakClient.cs
@@ -102,9 +102,11 @@ public partial class KeycloakClient
     private Task<IFlurlRequest> GetBaseUrlAsync(string targetRealm, CancellationToken cancellationToken = default)
     {
         var url = new Url(_url);
-        if(_useAuthTrail) 
+        if (_useAuthTrail)
+        {
             url = url
             .AppendPathSegment("/auth");
+        }
 
         return url
             .ConfigureRequest(settings => settings.JsonSerializer = _serializer)

--- a/src/keycloak/Keycloak.Library/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/KeycloakClient.cs
@@ -48,21 +48,23 @@ public partial class KeycloakClient
     private readonly Func<CancellationToken, Task<string>>? _getTokenAsync;
     private readonly string? _authRealm;
     private readonly string? _clientId;
+    private readonly bool _useAuthTrail;
 
     private KeycloakClient(string url)
     {
         _url = url;
     }
 
-    public KeycloakClient(string url, string userName, string password, string authRealm)
+    public KeycloakClient(string url, string? userName, string? password, string? authRealm, bool useAuthTrail)
         : this(url)
     {
         _userName = userName;
         _password = password;
         _authRealm = authRealm;
+        _useAuthTrail = useAuthTrail;
     }
 
-    private KeycloakClient(string url, string? userName, string? password, string? authRealm, string? clientId, string? clientSecret)
+    private KeycloakClient(string url, string? userName, string? password, string? authRealm, string? clientId, string? clientSecret, bool useAuthTrail)
         : this(url)
     {
         _userName = userName;
@@ -70,6 +72,7 @@ public partial class KeycloakClient
         _clientSecret = clientSecret;
         _clientId = clientId;
         _authRealm = authRealm;
+        _useAuthTrail = useAuthTrail;
     }
 
     public KeycloakClient(string url, Func<string> getToken, string? authRealm = null)
@@ -86,9 +89,9 @@ public partial class KeycloakClient
         _authRealm = authRealm;
     }
 
-    public static KeycloakClient CreateWithClientId(string url, string clientId, string clientSecret, string? authRealm = null)
+    public static KeycloakClient CreateWithClientId(string url, string? clientId, string? clientSecret, bool useAuthTrail, string? authRealm = null)
     {
-        return new KeycloakClient(url, userName: null, password: null, authRealm, clientId, clientSecret);
+        return new KeycloakClient(url, userName: null, password: null, authRealm, clientId, clientSecret, useAuthTrail);
     }
 
     public void SetSerializer(ISerializer serializer)
@@ -96,8 +99,15 @@ public partial class KeycloakClient
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
     }
 
-    private Task<IFlurlRequest> GetBaseUrlAsync(string targetRealm, CancellationToken cancellationToken = default) => new Url(_url)
-        .AppendPathSegment("/auth")
-        .ConfigureRequest(settings => settings.JsonSerializer = _serializer)
-        .WithAuthenticationAsync(_getTokenAsync, _url, _authRealm ?? targetRealm, _userName, _password, _clientSecret, _clientId, cancellationToken);
+    private Task<IFlurlRequest> GetBaseUrlAsync(string targetRealm, CancellationToken cancellationToken = default)
+    {
+        var url = new Url(_url);
+        if(_useAuthTrail) 
+            url = url
+            .AppendPathSegment("/auth");
+
+        return url
+            .ConfigureRequest(settings => settings.JsonSerializer = _serializer)
+            .WithAuthenticationAsync(_getTokenAsync, _url, _authRealm ?? targetRealm, _userName, _password, _clientSecret, _clientId, _useAuthTrail, cancellationToken);
+    }
 }

--- a/src/keycloak/Keycloak.Seeding/appsettings.json
+++ b/src/keycloak/Keycloak.Seeding/appsettings.json
@@ -27,7 +27,8 @@
       "ConnectionString": "",
       "User": "",
       "Password": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     }
   },
   "KeycloakSeeding": {

--- a/src/marketplace/Apps.Service/appsettings.json
+++ b/src/marketplace/Apps.Service/appsettings.json
@@ -35,13 +35,15 @@
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     },
     "shared": {
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     }
   },
   "JwtBearerOptions": {

--- a/src/marketplace/Services.Service/appsettings.json
+++ b/src/marketplace/Services.Service/appsettings.json
@@ -35,13 +35,15 @@
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     },
     "shared": {
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     }
   },
   "JwtBearerOptions": {

--- a/src/notifications/Notifications.Service/appsettings.json
+++ b/src/notifications/Notifications.Service/appsettings.json
@@ -31,13 +31,15 @@
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     },
     "shared": {
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     }
   },
   "ConnectionStrings": {

--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -25,13 +25,15 @@
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     },
     "shared": {
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     }
   },
   "ConnectionStrings": {

--- a/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
@@ -62,7 +62,7 @@ public partial class ProvisioningManager
     }.ToImmutableDictionary();
 
     public async ValueTask<string> GetNextCentralIdentityProviderNameAsync() =>
-        _Settings.IdpPrefix + (await _ProvisioningDBAccess!.GetNextIdentityProviderSequenceAsync().ConfigureAwait(false));
+        $"{_Settings.IdpPrefix}{await _ProvisioningDBAccess!.GetNextIdentityProviderSequenceAsync().ConfigureAwait(false)}";
 
     private Task CreateCentralIdentityProviderAsync(string alias, string displayName, IdentityProvider identityProvider)
     {

--- a/src/provisioning/Provisioning.Library/Provisioning.Library.csproj
+++ b/src/provisioning/Provisioning.Library/Provisioning.Library.csproj
@@ -20,6 +20,14 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <AssemblyName>Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library</AssemblyName>
+    <RootNamespace>Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library</RootNamespace>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Provisioning.DBAccess\Provisioning.DBAccess.csproj" />
     <ProjectReference Include="..\..\keycloak\Keycloak.ErrorHandling\Keycloak.ErrorHandling.csproj" />
@@ -36,12 +44,5 @@
     <PackageReference Include="PasswordGenerator" Version="2.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <AssemblyName>Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library</AssemblyName>
-    <TargetFramework>net7.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
 
 </Project>

--- a/src/provisioning/Provisioning.Library/ProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningManager.cs
@@ -54,7 +54,7 @@ public partial class ProvisioningManager : IProvisioningManager
         await CreateCentralIdentityProviderAsync(idpName, organisationName, _Settings.CentralIdentityProvider).ConfigureAwait(false);
 
         var (clientId, secret) = await CreateSharedIdpServiceAccountAsync(idpName).ConfigureAwait(false);
-        var sharedKeycloak = _Factory.CreateKeycloakClient("shared", clientId, secret);
+        var sharedKeycloak = _Factory.CreateKeycloakClient("shared", clientId, secret, _Settings.UseAuthTrail);
 
         await CreateSharedRealmAsync(sharedKeycloak, idpName, organisationName, loginTheme).ConfigureAwait(false);
 
@@ -285,7 +285,7 @@ public partial class ProvisioningManager : IProvisioningManager
     private async Task<KeycloakClient> GetSharedKeycloakClient(string realm)
     {
         var (clientId, secret) = await GetSharedIdpServiceAccountSecretAsync(realm).ConfigureAwait(false);
-        return _Factory.CreateKeycloakClient("shared", clientId, secret);
+        return _Factory.CreateKeycloakClient("shared", clientId, secret, _Settings.UseAuthTrail);
     }
 
     private static T Clone<T>(T cloneObject)

--- a/src/provisioning/Provisioning.Library/ProvisioningSettings.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningSettings.cs
@@ -31,7 +31,10 @@ public partial class ProvisioningSettings
     public string ClientPrefix { get; set; }
     public string MappedCompanyAttribute { get; set; }
     public string MappedBpnAttribute { get; set; }
+
     public string UserNameMapperTemplate { get; set; }
+
+    public bool UseAuthTrail { get; set; }
 }
 
 public static class ProvisioningSettingsExtension

--- a/src/registration/Registration.Service/appsettings.json
+++ b/src/registration/Registration.Service/appsettings.json
@@ -78,13 +78,15 @@
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     },
     "shared": {
       "ConnectionString": "",
       "ClientId": "",
       "ClientSecret": "",
-      "AuthRealm": ""
+      "AuthRealm": "",
+      "UseAuthTrail": false
     }
   },
   "JwtBearerOptions": {

--- a/tests/provisioning/Provisioning.Library.Tests/Extensions/ClientManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/Extensions/ClientManagerTests.cs
@@ -115,7 +115,7 @@ public class ClientManagerTests
         await _sut.UpdateClient(clientId, $"{url}/*", url).ConfigureAwait(false);
 
         // Assert
-        httpTest.ShouldHaveCalled($"{CentralUrl}/auth/admin/realms/test/clients/{clientClientId}")
+        httpTest.ShouldHaveCalled($"{CentralUrl}/admin/realms/test/clients/{clientClientId}")
             .WithVerb(HttpMethod.Put)
             .Times(1);
     }
@@ -157,7 +157,7 @@ public class ClientManagerTests
         await _sut.EnableClient(clientId).ConfigureAwait(false);
 
         // Assert
-        httpTest.ShouldHaveCalled($"{CentralUrl}/auth/admin/realms/test/clients/{clientClientId}")
+        httpTest.ShouldHaveCalled($"{CentralUrl}/admin/realms/test/clients/{clientClientId}")
             .WithVerb(HttpMethod.Put)
             .Times(1);
     }

--- a/tests/provisioning/Provisioning.Library.Tests/Extensions/ClientManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/Extensions/ClientManagerTests.cs
@@ -51,11 +51,11 @@ public class ClientManagerTests
         var keycloakFactory = A.Fake<IKeycloakFactory>();
         _provisioningDbAccess = A.Fake<IProvisioningDBAccess>();
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("central"))
-            .Returns(new KeycloakClient(CentralUrl, "test", "test", "test"));
+            .Returns(new KeycloakClient(CentralUrl, "test", "test", "test", false));
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared"))
-            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test"));
-        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._))
-            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test"));
+            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
+        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._, A<bool>._))
+            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
         var settings = new ProvisioningSettings
         {
             ClientPrefix = "cl",

--- a/tests/provisioning/Provisioning.Library.Tests/Extensions/RoleManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/Extensions/RoleManagerTests.cs
@@ -42,7 +42,7 @@ public class RoleManagerTests
 
         var keycloakFactory = A.Fake<IKeycloakFactory>();
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("central"))
-            .Returns(new KeycloakClient("https://test.de", "test", "test", "test"));
+            .Returns(new KeycloakClient("https://test.de", "test", "test", "test", false));
         var settings = new ProvisioningSettings
         {
             CentralRealm = "test"

--- a/tests/provisioning/Provisioning.Library.Tests/FlurlSetup/FlurlSetupExtensions.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/FlurlSetup/FlurlSetupExtensions.cs
@@ -32,7 +32,7 @@ public static class FlurlSetupExtensions
 {
     public static HttpTest WithAuthorization(this HttpTest testClient)
     {
-        testClient.ForCallsTo("*/auth/realms/*/protocol/openid-connect/token")
+        testClient.ForCallsTo("*/realms/*/protocol/openid-connect/token")
             .RespondWithJson(new { access_token = "123" });
         return testClient;
     }
@@ -72,7 +72,7 @@ public static class FlurlSetupExtensions
 
     public static HttpTest WithGetOpenIdConfigurationAsync(this HttpTest testClient, OpenIDConfiguration config)
     {
-        testClient.ForCallsTo($"*/realms/*/.well-known/openid-configuration")
+        testClient.ForCallsTo("*/realms/*/.well-known/openid-configuration")
             .WithVerb(HttpMethod.Get)
             .RespondWithJson(config);
         return testClient;

--- a/tests/provisioning/Provisioning.Library.Tests/ProvisioningManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/ProvisioningManagerTests.cs
@@ -117,10 +117,10 @@ public class ProvisioningManagerTests
         await _sut.SetupClientAsync($"{url}/*", url, new[] { "adminRole" }).ConfigureAwait(false);
 
         // Assert
-        httpTest.ShouldHaveCalled($"{CentralUrl}/auth/admin/realms/test/clients/{newClientId}/protocol-mappers/models")
+        httpTest.ShouldHaveCalled($"{CentralUrl}/admin/realms/test/clients/{newClientId}/protocol-mappers/models")
             .WithVerb(HttpMethod.Post)
             .Times(1);
-        httpTest.ShouldHaveCalled($"{CentralUrl}/auth/admin/realms/test/clients/{newClientId}/roles")
+        httpTest.ShouldHaveCalled($"{CentralUrl}/admin/realms/test/clients/{newClientId}/roles")
             .WithVerb(HttpMethod.Post)
             .Times(1);
     }
@@ -151,22 +151,22 @@ public class ProvisioningManagerTests
         await _sut.SetupSharedIdpAsync(ValidClientName, OrgName, LoginTheme).ConfigureAwait(false);
 
         // Assert
-        httpTest.ShouldHaveCalled($"{CentralUrl}/auth/admin/realms/test/identity-provider/instances")
+        httpTest.ShouldHaveCalled($"{CentralUrl}/admin/realms/test/identity-provider/instances")
             .WithVerb(HttpMethod.Post)
             .Times(1);
-        httpTest.ShouldHaveCalled($"{SharedUrl}/auth/admin/realms/master/clients")
+        httpTest.ShouldHaveCalled($"{SharedUrl}/admin/realms/master/clients")
             .WithVerb(HttpMethod.Post)
             .Times(1);
-        httpTest.ShouldHaveCalled($"{SharedUrl}/auth/admin/realms/master/users/{userId}/role-mappings/realm")
+        httpTest.ShouldHaveCalled($"{SharedUrl}/admin/realms/master/users/{userId}/role-mappings/realm")
             .WithVerb(HttpMethod.Post)
             .Times(1);
-        httpTest.ShouldHaveCalled($"{SharedUrl}/auth/admin/realms")
+        httpTest.ShouldHaveCalled($"{SharedUrl}/admin/realms")
             .WithVerb(HttpMethod.Post)
             .Times(1);
-        httpTest.ShouldHaveCalled($"{CentralUrl}/auth/admin/realms/test/identity-provider/instances/{ValidClientName}")
+        httpTest.ShouldHaveCalled($"{CentralUrl}/admin/realms/test/identity-provider/instances/{ValidClientName}")
             .WithVerb(HttpMethod.Put)
             .Times(2);
-        httpTest.ShouldHaveCalled($"{CentralUrl}/auth/admin/realms/test/identity-provider/instances/{ValidClientName}/mappers")
+        httpTest.ShouldHaveCalled($"{CentralUrl}/admin/realms/test/identity-provider/instances/{ValidClientName}/mappers")
             .WithVerb(HttpMethod.Post)
             .Times(1);
     }
@@ -187,10 +187,10 @@ public class ProvisioningManagerTests
         await _sut.UpdateSharedIdentityProviderAsync(ValidClientName, "displayName").ConfigureAwait(false);
 
         // Arrange
-        httpTest.ShouldHaveCalled($"{SharedUrl}/auth/admin/realms/{ValidClientName}")
+        httpTest.ShouldHaveCalled($"{SharedUrl}/admin/realms/{ValidClientName}")
             .WithVerb(HttpMethod.Put)
             .Times(1);
-        httpTest.ShouldHaveCalled($"{CentralUrl}/auth/admin/realms/test/identity-provider/instances/{ValidClientName}")
+        httpTest.ShouldHaveCalled($"{CentralUrl}/admin/realms/test/identity-provider/instances/{ValidClientName}")
             .WithVerb(HttpMethod.Put)
             .Times(1);
     }
@@ -211,7 +211,7 @@ public class ProvisioningManagerTests
         await _sut.UpdateSharedRealmTheme(ValidClientName, "new-theme").ConfigureAwait(false);
 
         // Arrange
-        httpTest.ShouldHaveCalled($"{SharedUrl}/auth/admin/realms/{ValidClientName}")
+        httpTest.ShouldHaveCalled($"{SharedUrl}/admin/realms/{ValidClientName}")
             .WithVerb(HttpMethod.Put)
             .Times(1);
     }

--- a/tests/provisioning/Provisioning.Library.Tests/ProvisioningManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/ProvisioningManagerTests.cs
@@ -56,11 +56,11 @@ public class ProvisioningManagerTests
         var keycloakFactory = A.Fake<IKeycloakFactory>();
         _provisioningDbAccess = A.Fake<IProvisioningDBAccess>();
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("central"))
-            .Returns(new KeycloakClient(CentralUrl, "test", "test", "test"));
+            .Returns(new KeycloakClient(CentralUrl, "test", "test", "test", false));
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared"))
-            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test"));
-        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._))
-            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test"));
+            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
+        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._, A<bool>._))
+            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
         var settings = new ProvisioningSettings
         {
             ClientPrefix = "cl",

--- a/tests/provisioning/Provisioning.Library.Tests/UserManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/UserManagerTests.cs
@@ -55,11 +55,11 @@ public class UserManagerTests
         var keycloakFactory = A.Fake<IKeycloakFactory>();
         _provisioningDbAccess = A.Fake<IProvisioningDBAccess>();
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("central"))
-            .Returns(new KeycloakClient(CentralUrl, "test", "test", "test"));
+            .Returns(new KeycloakClient(CentralUrl, "test", "test", "test", false));
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared"))
-            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test"));
-        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._))
-            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test"));
+            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
+        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._, A<bool>._))
+            .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
         var settings = new ProvisioningSettings
         {
             ClientPrefix = "cl",


### PR DESCRIPTION
## Description

Make the auth path of keycloak configureable

## Why

With the keycloak upgrade the /auth path in the urls of keycloak was removed, to be able to still use older versions its now configurable

## Issue

N/A - Jira Issue: CPLP-3214

## Depending CD PR
[#95](https://github.com/eclipse-tractusx/portal-cd/pull/95)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
