### PR TITLE
fix(seeding-data): change user_entity_id

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
@@ -46,7 +46,7 @@
     "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
     "date_created": "2023-01-01 18:01:33.439000 +00:00",
     "user_status_id": 1,
-    "user_entity_id": "4ba959c0-3d44-40bc-84ab-13019b8e4b7a",
+    "user_entity_id": "f0c69a64-dfbe-46e4-92db-75f6f4670909",
     "identity_type_id": 2
   },
   {
@@ -54,7 +54,7 @@
     "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
     "date_created": "2023-01-01 18:01:33.439000 +00:00",
     "user_status_id": 1,
-    "user_entity_id": "69ac2d10-0ae2-4e0e-98f2-35610f54957e",
+    "user_entity_id": "18c3a6b3-ecfe-4572-bbb4-af0c1823f206",
     "identity_type_id": 2
   },
   {
@@ -62,7 +62,7 @@
     "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
     "date_created": "2023-01-01 18:01:33.439000 +00:00",
     "user_status_id": 1,
-    "user_entity_id": "383eaec3-4332-47fa-9279-28edc74cb752",
+    "user_entity_id": "dcb9a153-e1b4-4fac-bc51-7032023e9db9",
     "identity_type_id": 2
   },
   {


### PR DESCRIPTION
## Description

change to correct user_entity_id's of the CX-Central realm (centralidp) for the following service accounts:
- sa-cl2-01
- sa-cl2-02
- sa-cl8-cx-1

## Why

service account policy is failing.
was missed during previous check: https://github.com/eclipse-tractusx/portal-backend/pull/210

manual update statement:
```sql
UPDATE portal.identities
SET user_entity_id = CASE id
    WHEN '7e85a0b8-0001-ab67-10d1-0ef508201026' THEN 'f0c69a64-dfbe-46e4-92db-75f6f4670909'
    WHEN '7e85a0b8-0001-ab67-10d1-0ef508201027' THEN '18c3a6b3-ecfe-4572-bbb4-af0c1823f206'
    WHEN '7e85a0b8-0001-ab67-10d1-0ef508201028' THEN 'dcb9a153-e1b4-4fac-bc51-7032023e9db9'
    ELSE user_entity_id
END
WHERE id IN ('7e85a0b8-0001-ab67-10d1-0ef508201026', '7e85a0b8-0001-ab67-10d1-0ef508201027', '7e85a0b8-0001-ab67-10d1-0ef508201028');
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally