### PR TITLE
fix(n2n): register network process worker

### DIFF
--- a/src/processes/NetworkRegistration.Executor/DependencyInjection/NetworkRegistrationProcessCollectionExtensions.cs
+++ b/src/processes/NetworkRegistration.Executor/DependencyInjection/NetworkRegistrationProcessCollectionExtensions.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.OnboardingServiceProvider.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.NetworkRegistration.Library.DependencyInjection;
+using Org.Eclipse.TractusX.Portal.Backend.Processes.Worker.Library;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Processes.NetworkRegistration.Executor.DependencyInjection;
 
@@ -29,5 +30,6 @@ public static class NetworkRegistrationProcessCollectionExtensions
 {
     public static IServiceCollection AddNetworkRegistrationProcessExecutor(this IServiceCollection services, IConfiguration config) =>
         services.AddNetworkRegistrationHandler(config)
-                .AddOnboardingServiceProviderService(config);
+                .AddOnboardingServiceProviderService(config)
+                .AddTransient<IProcessTypeExecutor, NetworkRegistrationProcessTypeExecutor>();
 }


### PR DESCRIPTION
## Description

Network process worker has been registered

## Why

To be able to run the network processes the worker needs to be registered

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
