### PR TITLE
fix(sonar): adjust sonarcloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -70,6 +70,6 @@ jobs:
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"${{ vars.SONAR_PROJECT_KEY }}" /o:"${{ vars.SONAR_ORGANIZATION }}" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=src/coverage.xml
           dotnet build src
           cd src
-          dotnet-coverage collect 'dotnet test --filter FullyQualifiedName\!~Org.Eclipse.TractusX.Portal.Backend.EndToEnd.Tests --no-restore --verbosity normal' -s 'settings-coverage.xml' -f xml -o 'coverage.xml'
+          dotnet-coverage collect 'dotnet test --filter Category!=PortalHC&Category!=InterfaceHC&Category!=Portal&Category!=Registration --no-restore --verbosity normal' -s 'settings-coverage.xml' -f xml -o 'coverage.xml'
           cd ..
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/unit.tests-formatting.yml
+++ b/.github/workflows/unit.tests-formatting.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Check Format
         run: dotnet format src --verify-no-changes --no-restore
       - name: Test
-        run: dotnet test src --filter FullyQualifiedName\!~Org.Eclipse.TractusX.Portal.Backend.EndToEnd.Tests --no-restore --verbosity normal
+        run: dotnet test src --filter Category!=PortalHC&Category!=InterfaceHC&Category!=Portal&Category!=Registration --no-restore --verbosity normal

--- a/.github/workflows/unit.tests-formatting.yml
+++ b/.github/workflows/unit.tests-formatting.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Check Format
         run: dotnet format src --verify-no-changes --no-restore
       - name: Test
-        run: dotnet test src --filter Category!=PortalHC&Category!=InterfaceHC&Category!=Portal&Category!=Registration --no-restore --verbosity normal
+        run: dotnet test src --filter FullyQualifiedName\!~Org.Eclipse.TractusX.Portal.Backend.EndToEnd.Tests --no-restore --verbosity normal


### PR DESCRIPTION
## Description

adjust filter for dotnet tests to exclude endtoend tests by their category since the FullyQualifiedName filter filters all unit tests

## Why

currently the sonarcloud workflow doesn't executes the unit tests

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
