### PR TITLE
fix(arch): build arm64 images

### DIFF
--- a/docker/Dockerfile-administration-service
+++ b/docker/Dockerfile-administration-service
@@ -19,12 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/administration/Administration.Service
-RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-administration-service
+++ b/docker/Dockerfile-administration-service
@@ -20,16 +20,11 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/administration/Administration.Service
-RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-administration-service
+++ b/docker/Dockerfile-administration-service
@@ -20,11 +20,16 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/administration/Administration.Service
-RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-iam-seeding
+++ b/docker/Dockerfile-iam-seeding
@@ -20,11 +20,6 @@
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/framework/Framework.Async /src/framework/Framework.Async
@@ -37,7 +32,7 @@ COPY /src/keycloak/Keycloak.Factory /src/keycloak/Keycloak.Factory
 COPY /src/keycloak/Keycloak.Library /src/keycloak/Keycloak.Library
 COPY /src/keycloak/Keycloak.Seeding /src/keycloak/Keycloak.Seeding
 WORKDIR /src/keycloak/Keycloak.Seeding
-RUN dotnet publish "Keycloak.Seeding.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Keycloak.Seeding.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-iam-seeding
+++ b/docker/Dockerfile-iam-seeding
@@ -19,7 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/framework/Framework.Async /src/framework/Framework.Async
@@ -32,7 +37,7 @@ COPY /src/keycloak/Keycloak.Factory /src/keycloak/Keycloak.Factory
 COPY /src/keycloak/Keycloak.Library /src/keycloak/Keycloak.Library
 COPY /src/keycloak/Keycloak.Seeding /src/keycloak/Keycloak.Seeding
 WORKDIR /src/keycloak/Keycloak.Seeding
-RUN dotnet publish "Keycloak.Seeding.csproj" -c Release -o /app/publish
+RUN dotnet publish "Keycloak.Seeding.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -19,7 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/maintenance/Maintenance.App/ src/maintenance/Maintenance.App/
@@ -34,7 +39,7 @@ COPY src/framework/Framework.ProcessIdentity/ src/framework/Framework.ProcessIde
 COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 RUN dotnet restore "src/maintenance/Maintenance.App/Maintenance.App.csproj"
 WORKDIR /src/maintenance/Maintenance.App
-RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish
+RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -20,11 +20,6 @@
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/maintenance/Maintenance.App/ src/maintenance/Maintenance.App/
@@ -39,7 +34,7 @@ COPY src/framework/Framework.ProcessIdentity/ src/framework/Framework.ProcessIde
 COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 RUN dotnet restore "src/maintenance/Maintenance.App/Maintenance.App.csproj"
 WORKDIR /src/maintenance/Maintenance.App
-RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-marketplace-app-service
+++ b/docker/Dockerfile-marketplace-app-service
@@ -20,16 +20,11 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/marketplace/Apps.Service
-RUN dotnet publish "Apps.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Apps.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-marketplace-app-service
+++ b/docker/Dockerfile-marketplace-app-service
@@ -19,12 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/marketplace/Apps.Service
-RUN dotnet publish "Apps.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Apps.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-notification-service
+++ b/docker/Dockerfile-notification-service
@@ -20,16 +20,11 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/notifications/Notifications.Service
-RUN dotnet publish "Notifications.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Notifications.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-notification-service
+++ b/docker/Dockerfile-notification-service
@@ -19,12 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/notifications/Notifications.Service
-RUN dotnet publish "Notifications.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Notifications.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -20,11 +20,6 @@
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/portalbackend /src/portalbackend
@@ -38,7 +33,7 @@ COPY /src/framework/Framework.ProcessIdentity /src/framework/Framework.ProcessId
 COPY /src/framework/Framework.Seeding /src/framework/Framework.Seeding
 COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 WORKDIR /src/portalbackend/PortalBackend.Migrations
-RUN dotnet publish "PortalBackend.Migrations.csproj" -c Release -o /migrations/publish -r $(cat /tmp/rid)
+RUN dotnet publish "PortalBackend.Migrations.csproj" -c Release -o /migrations/publish
 
 FROM base AS final
 WORKDIR /migrations

--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -19,7 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/portalbackend /src/portalbackend
@@ -33,7 +38,7 @@ COPY /src/framework/Framework.ProcessIdentity /src/framework/Framework.ProcessId
 COPY /src/framework/Framework.Seeding /src/framework/Framework.Seeding
 COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 WORKDIR /src/portalbackend/PortalBackend.Migrations
-RUN dotnet publish "PortalBackend.Migrations.csproj" -c Release -o /migrations/publish
+RUN dotnet publish "PortalBackend.Migrations.csproj" -c Release -o /migrations/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /migrations

--- a/docker/Dockerfile-processes-worker
+++ b/docker/Dockerfile-processes-worker
@@ -19,13 +19,18 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 RUN dotnet restore "src/processes/Processes.Worker/Processes.Worker.csproj"
 WORKDIR /src/processes/Processes.Worker
-RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish
+RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-processes-worker
+++ b/docker/Dockerfile-processes-worker
@@ -20,17 +20,12 @@
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 RUN dotnet restore "src/processes/Processes.Worker/Processes.Worker.csproj"
 WORKDIR /src/processes/Processes.Worker
-RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-provisioning-migrations
+++ b/docker/Dockerfile-provisioning-migrations
@@ -19,7 +19,12 @@
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/provisioning /src/provisioning
@@ -30,7 +35,7 @@ COPY /src/framework/Framework.Models /src/framework/Framework.Models
 COPY /src/framework/Framework.Linq /src/framework/Framework.Linq
 COPY /src/framework/Framework.Logging /src/framework/Framework.Logging
 WORKDIR /src/provisioning/Provisioning.Migrations
-RUN dotnet publish "Provisioning.Migrations.csproj" -c Release -o /migrations/publish
+RUN dotnet publish "Provisioning.Migrations.csproj" -c Release -o /migrations/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /migrations

--- a/docker/Dockerfile-provisioning-migrations
+++ b/docker/Dockerfile-provisioning-migrations
@@ -20,11 +20,6 @@
 FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/provisioning /src/provisioning
@@ -35,7 +30,7 @@ COPY /src/framework/Framework.Models /src/framework/Framework.Models
 COPY /src/framework/Framework.Linq /src/framework/Framework.Linq
 COPY /src/framework/Framework.Logging /src/framework/Framework.Logging
 WORKDIR /src/provisioning/Provisioning.Migrations
-RUN dotnet publish "Provisioning.Migrations.csproj" -c Release -o /migrations/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Provisioning.Migrations.csproj" -c Release -o /migrations/publish
 
 FROM base AS final
 WORKDIR /migrations

--- a/docker/Dockerfile-registration-service
+++ b/docker/Dockerfile-registration-service
@@ -20,16 +20,11 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/registration/Registration.Service
-RUN dotnet publish "Registration.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Registration.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-registration-service
+++ b/docker/Dockerfile-registration-service
@@ -19,12 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/registration/Registration.Service
-RUN dotnet publish "Registration.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Registration.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-services-service
+++ b/docker/Dockerfile-services-service
@@ -20,16 +20,11 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
-ARG TARGETARCH
-ARG TARGETOS
-RUN arch=$TARGETARCH \
-    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
-    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/marketplace/Services.Service
-RUN dotnet publish "Services.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
+RUN dotnet publish "Services.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app

--- a/docker/Dockerfile-services-service
+++ b/docker/Dockerfile-services-service
@@ -19,12 +19,17 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+ARG TARGETARCH
+ARG TARGETOS
+RUN arch=$TARGETARCH \
+    && if [ "$arch" = "amd64" ]; then arch="x64"; fi \
+    && echo $TARGETOS-$arch > /tmp/rid
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
 WORKDIR /src/marketplace/Services.Service
-RUN dotnet publish "Services.Service.csproj" -c Release -o /app/publish
+RUN dotnet publish "Services.Service.csproj" -c Release -o /app/publish -r $(cat /tmp/rid)
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
## Description

fix image build enabling for arm64

## Why

docker build and push fails after https://github.com/eclipse-tractusx/portal-backend/pull/277

## Issue

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes https://github.com/eclipse-tractusx/portal-backend/actions/runs/6337051850
