### PR TITLE
feat(administration)! add errordetails to bulk-user-creation response

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
@@ -256,7 +256,6 @@ public class UserUploadBusinessLogic : IUserUploadBusinessLogic
             _ => new UserCreationError(line, error.Message, Enumerable.Empty<ErrorDetails>())
         };
 
-
     private async ValueTask<IEnumerable<UserRoleData>> GetUserRoleDatas(IEnumerable<string> roles, List<UserRoleData> validRoleData, Guid companyId)
     {
         var unknownRoles = roles.Except(validRoleData.Select(r => r.UserRoleText));

--- a/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
@@ -21,8 +21,8 @@
 using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.IO;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
@@ -39,6 +39,7 @@ public class UserUploadBusinessLogic : IUserUploadBusinessLogic
     private readonly IMailingService _mailingService;
     private readonly UserSettings _settings;
     private readonly IIdentityService _identityService;
+    private readonly IErrorMessageService _errorMessageService;
 
     /// <summary>
     /// Constructor.
@@ -46,16 +47,19 @@ public class UserUploadBusinessLogic : IUserUploadBusinessLogic
     /// <param name="userProvisioningService">User Provisioning Service</param>
     /// <param name="mailingService">Mailing Service</param>
     /// <param name="identityService">Access to the identity Service</param>
+    /// <param name="errorMessageService">ErrorMessage Service</param>
     /// <param name="settings">Settings</param>
     public UserUploadBusinessLogic(
         IUserProvisioningService userProvisioningService,
         IMailingService mailingService,
         IIdentityService identityService,
+        IErrorMessageService errorMessageService,
         IOptions<UserSettings> settings)
     {
         _userProvisioningService = userProvisioningService;
         _mailingService = mailingService;
         _identityService = identityService;
+        _errorMessageService = errorMessageService;
         _settings = settings.Value;
     }
 
@@ -109,7 +113,11 @@ public class UserUploadBusinessLogic : IUserUploadBusinessLogic
                     .Select(x => (x.CompanyUserId != Guid.Empty, x.Error)),
             cancellationToken).ConfigureAwait(false);
 
-        return new UserCreationStats(numCreated, errors.Count(), numLines, errors.Select(x => $"line: {x.Line}, message: {x.Error.Message}"));
+        return new UserCreationStats(
+            numCreated,
+            errors.Count(),
+            numLines,
+            errors.Select(error => CreateUserCreationError(error.Line, error.Error)));
     }
 
     private async IAsyncEnumerable<(Guid CompanyUserId, string UserName, string? Password, Exception? Error)> CreateOwnCompanyIdpUsersWithEmailAsync(string nameCreatedBy, CompanyNameIdpAliasData companyNameIdpAliasData, IAsyncEnumerable<UserCreationRoleDataIdpInfo> userCreationInfos, [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -234,8 +242,20 @@ public class UserUploadBusinessLogic : IUserUploadBusinessLogic
                     .Select(x => (x.CompanyUserId != Guid.Empty, x.Error)),
             cancellationToken).ConfigureAwait(false);
 
-        return new UserCreationStats(numCreated, errors.Count(), numLines, errors.Select(x => $"line: {x.Line}, message: {x.Error.Message}"));
+        return new UserCreationStats(
+            numCreated,
+            errors.Count(),
+            numLines,
+            errors.Select(error => CreateUserCreationError(error.Line, error.Error)));
     }
+
+    private UserCreationError CreateUserCreationError(int line, Exception error) =>
+        error switch
+        {
+            DetailException detailException when detailException.HasDetails => new UserCreationError(line, detailException.GetErrorMessage(_errorMessageService), detailException.GetErrorDetails(_errorMessageService)),
+            _ => new UserCreationError(line, error.Message, Enumerable.Empty<ErrorDetails>())
+        };
+
 
     private async ValueTask<IEnumerable<UserRoleData>> GetUserRoleDatas(IEnumerable<string> roles, List<UserRoleData> validRoleData, Guid companyId)
     {

--- a/src/administration/Administration.Service/Models/IdentityProviderUpdateStats.cs
+++ b/src/administration/Administration.Service/Models/IdentityProviderUpdateStats.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -18,6 +17,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 
-public record IdentityProviderUpdateStats(int Updated, int Unchanged, int Error, int Total, IEnumerable<string> Errors);
+public record IdentityProviderUpdateStats(int Updated, int Unchanged, int Error, int Total, IEnumerable<UserUpdateError> Errors);
+public record UserUpdateError(int Line, string Message, IEnumerable<ErrorDetails> Details);

--- a/src/administration/Administration.Service/Models/UserCreationStats.cs
+++ b/src/administration/Administration.Service/Models/UserCreationStats.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/administration/Administration.Service/Models/UserCreationStats.cs
+++ b/src/administration/Administration.Service/Models/UserCreationStats.cs
@@ -18,6 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 
-public record UserCreationStats(int Created, int Error, int Total, IEnumerable<string> Errors);
+public record UserCreationStats(int Created, int Error, int Total, IEnumerable<UserCreationError> Errors);
+public record UserCreationError(int Line, string Message, IEnumerable<ErrorDetails> Details);

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -31,8 +31,8 @@ using Org.Eclipse.TractusX.Portal.Backend.Processes.NetworkRegistration.Library.
 using Org.Eclipse.TractusX.Portal.Backend.Processes.OfferSubscription.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
-using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Service;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Service;
 
 var VERSION = "v2";
 

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -32,6 +32,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Processes.OfferSubscription.Library.De
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.ErrorHandling;
 
 var VERSION = "v2";
 
@@ -82,7 +83,8 @@ WebApplicationBuildRunner
 
         builder.Services
             .AddSingleton<IErrorMessageService, ErrorMessageService>()
-            .AddSingleton<IErrorMessageContainer, AdministrationRegistrationErrorMessageContainer>();
+            .AddSingleton<IErrorMessageContainer, AdministrationRegistrationErrorMessageContainer>()
+            .AddSingleton<IErrorMessageContainer, ProvisioningServiceErrorMessageContainer>();
 
         builder.Services.AddProvisioningDBAccess(builder.Configuration);
     });

--- a/src/provisioning/Provisioning.Library/ErrorHandling/ProvisioningServiceErrorMessageContainer.cs
+++ b/src/provisioning/Provisioning.Library/ErrorHandling/ProvisioningServiceErrorMessageContainer.cs
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Library;
+using System.Collections.Immutable;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.ErrorHandling;
+
+public class ProvisioningServiceErrorMessageContainer : IErrorMessageContainer
+{
+    private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<int, string> {
+                { (int) ProvisioningServiceErrors.USER_CREATION_USERNAME_NULL, "userName is {userName} when trying to create user in realm {realm}" },
+                { (int) ProvisioningServiceErrors.USER_CREATION_CONFLICT, "userName {userName} already exists in realm {realm}" },
+                { (int) ProvisioningServiceErrors.USER_CREATION_NOTFOUND, "realm {realm} not found to create userName {userName}" },
+                { (int) ProvisioningServiceErrors.USER_CREATION_ARGUMENT, "invalid realm {realm} or userName {userName} for usercreation" },
+                { (int) ProvisioningServiceErrors.USER_CREATION_FAILURE, "unexpected error while creating userName {userName} in realm {realm}" },
+                { (int) ProvisioningServiceErrors.USER_CREATION_RETURNS_NULL, "creation of userName {userName} in realm {realm} returns null" }
+            }.ToImmutableDictionary();
+
+    public Type Type { get => typeof(ProvisioningServiceErrors); }
+    public IReadOnlyDictionary<int, string> MessageContainer { get => _messageContainer; }
+}
+
+public enum ProvisioningServiceErrors
+{
+    USER_CREATION_USERNAME_NULL,
+    USER_CREATION_CONFLICT,
+    USER_CREATION_NOTFOUND,
+    USER_CREATION_ARGUMENT,
+    USER_CREATION_FAILURE,
+    USER_CREATION_RETURNS_NULL,
+}

--- a/src/provisioning/Provisioning.Library/ErrorHandling/ProvisioningServiceErrorMessageContainer.cs
+++ b/src/provisioning/Provisioning.Library/ErrorHandling/ProvisioningServiceErrorMessageContainer.cs
@@ -24,14 +24,14 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.ErrorHandling
 
 public class ProvisioningServiceErrorMessageContainer : IErrorMessageContainer
 {
-    private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<int, string> {
-                { (int) ProvisioningServiceErrors.USER_CREATION_USERNAME_NULL, "userName is {userName} when trying to create user in realm {realm}" },
-                { (int) ProvisioningServiceErrors.USER_CREATION_CONFLICT, "userName {userName} already exists in realm {realm}" },
-                { (int) ProvisioningServiceErrors.USER_CREATION_NOTFOUND, "realm {realm} not found to create userName {userName}" },
-                { (int) ProvisioningServiceErrors.USER_CREATION_ARGUMENT, "invalid realm {realm} or userName {userName} for usercreation" },
-                { (int) ProvisioningServiceErrors.USER_CREATION_FAILURE, "unexpected error while creating userName {userName} in realm {realm}" },
-                { (int) ProvisioningServiceErrors.USER_CREATION_RETURNS_NULL, "creation of userName {userName} in realm {realm} returns null" }
-            }.ToImmutableDictionary();
+    private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<ProvisioningServiceErrors, string> {
+                { ProvisioningServiceErrors.USER_CREATION_USERNAME_NULL, "userName is {userName} when trying to create user in realm {realm}" },
+                { ProvisioningServiceErrors.USER_CREATION_CONFLICT, "userName {userName} already exists in realm {realm}" },
+                { ProvisioningServiceErrors.USER_CREATION_NOTFOUND, "realm {realm} not found to create userName {userName}" },
+                { ProvisioningServiceErrors.USER_CREATION_ARGUMENT, "invalid realm {realm} or userName {userName} for usercreation" },
+                { ProvisioningServiceErrors.USER_CREATION_FAILURE, "unexpected error while creating userName {userName} in realm {realm}" },
+                { ProvisioningServiceErrors.USER_CREATION_RETURNS_NULL, "creation of userName {userName} in realm {realm} returns null" }
+            }.ToImmutableDictionary(x => (int)x.Key, x => x.Value);
 
     public Type Type { get => typeof(ProvisioningServiceErrors); }
     public IReadOnlyDictionary<int, string> MessageContainer { get => _messageContainer; }

--- a/src/provisioning/Provisioning.Library/Extensions/UserManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/UserManager.cs
@@ -22,8 +22,8 @@ using Flurl.Http;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Users;
-using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
@@ -140,7 +140,7 @@ public partial class ProvisioningManager
         return CreateAndRetrieveUserIdMappingError(_CentralIdp, _Settings.CentralRealm, newUser);
     }
 
-    private async Task<string> CreateAndRetrieveUserIdMappingError(Keycloak.Library.KeycloakClient keycloak, string realm, User newUser)
+    private static async Task<string> CreateAndRetrieveUserIdMappingError(Keycloak.Library.KeycloakClient keycloak, string realm, User newUser)
     {
         if (newUser.UserName == null)
             throw ControllerArgumentException.Create(ProvisioningServiceErrors.USER_CREATION_USERNAME_NULL, new ErrorParameter[] { new("userName", "null"), new("realm", realm) });


### PR DESCRIPTION
## Description

Error-messages in bulk-user-upload have been enhanced. In case an error happens creating the user in keycloak the new ErrorDetails type is being used to pass information about the userName and realm of the user to be created in conjunction with an errorcode for the precise error-condition.

## Why

error-responses in file-upload based user-creation are not easily parseable by the frontend. The user only gets to see the url of the POST-request but not the payload containing the user-creation-parameters

## Issue

N/A (CPLP-3189)

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
