### PR TITLE
chore: mask sensitive log data

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -35,6 +35,7 @@ nuget/nuget/-/Serilog.AspNetCore/7.0.0, Apache-2.0 AND MIT, approved, #10084
 nuget/nuget/-/Serilog.Enrichers.CorrelationId/3.0.1, MIT, approved, clearlydefined
 nuget/nuget/-/Serilog.Enrichers.Environment/2.2.0, Apache-2.0, approved, clearlydefined
 nuget/nuget/-/Serilog.Enrichers.Process/2.0.2, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Serilog.Enrichers.Sensitive/1.7.3, MIT, approved, clearlydefined
 nuget/nuget/-/Serilog.Enrichers.Thread/3.1.0, Apache-2.0, approved, clearlydefined
 nuget/nuget/-/Serilog.Extensions.Hosting/7.0.0, Apache-2.0, approved, #10078
 nuget/nuget/-/Serilog.Extensions.Logging/7.0.0, Apache-2.0, approved, #10070

--- a/src/Portal.Backend.sln
+++ b/src/Portal.Backend.sln
@@ -232,6 +232,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnboardingServiceProvider.L
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkRegistration.Executor.Tests", "..\tests\processes\NetworkRegistration.Executor.Tests\NetworkRegistration.Executor.Tests.csproj", "{F1A5A73C-2B8C-4959-A128-CC5A8DECCB1B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Framework.Logging.Tests", "..\tests\framework\Framework.Logging.Tests\Framework.Logging.Tests.csproj", "{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1466,6 +1468,18 @@ Global
 		{F1A5A73C-2B8C-4959-A128-CC5A8DECCB1B}.Release|x64.Build.0 = Release|Any CPU
 		{F1A5A73C-2B8C-4959-A128-CC5A8DECCB1B}.Release|x86.ActiveCfg = Release|Any CPU
 		{F1A5A73C-2B8C-4959-A128-CC5A8DECCB1B}.Release|x86.Build.0 = Release|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Debug|x64.Build.0 = Debug|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Debug|x86.Build.0 = Debug|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Release|x64.ActiveCfg = Release|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Release|x64.Build.0 = Release|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Release|x86.ActiveCfg = Release|Any CPU
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1474,6 +1488,7 @@ Global
 		SolutionGuid = {2EB6265F-323A-4BF3-969E-003D64A14B64}
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{146865E5-7DFF-4CC2-8521-9E22CFCEEA20} = {323C198D-A8C6-4EB0-8B79-72624275E35F}
 		{A43B5ACA-1209-46E9-84DB-A48553ED623E} = {323C198D-A8C6-4EB0-8B79-72624275E35F}
 		{1EAF34DA-6D16-4F5E-86F4-344185F53942} = {323C198D-A8C6-4EB0-8B79-72624275E35F}
 		{A5BEDD89-7280-466E-8D14-EC5E177AAD07} = {323C198D-A8C6-4EB0-8B79-72624275E35F}

--- a/src/framework/Framework.Logging/Framework.Logging.csproj
+++ b/src/framework/Framework.Logging/Framework.Logging.csproj
@@ -33,6 +33,7 @@
       <PackageReference Include="Serilog" Version="3.0.1" />
       <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
       <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
+      <PackageReference Include="Serilog.Enrichers.Sensitive" Version="1.7.3" />
       <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />

--- a/src/framework/Framework.Logging/LoggingExtensions.cs
+++ b/src/framework/Framework.Logging/LoggingExtensions.cs
@@ -20,8 +20,10 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Logging.MaskingOperator;
 using Serilog;
 using Serilog.Core;
+using Serilog.Enrichers.Sensitive;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 
@@ -38,6 +40,12 @@ public static class LoggingExtensions
         host.UseSerilog((context, configuration) =>
         {
             configuration
+                .Enrich.WithSensitiveDataMasking(opt =>
+                {
+                    opt.Mode = MaskingMode.Globally;
+                    opt.MaskValue = "*****";
+                    opt.MaskingOperators.Add(new SecretOperator());
+                })
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
                 .ReadFrom.Configuration(context.Configuration)
                 .WriteTo.Console(new JsonFormatter(renderMessage: true));
@@ -57,6 +65,12 @@ public static class LoggingExtensions
             return;
 
         Log.Logger = new LoggerConfiguration()
+            .Enrich.WithSensitiveDataMasking(opt =>
+            {
+                opt.Mode = MaskingMode.Globally;
+                opt.MaskValue = "*****";
+                opt.MaskingOperators.Add(new SecretOperator());
+            })
             .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
             .WriteTo.Console(new JsonFormatter(renderMessage: true))
             .CreateBootstrapLogger();

--- a/src/framework/Framework.Logging/MaskingOperator/SecretOperator.cs
+++ b/src/framework/Framework.Logging/MaskingOperator/SecretOperator.cs
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Serilog.Enrichers.Sensitive;
+using System.Text.RegularExpressions;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Logging.MaskingOperator;
+
+public class SecretOperator : RegexMaskingOperator
+{
+    private const string SecretPattern = "(secret|password)=(.*?)&";
+
+    public SecretOperator()
+        : base(SecretPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)
+    {
+    }
+
+    protected override string PreprocessMask(string mask, Match match) => $"{match.Value.Split("=")[0]}{mask}&";
+
+    protected override bool ShouldMaskInput(string input) => input.Contains("secret=") || input.Contains("password=");
+}

--- a/tests/framework/Framework.Logging.Tests/Framework.Logging.Tests.csproj
+++ b/tests/framework/Framework.Logging.Tests/Framework.Logging.Tests.csproj
@@ -1,0 +1,48 @@
+<!--
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+-
+- See the NOTICE file(s) distributed with this work for additional
+- information regarding copyright ownership.
+-
+- This program and the accompanying materials are made available under the
+- terms of the Apache License, Version 2.0 which is available at
+- https://www.apache.org/licenses/LICENSE-2.0.
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+- License for the specific language governing permissions and limitations
+- under the License.
+-
+- SPDX-License-Identifier: Apache-2.0
+-->
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Org.Eclipse.TractusX.Portal.Backend.Framework.Logging.Tests</AssemblyName>
+    <RootNamespace>Org.Eclipse.TractusX.Portal.Backend.Framework.Logging.Tests</RootNamespace>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.0" />
+    <PackageReference Include="FakeItEasy" Version="7.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\framework\Framework.Logging\Framework.Logging.csproj" />
+    <ProjectReference Include="..\..\shared\Tests.Shared\Tests.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/framework/Framework.Logging.Tests/Usings.cs
+++ b/tests/framework/Framework.Logging.Tests/Usings.cs
@@ -17,21 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Serilog.Enrichers.Sensitive;
-using System.Text.RegularExpressions;
-
-namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Logging.MaskingOperator;
-
-public class SecretOperator : RegexMaskingOperator
-{
-    private const string SecretPattern = "(secret|password)=(.*?)&";
-
-    public SecretOperator()
-        : base(SecretPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)
-    {
-    }
-
-    protected override string PreprocessMask(string mask, Match match) => $"{match.Groups[1]}={mask}&";
-
-    protected override bool ShouldMaskInput(string input) => input.Contains("secret=", StringComparison.InvariantCultureIgnoreCase) || input.Contains("password=", StringComparison.InvariantCultureIgnoreCase);
-}
+global using AutoFixture;
+global using AutoFixture.AutoFakeItEasy;
+global using FakeItEasy;
+global using FluentAssertions;
+global using Xunit;


### PR DESCRIPTION
## Description

Mask sensitive information in our logs

## Why

Currently secrets and passwords are written in cleartext to the logs.

## Issue

N/A - Jira Issue: CPLP-3255

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
