### PR TITLE
feat(errorhandling)! enhance exceptions with details for errortype, errorcode and parameters

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -20,6 +20,7 @@
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Clearinghouse.Library.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Clearinghouse.Library.Models;
@@ -82,7 +83,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
         var companyWithAddress = await _portalRepositories.GetInstance<IApplicationRepository>().GetCompanyUserRoleWithAddressUntrackedAsync(applicationId).ConfigureAwait(false);
         if (companyWithAddress == null)
         {
-            throw new NotFoundException($"applicationId {applicationId} not found");
+            throw NotFoundException.Create(AdministrationRegistrationErrors.APPLICATION_NOT_FOUND, new ErrorParameter[] { new("applicationId", applicationId.ToString()) });
         }
         return new CompanyWithAddressData(
             companyWithAddress.CompanyId,

--- a/src/administration/Administration.Service/ErrorHandling/AdministrationRegistrationErrorMessageContainer.cs
+++ b/src/administration/Administration.Service/ErrorHandling/AdministrationRegistrationErrorMessageContainer.cs
@@ -24,9 +24,9 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.ErrorHandling;
 
 public class AdministrationRegistrationErrorMessageContainer : IErrorMessageContainer
 {
-    private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<int, string> {
-                { (int) AdministrationRegistrationErrors.APPLICATION_NOT_FOUND, "application {applicationId} does not exist" }
-            }.ToImmutableDictionary();
+    private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<AdministrationRegistrationErrors, string> {
+                { AdministrationRegistrationErrors.APPLICATION_NOT_FOUND, "application {applicationId} does not exist" }
+            }.ToImmutableDictionary(x => (int)x.Key, x => x.Value);
 
     public Type Type { get => typeof(AdministrationRegistrationErrors); }
     public IReadOnlyDictionary<int, string> MessageContainer { get => _messageContainer; }

--- a/src/administration/Administration.Service/ErrorHandling/AdministrationRegistrationErrorMessageContainer.cs
+++ b/src/administration/Administration.Service/ErrorHandling/AdministrationRegistrationErrorMessageContainer.cs
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
+using System.Collections.Immutable;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.ErrorHandling;
+
+public class AdministrationRegistrationErrorMessageContainer : IErrorMessageContainer
+{
+    private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<int, string> {
+                { (int) AdministrationRegistrationErrors.APPLICATION_NOT_FOUND, "application {applicationId} does not exist" }
+            }.ToImmutableDictionary();
+
+    public Type Type { get => typeof(AdministrationRegistrationErrors); }
+    public IReadOnlyDictionary<int, string> MessageContainer { get => _messageContainer; }
+}
+
+public enum AdministrationRegistrationErrors
+{
+    APPLICATION_NOT_FOUND
+}

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -20,6 +20,7 @@
 
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.DependencyInjection;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
@@ -30,6 +31,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Processes.OfferSubscription.Library.De
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
 
 var VERSION = "v2";
 
@@ -77,6 +79,10 @@ WebApplicationBuildRunner
             .AddTransient<ISubscriptionConfigurationBusinessLogic, SubscriptionConfigurationBusinessLogic>()
             .AddPartnerRegistration(builder.Configuration)
             .AddNetworkRegistrationProcessHelper();
+
+        builder.Services
+            .AddSingleton<IErrorMessageService, ErrorMessageService>()
+            .AddSingleton<IErrorMessageContainer, AdministrationRegistrationErrorMessageContainer>();
 
         builder.Services.AddProvisioningDBAccess(builder.Configuration);
     });

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -18,9 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Administration.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.DependencyInjection;
-using Org.Eclipse.TractusX.Portal.Backend.Administration.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
@@ -31,7 +32,6 @@ using Org.Eclipse.TractusX.Portal.Backend.Processes.OfferSubscription.Library.De
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Service;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
 
 var VERSION = "v2";
 

--- a/src/framework/Framework.ErrorHandling.Library/ConfigurationException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ConfigurationException.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -21,12 +20,19 @@
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 [Serializable]
-public class ConfigurationException : Exception
+public class ConfigurationException : DetailException
 {
-    public ConfigurationException() { }
+    public ConfigurationException() : base() { }
     public ConfigurationException(string message) : base(message) { }
     public ConfigurationException(string message, Exception inner) : base(message, inner) { }
     protected ConfigurationException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+
+    protected ConfigurationException(Type errorType, int errorCode, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) : base(errorType, errorCode, parameters, inner) { }
+
+    public static ConfigurationException Create<T>(T error, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, inner);
+    public static ConfigurationException Create<T>(T error, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, inner);
 }

--- a/src/framework/Framework.ErrorHandling.Library/ConflictException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ConflictException.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -21,12 +20,19 @@
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 [Serializable]
-public class ConflictException : Exception
+public class ConflictException : DetailException
 {
-    public ConflictException() { }
+    public ConflictException() : base() { }
     public ConflictException(string message) : base(message) { }
-    public ConflictException(string message, System.Exception inner) : base(message, inner) { }
+    public ConflictException(string message, Exception inner) : base(message, inner) { }
     protected ConflictException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+
+    protected ConflictException(Type errorType, int errorCode, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) : base(errorType, errorCode, parameters, inner) { }
+
+    public static ConflictException Create<T>(T error, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, inner);
+    public static ConflictException Create<T>(T error, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, inner);
 }

--- a/src/framework/Framework.ErrorHandling.Library/ControllerArgumentException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ControllerArgumentException.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -22,18 +21,14 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 /// <inheritdoc />
 [Serializable]
-public class ControllerArgumentException : Exception
+public class ControllerArgumentException : DetailException
 {
+    public ControllerArgumentException() : base() { }
+
     public ControllerArgumentException(string message) : base(message) { }
 
-    public ControllerArgumentException(ArgumentException argumentException)
-        : this(argumentException.Message)
-    {
-        ParamName = argumentException.ParamName;
-    }
-
     public ControllerArgumentException(string message, string paramName)
-        : base(String.Format("{0} (Parameter '{1}')", message, paramName))
+        : base(string.Format("{0} (Parameter '{1}')", message, paramName))
     {
         ParamName = paramName;
     }
@@ -43,4 +38,18 @@ public class ControllerArgumentException : Exception
     protected ControllerArgumentException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+
+    protected ControllerArgumentException(Type errorType, int errorCode, IEnumerable<ErrorParameter>? parameters = null, string? paramName = null, Exception? inner = null) : base(errorType, errorCode, parameters, inner)
+    {
+        ParamName = paramName;
+    }
+
+    public static ControllerArgumentException Create<T>(T error, IEnumerable<ErrorParameter>? parameters = null, string? paramName = null, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, paramName, inner);
+    public static ControllerArgumentException Create<T>(T error, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, null, inner);
+    public static ControllerArgumentException Create<T>(T error, IEnumerable<ErrorParameter> parameters, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, null, inner);
+    public static ControllerArgumentException Create<T>(T error, string paramName, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, paramName, inner);
 }

--- a/src/framework/Framework.ErrorHandling.Library/DetailException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/DetailException.cs
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
+using System.Text.RegularExpressions;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+
+[Serializable]
+public abstract class DetailException : Exception
+{
+    private static readonly Regex _templateMatcherExpression = new Regex(@"\{(\w+)\}", RegexOptions.None, TimeSpan.FromSeconds(1)); // to replace any text surrounded by { and }
+    private enum NoDetailsErrorType
+    {
+        NONE = 0
+    }
+
+    protected DetailException() : base() { }
+    protected DetailException(string message) : base(message) { }
+    protected DetailException(string message, Exception inner) : base(message, inner) { }
+    protected DetailException(
+        System.Runtime.Serialization.SerializationInfo info,
+        System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+
+    protected DetailException(
+        Type errorType, int errorCode, IEnumerable<ErrorParameter>? parameters, Exception? inner) : base(Enum.GetName(errorType, errorCode), inner)
+    {
+        ErrorType = errorType;
+        ErrorCode = errorCode;
+        Parameters = parameters ?? Enumerable.Empty<ErrorParameter>();
+    }
+
+    protected static int ValueOf<T>(T error) where T : Enum => (int)Convert.ChangeType(error, TypeCode.Int32);
+
+    public Type ErrorType { get; } = typeof(NoDetailsErrorType);
+    public int ErrorCode { get; } = (int)NoDetailsErrorType.NONE;
+    public IEnumerable<ErrorParameter> Parameters { get; } = Enumerable.Empty<ErrorParameter>();
+    public bool HasDetails { get => ErrorType != typeof(NoDetailsErrorType); }
+
+    public string GetErrorMessage(IErrorMessageService messageService) =>
+        _templateMatcherExpression.Replace(
+            messageService.GetMessage(ErrorType, ErrorCode),
+            m => Parameters.SingleOrDefault(x => x.Name == m.Groups[1].Value)?.Value ?? "null");
+
+    public IEnumerable<ErrorDetails> GetErrorDetails(IErrorMessageService messageService) =>
+        GetDetailExceptions().Select(x =>
+            new ErrorDetails(
+                x.Message,
+                x.ErrorType.Name,
+                messageService.GetMessage(x.ErrorType, x.ErrorCode),
+                x.Parameters));
+
+    private IEnumerable<DetailException> GetDetailExceptions()
+    {
+        yield return this;
+        var inner = InnerException;
+        while (inner is not null)
+        {
+            if (inner is DetailException detail && detail.ErrorType != typeof(NoDetailsErrorType))
+                yield return detail;
+            inner = inner.InnerException;
+        }
+    }
+}

--- a/src/framework/Framework.ErrorHandling.Library/ErrorDetails.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ErrorDetails.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -18,33 +17,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using System.Text.Json.Serialization;
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
-namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
+public record ErrorDetails(
+    string ErrorCode,
+    string Type,
+    string Message,
+    IEnumerable<ErrorParameter> Parameters
+);
 
-public class ErrorResponse
-{
-    public ErrorResponse(string type, string title, int status, IDictionary<string, IEnumerable<string>> errors, string errorId)
-    {
-        Type = type;
-        Title = title;
-        Status = status;
-        Errors = errors;
-        ErrorId = errorId;
-    }
-
-    [JsonPropertyName("type")]
-    public string Type { get; set; }
-
-    [JsonPropertyName("title")]
-    public string Title { get; set; }
-
-    [JsonPropertyName("status")]
-    public int Status { get; set; }
-
-    [JsonPropertyName("errors")]
-    public IDictionary<string, IEnumerable<string>> Errors { get; set; }
-
-    [JsonPropertyName("errorId")]
-    public string ErrorId { get; set; }
-}
+public record ErrorParameter(
+    string Name,
+    string Value
+);

--- a/src/framework/Framework.ErrorHandling.Library/ForbiddenException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ForbiddenException.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -21,12 +20,19 @@
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 [Serializable]
-public class ForbiddenException : Exception
+public class ForbiddenException : DetailException
 {
-    public ForbiddenException() { }
+    public ForbiddenException() : base() { }
     public ForbiddenException(string message) : base(message) { }
-    public ForbiddenException(string message, System.Exception inner) : base(message, inner) { }
+    public ForbiddenException(string message, Exception inner) : base(message, inner) { }
     protected ForbiddenException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+
+    protected ForbiddenException(Type errorType, int errorCode, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) : base(errorType, errorCode, parameters, inner) { }
+
+    public static ForbiddenException Create<T>(T error, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, inner);
+    public static ForbiddenException Create<T>(T error, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, inner);
 }

--- a/src/framework/Framework.ErrorHandling.Library/Library/ErrorMessageService.cs
+++ b/src/framework/Framework.ErrorHandling.Library/Library/ErrorMessageService.cs
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using System.Collections.Immutable;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
+
+public sealed class ErrorMessageService : IErrorMessageService
+{
+    private readonly IReadOnlyDictionary<Type, IReadOnlyDictionary<int, string>> _messageContainers;
+
+    public ErrorMessageService(IEnumerable<IErrorMessageContainer> errorMessageContainers)
+    {
+        _messageContainers = errorMessageContainers.ToImmutableDictionary(x => x.Type, x => x.MessageContainer);
+    }
+
+    public string GetMessage(Type type, int code)
+    {
+        if (!_messageContainers.TryGetValue(type, out var container))
+            throw new ArgumentException($"unexpected type {type.Name}");
+
+        if (!container.TryGetValue(code, out var message))
+            throw new ArgumentException($"no message defined for {type.Name}.{Enum.GetName(type, code)}");
+
+        return message;
+    }
+}

--- a/src/framework/Framework.ErrorHandling.Library/Library/ErrorResponse.cs
+++ b/src/framework/Framework.ErrorHandling.Library/Library/ErrorResponse.cs
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
+
+public record ErrorResponse(
+    string Type,
+    string Title,
+    int Status,
+    IDictionary<string, IEnumerable<string>> Errors,
+    string ErrorId,
+    IEnumerable<ErrorDetails>? Details
+);

--- a/src/framework/Framework.ErrorHandling.Library/Library/IErrorMessageContainer.cs
+++ b/src/framework/Framework.ErrorHandling.Library/Library/IErrorMessageContainer.cs
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
+
+public interface IErrorMessageContainer
+{
+    public Type Type { get; }
+    public IReadOnlyDictionary<int, string> MessageContainer { get; }
+}

--- a/src/framework/Framework.ErrorHandling.Library/Library/IErrorMessageService.cs
+++ b/src/framework/Framework.ErrorHandling.Library/Library/IErrorMessageService.cs
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
+
+public interface IErrorMessageService
+{
+    public string GetMessage(Type type, int code);
+}

--- a/src/framework/Framework.ErrorHandling.Library/NotFoundException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/NotFoundException.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -21,12 +20,19 @@
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 [Serializable]
-public class NotFoundException : Exception
+public class NotFoundException : DetailException
 {
-    public NotFoundException() { }
+    public NotFoundException() : base() { }
     public NotFoundException(string message) : base(message) { }
-    public NotFoundException(string message, System.Exception inner) : base(message, inner) { }
+    public NotFoundException(string message, Exception inner) : base(message, inner) { }
     protected NotFoundException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+
+    protected NotFoundException(Type errorType, int errorCode, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) : base(errorType, errorCode, parameters, inner) { }
+
+    public static NotFoundException Create<T>(T error, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, inner);
+    public static NotFoundException Create<T>(T error, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, inner);
 }

--- a/src/framework/Framework.ErrorHandling.Library/ServiceException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ServiceException.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -23,10 +22,12 @@ using System.Net;
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 [Serializable]
-public class ServiceException : Exception
+public class ServiceException : DetailException
 {
     public HttpStatusCode? StatusCode { get; }
     public bool IsRecoverable { get; }
+
+    public ServiceException() : base() { }
 
     public ServiceException(string message, bool isRecoverable = false) : base(message)
     {
@@ -40,13 +41,13 @@ public class ServiceException : Exception
         IsRecoverable = isRecoverable;
     }
 
-    public ServiceException(string message, System.Exception inner, bool isRecoverable = false) : base(message, inner)
+    public ServiceException(string message, Exception inner, bool isRecoverable = false) : base(message, inner)
     {
         StatusCode = null;
         IsRecoverable = isRecoverable;
     }
 
-    public ServiceException(string message, System.Exception inner, HttpStatusCode httpStatusCode, bool isRecoverable = false) : base(message, inner)
+    public ServiceException(string message, Exception inner, HttpStatusCode httpStatusCode, bool isRecoverable = false) : base(message, inner)
     {
         StatusCode = httpStatusCode;
         IsRecoverable = isRecoverable;
@@ -55,4 +56,25 @@ public class ServiceException : Exception
     protected ServiceException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+
+    protected ServiceException(Type errorType, int errorCode, IEnumerable<ErrorParameter>? parameters = null, HttpStatusCode? httpStatusCode = null, bool isRecoverable = false, Exception? inner = null) : base(errorType, errorCode, parameters, inner)
+    {
+        StatusCode = httpStatusCode;
+        IsRecoverable = isRecoverable;
+    }
+
+    public static ServiceException Create<T>(T error, IEnumerable<ErrorParameter>? parameters = null, HttpStatusCode? httpStatusCode = null, bool isRecoverable = false, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, httpStatusCode, isRecoverable, inner);
+    public static ServiceException Create<T>(T error, HttpStatusCode httpStatusCode, bool isRecoverable = false, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, httpStatusCode, isRecoverable, inner);
+    public static ServiceException Create<T>(T error, bool isRecoverable = false, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, null, isRecoverable, inner);
+    public static ServiceException Create<T>(T error, IEnumerable<ErrorParameter> parameters, bool isRecoverable, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, null, isRecoverable, inner);
+    public static ServiceException Create<T>(T error, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, null, false, inner);
+    public static ServiceException Create<T>(T error, IEnumerable<ErrorParameter> parameters, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, null, false, inner);
+    public static ServiceException Create<T>(T error, IEnumerable<ErrorParameter> parameters, HttpStatusCode httpStatusCode, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, httpStatusCode, false, inner);
 }

--- a/src/framework/Framework.ErrorHandling.Library/UnexpectedConditionException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/UnexpectedConditionException.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -21,12 +20,19 @@
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 [Serializable]
-public class UnexpectedConditionException : Exception
+public class UnexpectedConditionException : DetailException
 {
-    public UnexpectedConditionException() { }
+    public UnexpectedConditionException() : base() { }
     public UnexpectedConditionException(string message) : base(message) { }
     public UnexpectedConditionException(string message, Exception inner) : base(message, inner) { }
     protected UnexpectedConditionException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+
+    protected UnexpectedConditionException(Type errorType, int errorCode, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) : base(errorType, errorCode, parameters, inner) { }
+
+    public static UnexpectedConditionException Create<T>(T error, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, inner);
+    public static UnexpectedConditionException Create<T>(T error, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, inner);
 }

--- a/src/framework/Framework.ErrorHandling.Library/UnsupportedMediaTypeException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/UnsupportedMediaTypeException.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -21,12 +20,19 @@
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 [Serializable]
-public class UnsupportedMediaTypeException : Exception
+public class UnsupportedMediaTypeException : DetailException
 {
-    public UnsupportedMediaTypeException() { }
+    public UnsupportedMediaTypeException() : base() { }
     public UnsupportedMediaTypeException(string message) : base(message) { }
-    public UnsupportedMediaTypeException(string message, System.Exception inner) : base(message, inner) { }
+    public UnsupportedMediaTypeException(string message, Exception inner) : base(message, inner) { }
     protected UnsupportedMediaTypeException(
         System.Runtime.Serialization.SerializationInfo info,
         System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+
+    protected UnsupportedMediaTypeException(Type errorType, int errorCode, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) : base(errorType, errorCode, parameters, inner) { }
+
+    public static UnsupportedMediaTypeException Create<T>(T error, IEnumerable<ErrorParameter>? parameters = null, Exception? inner = null) where T : Enum =>
+        new(typeof(T), ValueOf(error), parameters, inner);
+    public static UnsupportedMediaTypeException Create<T>(T error, Exception inner) where T : Enum =>
+        new(typeof(T), ValueOf(error), null, inner);
 }

--- a/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
+++ b/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
+++ b/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
@@ -47,7 +47,7 @@ public class GeneralHttpErrorHandler
         { HttpStatusCode.InternalServerError, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1", "The server encountered an unexpected condition.") }
     }.ToImmutableDictionary();
 
-    public GeneralHttpErrorHandler(RequestDelegate next, ILogger<GeneralHttpErrorHandler> logger, IErrorMessageService? errorMessageService = null)
+    public GeneralHttpErrorHandler(RequestDelegate next, ILogger<GeneralHttpErrorHandler> logger, IErrorMessageService? errorMessageService = null) //TODO make errorMessageService mandatory as soon all dependant services are adjusted accordingly
     {
         _next = next;
         _logger = logger;

--- a/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
+++ b/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
@@ -25,12 +25,15 @@ using Serilog.Context;
 using System.Collections.Immutable;
 using System.Net;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 
 public class GeneralHttpErrorHandler
 {
+    private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
     private readonly RequestDelegate _next;
+    private readonly IErrorMessageService? _errorMessageService;
     private readonly ILogger _logger;
 
     private static readonly IReadOnlyDictionary<HttpStatusCode, MetaData> Metadata = new Dictionary<HttpStatusCode, MetaData>
@@ -45,10 +48,11 @@ public class GeneralHttpErrorHandler
         { HttpStatusCode.InternalServerError, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1", "The server encountered an unexpected condition.") }
     }.ToImmutableDictionary();
 
-    public GeneralHttpErrorHandler(RequestDelegate next, ILogger<GeneralHttpErrorHandler> logger)
+    public GeneralHttpErrorHandler(RequestDelegate next, ILogger<GeneralHttpErrorHandler> logger, IErrorMessageService? errorMessageService = null)
     {
         _next = next;
         _logger = logger;
+        _errorMessageService = errorMessageService;
     }
 
     public async Task Invoke(HttpContext context)
@@ -60,13 +64,14 @@ public class GeneralHttpErrorHandler
         catch (Exception error)
         {
             var errorId = Guid.NewGuid().ToString();
+            var details = GetErrorDetails(error);
+            var message = GetErrorMessage(error);
             LogErrorInformation(errorId, error);
             var (statusCode, messageFunc, logLevel) = GetErrorInformation(error);
-
-            _logger.Log(logLevel, error, "GeneralErrorHandler caught {Error} with errorId: {ErrorId} resulting in response status code {StatusCode}, message '{Message}'", error.GetType().Name, errorId, (int)statusCode, error.Message);
+            _logger.Log(logLevel, error, "GeneralErrorHandler caught {Error} with errorId: {ErrorId} resulting in response status code {StatusCode}, message '{Message}'", error.GetType().Name, errorId, (int)statusCode, message);
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = (int)statusCode;
-            await context.Response.WriteAsync(JsonSerializer.Serialize(CreateErrorResponse(statusCode, error, errorId, messageFunc))).ConfigureAwait(false);
+            await context.Response.WriteAsync(JsonSerializer.Serialize(CreateErrorResponse(statusCode, error, errorId, message, details, messageFunc), Options)).ConfigureAwait(false);
         }
     }
 
@@ -128,20 +133,20 @@ public class GeneralHttpErrorHandler
         return (statusCode, messageFunc, logLevel);
     }
 
-    private static ErrorResponse CreateErrorResponse(HttpStatusCode statusCode, Exception error, string errorId, Func<Exception, (string?, IEnumerable<string>)>? getSourceAndMessages = null)
+    private ErrorResponse CreateErrorResponse(HttpStatusCode statusCode, Exception error, string errorId, string message, IEnumerable<ErrorDetails>? details, Func<Exception, (string?, IEnumerable<string>)>? getSourceAndMessages = null)
     {
         var meta = Metadata.GetValueOrDefault(statusCode, Metadata[HttpStatusCode.InternalServerError]);
-        var (source, messages) = getSourceAndMessages?.Invoke(error) ?? (error.Source, Enumerable.Repeat(error.Message, 1));
+        var (source, messages) = getSourceAndMessages?.Invoke(error) ?? (error.Source, Enumerable.Repeat(message, 1));
 
         var messageMap = new Dictionary<string, IEnumerable<string>> { { source ?? "unknown", messages } };
         while (error.InnerException != null)
         {
-            error = error.InnerException;
-            source = error.Source ?? "inner";
+            var inner = error.InnerException;
+            source = inner.Source ?? "inner";
 
             messageMap[source] = messageMap.TryGetValue(source, out messages)
-                ? messages.Append(error.Message)
-                : Enumerable.Repeat(error.Message, 1);
+                ? messages.Append(GetErrorMessage(inner))
+                : Enumerable.Repeat(GetErrorMessage(inner), 1);
         }
 
         return new ErrorResponse(
@@ -149,9 +154,20 @@ public class GeneralHttpErrorHandler
             meta.Description,
             (int)statusCode,
             messageMap,
-            errorId
+            errorId,
+            details
         );
     }
+
+    private string GetErrorMessage(Exception exception) =>
+        _errorMessageService is not null && exception is DetailException detail && detail.HasDetails
+            ? detail.GetErrorMessage(_errorMessageService)
+            : exception.Message;
+
+    private IEnumerable<ErrorDetails> GetErrorDetails(Exception exception) =>
+        _errorMessageService is not null && exception is DetailException detail && detail.HasDetails
+            ? detail.GetErrorDetails(_errorMessageService)
+            : Enumerable.Empty<ErrorDetails>();
 
     private static void LogErrorInformation(string errorId, Exception exception)
     {


### PR DESCRIPTION
## Description

Exceptions in Framework.ErrorHandling have been enhanced. They now may contain an error-type, an error-code, a message-template and multiple parameters. This allows structured logging of error-details and a more precise display of errors in the frontend (and optionally internationalization by including multi-language error-message-resources for specific errorcodes into the frontend). As those details are optional this change is fully backwards-compatible and api-endpoints may be adjusted on an 'as needed' basis.

## Why

error-messages being returned from api-endpoints are just application-identifier (often a fully qualified class-name) plus string-message. This cannot easily be parsed by the frontend to map to more detailed (and optionally multilingual) help-texts. Parameters of methods throwing exceptions are embedded within the message and therefore not available explicitly.

## Issue

N/A (CPLP-3090)

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
