### PR TITLE
chore(e2e): exclude e2e tests from sonar coverage

### DIFF
--- a/tests/endtoend/EndToEnd.Tests.csproj
+++ b/tests/endtoend/EndToEnd.Tests.csproj
@@ -27,6 +27,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <UserSecretsId>89b874aa-64fd-4b0b-906a-89beb21c09e6</UserSecretsId>
+    <!-- Exclude the project from analysis -->
+    <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

exclude e2e tests from sonar coverage

## Why

coverage from ci sonar scan decreased significantly with e2e test project.
apparently tests project are also part of the coverage analysis.

## Issue

n/a

## Checklist

- [x] I have performed a self-review of my own code
