### PR TITLE
chore(localdev):  enhance image image build and launchsettings

### DIFF
--- a/.github/workflows/administration-service.yml
+++ b/.github/workflows/administration-service.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4

--- a/.github/workflows/administration-service.yml
+++ b/.github/workflows/administration-service.yml
@@ -61,6 +61,9 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -75,6 +78,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-administration-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/iam-seeding.yml
+++ b/.github/workflows/iam-seeding.yml
@@ -55,6 +55,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -69,6 +75,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-iam-seeding
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/maintenance-service.yml
+++ b/.github/workflows/maintenance-service.yml
@@ -56,6 +56,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -70,6 +76,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-maintenance-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/marketplace-app-service.yml
+++ b/.github/workflows/marketplace-app-service.yml
@@ -59,6 +59,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -73,6 +79,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-marketplace-app-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/notification-service.yml
+++ b/.github/workflows/notification-service.yml
@@ -58,6 +58,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -72,6 +78,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-notification-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/portal-migrations.yml
+++ b/.github/workflows/portal-migrations.yml
@@ -56,6 +56,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -70,6 +76,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-portal-migrations
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/processes-worker.yml
+++ b/.github/workflows/processes-worker.yml
@@ -58,6 +58,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -72,6 +78,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-processes-worker
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/provisioning-migrations.yml
+++ b/.github/workflows/provisioning-migrations.yml
@@ -56,6 +56,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -70,6 +76,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-provisioning-migrations
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/registration-service.yml
+++ b/.github/workflows/registration-service.yml
@@ -59,6 +59,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -73,6 +79,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-registration-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -70,6 +76,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-administration-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -101,6 +108,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -115,6 +128,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-processes-worker
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -146,6 +160,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -160,6 +180,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-registration-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -191,6 +212,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -205,6 +232,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-marketplace-app-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -236,6 +264,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -250,6 +284,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-portal-migrations
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -281,6 +316,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -295,6 +336,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-maintenance-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -326,6 +368,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -340,6 +388,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-notification-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -371,6 +420,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -385,6 +440,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-services-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -416,6 +472,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -430,6 +492,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-provisioning-migrations
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -54,6 +54,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -68,6 +74,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-administration-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -99,6 +106,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -113,6 +126,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-processes-worker
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -144,6 +158,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -158,6 +178,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-registration-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -189,6 +210,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -203,6 +230,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-marketplace-app-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -234,6 +262,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -248,6 +282,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-portal-migrations
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -279,6 +314,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -293,6 +334,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-maintenance-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -324,6 +366,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -338,6 +386,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-notification-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -369,6 +418,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -383,6 +438,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-services-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -414,6 +470,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -428,6 +490,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-provisioning-migrations
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release_iam-seeding.yml
+++ b/.github/workflows/release_iam-seeding.yml
@@ -46,6 +46,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -60,6 +66,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-iam-seeding
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release_release_candidate.yml
+++ b/.github/workflows/release_release_candidate.yml
@@ -54,6 +54,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -68,6 +74,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-administration-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -99,6 +106,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -113,6 +126,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-processes-worker
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -144,6 +158,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -158,6 +178,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-registration-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -189,6 +210,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -203,6 +230,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-marketplace-app-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -234,6 +262,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -248,6 +282,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-portal-migrations
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -279,6 +314,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -293,6 +334,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-maintenance-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -324,6 +366,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -338,6 +386,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-notification-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -369,6 +418,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -383,6 +438,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-services-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -414,6 +470,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -428,6 +490,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-provisioning-migrations
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/services-service.yml
+++ b/.github/workflows/services-service.yml
@@ -59,6 +59,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -73,6 +79,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile-services-service
+          platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/docker/Dockerfile-administration-service
+++ b/docker/Dockerfile-administration-service
@@ -19,17 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/administration/Administration.Service
-RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-administration-service
+++ b/docker/Dockerfile-administration-service
@@ -19,15 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/administration/Administration.Service
-RUN dotnet build "Administration.Service.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-iam-seeding
+++ b/docker/Dockerfile-iam-seeding
@@ -19,12 +19,7 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/framework/Framework.Async /src/framework/Framework.Async
@@ -37,7 +32,7 @@ COPY /src/keycloak/Keycloak.Factory /src/keycloak/Keycloak.Factory
 COPY /src/keycloak/Keycloak.Library /src/keycloak/Keycloak.Library
 COPY /src/keycloak/Keycloak.Seeding /src/keycloak/Keycloak.Seeding
 WORKDIR /src/keycloak/Keycloak.Seeding
-RUN dotnet publish "Keycloak.Seeding.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Keycloak.Seeding.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-iam-seeding
+++ b/docker/Dockerfile-iam-seeding
@@ -19,7 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/framework/Framework.Async /src/framework/Framework.Async
@@ -32,10 +37,7 @@ COPY /src/keycloak/Keycloak.Factory /src/keycloak/Keycloak.Factory
 COPY /src/keycloak/Keycloak.Library /src/keycloak/Keycloak.Library
 COPY /src/keycloak/Keycloak.Seeding /src/keycloak/Keycloak.Seeding
 WORKDIR /src/keycloak/Keycloak.Seeding
-RUN dotnet build "Keycloak.Seeding.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Keycloak.Seeding.csproj" -c Release -o /app/publish
+RUN dotnet publish "Keycloak.Seeding.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -19,12 +19,7 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/maintenance/Maintenance.App/ src/maintenance/Maintenance.App/
@@ -39,7 +34,7 @@ COPY src/framework/Framework.ProcessIdentity/ src/framework/Framework.ProcessIde
 COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 RUN dotnet restore "src/maintenance/Maintenance.App/Maintenance.App.csproj"
 WORKDIR /src/maintenance/Maintenance.App
-RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -19,7 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/maintenance/Maintenance.App/ src/maintenance/Maintenance.App/
@@ -34,10 +39,7 @@ COPY src/framework/Framework.ProcessIdentity/ src/framework/Framework.ProcessIde
 COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 RUN dotnet restore "src/maintenance/Maintenance.App/Maintenance.App.csproj"
 WORKDIR /src/maintenance/Maintenance.App
-RUN dotnet build "Maintenance.App.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish
+RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-marketplace-app-service
+++ b/docker/Dockerfile-marketplace-app-service
@@ -19,17 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/marketplace/Apps.Service
-RUN dotnet publish "Apps.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Apps.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-marketplace-app-service
+++ b/docker/Dockerfile-marketplace-app-service
@@ -19,15 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/marketplace/Apps.Service
-RUN dotnet build "Apps.Service.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Apps.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Apps.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-notification-service
+++ b/docker/Dockerfile-notification-service
@@ -19,17 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/notifications/Notifications.Service
-RUN dotnet publish "Notifications.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Notifications.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-notification-service
+++ b/docker/Dockerfile-notification-service
@@ -19,15 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/notifications/Notifications.Service
-RUN dotnet build "Notifications.Service.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Notifications.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Notifications.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -19,7 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/portalbackend /src/portalbackend
@@ -33,9 +38,6 @@ COPY /src/framework/Framework.ProcessIdentity /src/framework/Framework.ProcessId
 COPY /src/framework/Framework.Seeding /src/framework/Framework.Seeding
 COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 WORKDIR /src/portalbackend/PortalBackend.Migrations
-RUN dotnet build "PortalBackend.Migrations.csproj" -c Release -o /migrations/build
-
-FROM build AS publish
 RUN dotnet publish "PortalBackend.Migrations.csproj" -c Release -o /migrations/publish
 
 FROM base AS final

--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -19,12 +19,7 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/portalbackend /src/portalbackend

--- a/docker/Dockerfile-processes-worker
+++ b/docker/Dockerfile-processes-worker
@@ -19,18 +19,13 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 RUN dotnet restore "src/processes/Processes.Worker/Processes.Worker.csproj"
 WORKDIR /src/processes/Processes.Worker
-RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-processes-worker
+++ b/docker/Dockerfile-processes-worker
@@ -19,16 +19,18 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 RUN dotnet restore "src/processes/Processes.Worker/Processes.Worker.csproj"
 WORKDIR /src/processes/Processes.Worker
-RUN dotnet build "Processes.Worker.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish
+RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-provisioning-migrations
+++ b/docker/Dockerfile-provisioning-migrations
@@ -19,12 +19,7 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/provisioning /src/provisioning

--- a/docker/Dockerfile-provisioning-migrations
+++ b/docker/Dockerfile-provisioning-migrations
@@ -19,7 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/provisioning /src/provisioning
@@ -30,9 +35,6 @@ COPY /src/framework/Framework.Models /src/framework/Framework.Models
 COPY /src/framework/Framework.Linq /src/framework/Framework.Linq
 COPY /src/framework/Framework.Logging /src/framework/Framework.Logging
 WORKDIR /src/provisioning/Provisioning.Migrations
-RUN dotnet build "Provisioning.Migrations.csproj" -c Release -o /migrations/build
-
-FROM build AS publish
 RUN dotnet publish "Provisioning.Migrations.csproj" -c Release -o /migrations/publish
 
 FROM base AS final

--- a/docker/Dockerfile-registration-service
+++ b/docker/Dockerfile-registration-service
@@ -19,15 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/registration/Registration.Service
-RUN dotnet build "Registration.Service.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Registration.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Registration.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-registration-service
+++ b/docker/Dockerfile-registration-service
@@ -19,17 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/registration/Registration.Service
-RUN dotnet publish "Registration.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Registration.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-services-service
+++ b/docker/Dockerfile-services-service
@@ -19,15 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/marketplace/Services.Service
-RUN dotnet build "Services.Service.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Services.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Services.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-services-service
+++ b/docker/Dockerfile-services-service
@@ -19,17 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/marketplace/Services.Service
-RUN dotnet publish "Services.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Services.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/src/administration/Administration.Service/Properties/launchSettings.json
+++ b/src/administration/Administration.Service/Properties/launchSettings.json
@@ -24,7 +24,8 @@
       "launchUrl": "api/administration/swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "Cors__AllowedOrigins__0": "http://localhost:3000"
+        "Cors__AllowedOrigins__0": "http://localhost:3000",
+        "Cors__AllowedOrigins__1": "https://portal.example.org"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },

--- a/src/marketplace/Apps.Service/Properties/launchSettings.json
+++ b/src/marketplace/Apps.Service/Properties/launchSettings.json
@@ -17,7 +17,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Cors__AllowedOrigins__0": "http://localhost:3000"
       },
-      "applicationUrl": "https://localhost:7202;http://localhost:5202",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "dotnetRunMessages": true
     },
     "IIS Express": {
@@ -25,7 +25,8 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "Cors__AllowedOrigins__0": "http://localhost:3000"
+        "Cors__AllowedOrigins__0": "http://localhost:3000",
+        "Cors__AllowedOrigins__1": "https://portal.example.org"
       }
     },
     "Docker": {

--- a/src/marketplace/Services.Service/Properties/launchSettings.json
+++ b/src/marketplace/Services.Service/Properties/launchSettings.json
@@ -22,7 +22,8 @@
       "launchUrl": "api/services/swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "Cors__AllowedOrigins__0": "http://localhost:3000"
+        "Cors__AllowedOrigins__0": "http://localhost:3000",
+        "Cors__AllowedOrigins__1": "https://portal.example.org"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },

--- a/src/notifications/Notifications.Service/Properties/launchSettings.json
+++ b/src/notifications/Notifications.Service/Properties/launchSettings.json
@@ -24,7 +24,8 @@
       "launchUrl": "api/notification/swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "Cors__AllowedOrigins__0": "http://localhost:3000"
+        "Cors__AllowedOrigins__0": "http://localhost:3000",
+        "Cors__AllowedOrigins__1": "https://portal.example.org"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },

--- a/src/registration/Registration.Service/Properties/launchSettings.json
+++ b/src/registration/Registration.Service/Properties/launchSettings.json
@@ -24,7 +24,8 @@
       "launchUrl": "api/registration/swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "Cors__AllowedOrigins__0": "http://localhost:3000"
+        "Cors__AllowedOrigins__0": "http://localhost:3000",
+        "Cors__AllowedOrigins__1": "https://portal.example.org"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },


### PR DESCRIPTION
## Description

- build images also for arm64, in addition to amd64
- improve dockerfiles - 'dotnet build' not needed as implicit of 'dotnet publish'
- change launchsettings
  - cors for localdev env
  - align applicationUrl for apps service

## Why

enable localdev umbrella chart: arm64 images needed for usage on Mac

## Issue

[localdev](https://github.com/eclipse-tractusx/portal-cd/pull/90)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
