### PR TITLE
fix(bpdm): handle nullable SharingProcessStarted

### DIFF
--- a/src/externalsystems/Bpdm.Library/BusinessLogic/BpdmBusinessLogic.cs
+++ b/src/externalsystems/Bpdm.Library/BusinessLogic/BpdmBusinessLogic.cs
@@ -108,6 +108,11 @@ public class BpdmBusinessLogic : IBpdmBusinessLogic
         }
 
         var sharingState = await _bpdmService.GetSharingState(context.ApplicationId, cancellationToken).ConfigureAwait(false);
+        if (sharingState.SharingProcessStarted == null)
+        {
+            return new IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult(ProcessStepStatusId.TODO, null, null, null, false, "SharingProcessStarted was not set");
+        }
+
         return sharingState.SharingStateType switch
         {
             BpdmSharingStateType.Success =>

--- a/src/externalsystems/Bpdm.Library/Models/BpdmSharingState.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmSharingState.cs
@@ -24,13 +24,13 @@ public record BpdmPaginationSharingStateOutput(
 );
 
 public record BpdmSharingState(
-    BpdmSharingStateBusinessPartnerType BusinessPartnerType,
+    BpdmSharingStateBusinessPartnerType? BusinessPartnerType,
     Guid ExternalId,
-    BpdmSharingStateType SharingStateType,
+    BpdmSharingStateType? SharingStateType,
     string? SharingErrorCode,
     string? SharingErrorMessage,
     string? Bpn,
-    DateTimeOffset SharingProcessStarted
+    DateTimeOffset? SharingProcessStarted
 );
 
 public enum BpdmSharingStateType


### PR DESCRIPTION
## Description

Adjust bpdm pull process to handle an unset SharingProcessStarted and retry the process.

## Why

Currently the pull fails because the value of SharingProcessStarted isn't expected to be null.

## Issue

N/A - Jira Issue: CPLP-3226

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
