### PR TITLE
chore: added mail template for osp registration

### DIFF
--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -355,13 +355,6 @@
         }
       },
       {
-        "Name": "OspWelcomeMail",
-        "Setting": {
-          "Subject": "Welcome to Catena-X - Your user account has been created.",
-          "EmailTemplateType": "OspWelcomeMail"
-        }
-      },
-      {
         "Name": "CredentialApproval",
         "Setting": {
           "Subject": "Company Wallet - SSI Credential Approved",

--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -353,6 +353,13 @@
           "Subject": "Welcome to the Catena-X Network.",
           "EmailTemplateType": "PortalWelcomeEmail"
         }
+      },
+      {
+        "Name": "OspWelcomeMail",
+        "Setting": {
+          "Subject": "Welcome to Catena-X - Your user account has been created.",
+          "EmailTemplateType": "OspWelcomeMail"
+        }
       }
     ],
     "Mail": {


### PR DESCRIPTION
## Description

Move the OSPWelcome Mail Template from Administration to ProcessWorker

## Why

Currently no mails are send out for the registered users when executing an osp registration

## Issue

N/A - Jira Issue: CPLP-3355

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes