### PR TITLE
fix: set correct useAuthTrail

### DIFF
--- a/src/keycloak/Keycloak.Factory/IKeycloakFactory.cs
+++ b/src/keycloak/Keycloak.Factory/IKeycloakFactory.cs
@@ -26,5 +26,5 @@ public interface IKeycloakFactory
 {
     KeycloakClient CreateKeycloakClient(string instance);
 
-    KeycloakClient CreateKeycloakClient(string instance, string clientId, string secret, bool useAuthTrail);
+    KeycloakClient CreateKeycloakClient(string instance, string clientId, string secret);
 }

--- a/src/keycloak/Keycloak.Factory/KeycloakFactory.cs
+++ b/src/keycloak/Keycloak.Factory/KeycloakFactory.cs
@@ -46,7 +46,7 @@ public class KeycloakFactory : IKeycloakFactory
             : KeycloakClient.CreateWithClientId(settings.ConnectionString, settings.ClientId, settings.ClientSecret, settings.UseAuthTrail, settings.AuthRealm);
     }
 
-    public KeycloakClient CreateKeycloakClient(string instance, string clientId, string secret, bool useAuthTrail)
+    public KeycloakClient CreateKeycloakClient(string instance, string clientId, string secret)
     {
         if (!_settings.Keys.Contains(instance, StringComparer.InvariantCultureIgnoreCase))
         {
@@ -54,6 +54,6 @@ public class KeycloakFactory : IKeycloakFactory
         }
 
         var settings = _settings.Single(x => x.Key.Equals(instance, StringComparison.InvariantCultureIgnoreCase)).Value;
-        return KeycloakClient.CreateWithClientId(settings.ConnectionString, clientId, secret, useAuthTrail, settings.AuthRealm);
+        return KeycloakClient.CreateWithClientId(settings.ConnectionString, clientId, secret, settings.UseAuthTrail, settings.AuthRealm);
     }
 }

--- a/src/provisioning/Provisioning.Library/ProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningManager.cs
@@ -54,7 +54,7 @@ public partial class ProvisioningManager : IProvisioningManager
         await CreateCentralIdentityProviderAsync(idpName, organisationName, _Settings.CentralIdentityProvider).ConfigureAwait(false);
 
         var (clientId, secret) = await CreateSharedIdpServiceAccountAsync(idpName).ConfigureAwait(false);
-        var sharedKeycloak = _Factory.CreateKeycloakClient("shared", clientId, secret, _Settings.UseAuthTrail);
+        var sharedKeycloak = _Factory.CreateKeycloakClient("shared", clientId, secret);
 
         await CreateSharedRealmAsync(sharedKeycloak, idpName, organisationName, loginTheme).ConfigureAwait(false);
 
@@ -285,7 +285,7 @@ public partial class ProvisioningManager : IProvisioningManager
     private async Task<KeycloakClient> GetSharedKeycloakClient(string realm)
     {
         var (clientId, secret) = await GetSharedIdpServiceAccountSecretAsync(realm).ConfigureAwait(false);
-        return _Factory.CreateKeycloakClient("shared", clientId, secret, _Settings.UseAuthTrail);
+        return _Factory.CreateKeycloakClient("shared", clientId, secret);
     }
 
     private static T Clone<T>(T cloneObject)

--- a/src/provisioning/Provisioning.Library/ProvisioningSettings.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningSettings.cs
@@ -33,8 +33,6 @@ public partial class ProvisioningSettings
     public string MappedBpnAttribute { get; set; }
 
     public string UserNameMapperTemplate { get; set; }
-
-    public bool UseAuthTrail { get; set; }
 }
 
 public static class ProvisioningSettingsExtension

--- a/tests/provisioning/Provisioning.Library.Tests/Extensions/ClientManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/Extensions/ClientManagerTests.cs
@@ -54,7 +54,7 @@ public class ClientManagerTests
             .Returns(new KeycloakClient(CentralUrl, "test", "test", "test", false));
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared"))
             .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
-        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._, A<bool>._))
+        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._))
             .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
         var settings = new ProvisioningSettings
         {

--- a/tests/provisioning/Provisioning.Library.Tests/ProvisioningManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/ProvisioningManagerTests.cs
@@ -59,7 +59,7 @@ public class ProvisioningManagerTests
             .Returns(new KeycloakClient(CentralUrl, "test", "test", "test", false));
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared"))
             .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
-        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._, A<bool>._))
+        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._))
             .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
         var settings = new ProvisioningSettings
         {

--- a/tests/provisioning/Provisioning.Library.Tests/UserManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/UserManagerTests.cs
@@ -58,7 +58,7 @@ public class UserManagerTests
             .Returns(new KeycloakClient(CentralUrl, "test", "test", "test", false));
         A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared"))
             .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
-        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._, A<bool>._))
+        A.CallTo(() => keycloakFactory.CreateKeycloakClient("shared", A<string>._, A<string>._))
             .Returns(new KeycloakClient(SharedUrl, "test", "test", "test", false));
         var settings = new ProvisioningSettings
         {


### PR DESCRIPTION
## Description

Remove the auth trail from the provisioning settings and use the keycloak settings to set the correct useAuthTrail value.

## Why

With the current setting we'd need an extra configuration value where it is not needed.

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
