### PR TITLE
fix(sa): only sync active service accounts

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -472,7 +472,8 @@ public class UserRepository : IUserRepository
             .Where(x =>
                 x.IdentityTypeId == IdentityTypeId.COMPANY_SERVICE_ACCOUNT &&
                 x.UserEntityId == null &&
-                x.CompanyServiceAccount!.ClientClientId != null)
+                x.CompanyServiceAccount!.ClientClientId != null &&
+                x.UserStatusId == UserStatusId.ACTIVE)
             .Select(x => new ValueTuple<Guid, string>(x.Id, x.CompanyServiceAccount!.ClientClientId!))
             .Take(2)
             .ToAsyncEnumerable();

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -41,7 +41,6 @@
     "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2543",
     "client_client_id": "sa-x-2"
   },
-
   {
     "id": "cd436931-8399-4c1d-bd81-7dffb298c7ca",
     "name": "test-user-service-accounts",
@@ -50,6 +49,14 @@
     "offer_subscription_id": null,
     "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f8",
     "client_client_id": "sa-x-3"
+  },
+  {
+    "id": "38c92162-6328-40ce-80f3-22e3f3e9b94d",
+    "name": "sa-inactive",
+    "description": "inactive service account",
+    "company_service_account_type_id": 1,
+    "offer_subscription_id": null,
+    "company_id": "729e0af2-6723-4a7f-85a1-833d84b39bdf",
+    "client_client_id": "sa-x-inactive"
   }
-
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
@@ -150,5 +150,13 @@
     "user_status_id": 1,
     "user_entity_id": null,
     "identity_type_id": 1
+  },
+  {
+    "id": "38c92162-6328-40ce-80f3-22e3f3e9b94d",
+    "date_created": "2022-06-01 18:01:33.439000 +00:00",
+    "company_id": "729e0af2-6723-4a7f-85a1-833d84b39bdf",
+    "user_status_id": 2,
+    "user_entity_id": null,
+    "identity_type_id": 2
   }
 ]


### PR DESCRIPTION
## Description

Only sync active service accounts instead of all service accounts

## Why

currently all service accounts are synced which results in a failing worker since the inactive / deleted service accounts do not exist in keycloak anymore

## Issue

N/A - Jira Issue: CPLP-3312

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
