### PR TITLE
fix(bpdm): adjust conversion for bpdm fetch

### DIFF
--- a/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityOutputData.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityOutputData.cs
@@ -18,6 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using System.Text.Json.Serialization;
+
 namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Models;
 
 public record PageOutputResponseBpdmLegalEntityData(
@@ -25,29 +27,29 @@ public record PageOutputResponseBpdmLegalEntityData(
 );
 
 public record BpdmLegalEntityOutputData(
-    string? ExternalId,
-    string? Bpn,
-    string? LegalShortName,
-    string? LegalForm,
-    IEnumerable<BpdmIdentifier> Identifiers,
-    IEnumerable<BpdmStatus> States,
-    IEnumerable<BpdmProfileClassification> Classifications,
-    IEnumerable<string> LegalNameParts,
-    IEnumerable<string> Roles,
-    BpdmLegalAddressResponse LegalAddress
+    [property: JsonPropertyName("externalId")] string? ExternalId,
+    [property: JsonPropertyName("bpnl")] string? Bpn,
+    [property: JsonPropertyName("legalShortName")] string? LegalShortName,
+    [property: JsonPropertyName("legalForm")] string? LegalForm,
+    [property: JsonPropertyName("identifiers")] IEnumerable<BpdmIdentifier> Identifiers,
+    [property: JsonPropertyName("states")] IEnumerable<BpdmStatus> States,
+    [property: JsonPropertyName("classifications")] IEnumerable<BpdmProfileClassification> Classifications,
+    [property: JsonPropertyName("legalNameParts")] IEnumerable<string> LegalNameParts,
+    [property: JsonPropertyName("roles")] IEnumerable<string> Roles,
+    [property: JsonPropertyName("legalAddress")] BpdmLegalAddressResponse LegalAddress
 );
 
 public record BpdmLegalAddressResponse(
-    string ExternalId,
-    string LegalEntityExternalId,
-    string SiteExternalId,
-    string Bpn,
-    IEnumerable<string> NameParts,
-    IEnumerable<BpdmAddressState> States,
-    IEnumerable<BpdmAddressIdentifier> Identifiers,
-    BpdmAddressPhysicalPostalAddress PhysicalPostalAddress,
-    BpdmAddressAlternativePostalAddress AlternativePostalAddress,
-    IEnumerable<string> Roles
+    [property: JsonPropertyName("externalId")] string ExternalId,
+    [property: JsonPropertyName("legalEntityExternalId")] string LegalEntityExternalId,
+    [property: JsonPropertyName("siteExternalId")] string SiteExternalId,
+    [property: JsonPropertyName("bpna")] string Bpn,
+    [property: JsonPropertyName("nameParts")] IEnumerable<string> NameParts,
+    [property: JsonPropertyName("states")] IEnumerable<BpdmAddressState> States,
+    [property: JsonPropertyName("identifiers")] IEnumerable<BpdmAddressIdentifier> Identifiers,
+    [property: JsonPropertyName("physicalPostalAddress")] BpdmAddressPhysicalPostalAddress? PhysicalPostalAddress,
+    [property: JsonPropertyName("alternativePostalAddress")] BpdmAddressAlternativePostalAddress? AlternativePostalAddress,
+    [property: JsonPropertyName("roles")] IEnumerable<string> Roles
 );
 
 public record BpdmCountry

--- a/tests/externalsystems/Bpdm.Library/BpdmServiceTests.cs
+++ b/tests/externalsystems/Bpdm.Library/BpdmServiceTests.cs
@@ -113,25 +113,74 @@ public class BpdmServiceTests
     public async Task FetchInputLegalEntity_WithValidResult_ReturnsExpected()
     {
         // Arrange
-        var externalId = _fixture.Create<string>();
-        var data = _fixture.Build<BpdmLegalEntityOutputData>()
-            .With(x => x.ExternalId, externalId)
-            .With(x => x.Bpn, "TESTBPN")
-            .CreateMany(1);
-        var pagination = new PageOutputResponseBpdmLegalEntityData(data);
-
-        var options = new System.Text.Json.JsonSerializerOptions
-        {
-            PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
-            Converters = { new JsonStringEnumConverter(allowIntegerValues: false) }
-        };
+        const string externalId = "0bf60442-09a8-4f09-811b-8854626ed5a6";
+        const string json = @"{
+            ""totalElements"": 1,
+            ""totalPages"": 1,
+            ""page"": 0,
+            ""contentSize"": 1,
+            ""content"": [
+                {
+                    ""legalNameParts"": [
+                        ""Volkswagen AG""
+                    ],
+                    ""identifiers"": [
+                        {
+                            ""value"": ""DE234567890"",
+                            ""type"": ""EU_VAT_ID_DE"",
+                            ""issuingBody"": null
+                        }
+                    ],
+                    ""legalShortName"": ""Volkswagen AG"",
+                    ""legalForm"": null,
+                    ""states"": [],
+                    ""classifications"": [],
+                    ""roles"": [],
+                    ""legalAddress"": {
+                        ""nameParts"": [],
+                        ""states"": [],
+                        ""identifiers"": [],
+                        ""physicalPostalAddress"": {
+                            ""geographicCoordinates"": null,
+                            ""country"": ""DE"",
+                            ""administrativeAreaLevel1"": null,
+                            ""administrativeAreaLevel2"": null,
+                            ""administrativeAreaLevel3"": null,
+                            ""postalCode"": ""38440"",
+                            ""city"": ""Wolfsburg"",
+                            ""district"": null,
+                            ""street"": {
+                                ""namePrefix"": null,
+                                ""additionalNamePrefix"": null,
+                                ""name"": ""Berliner Ring 2"",
+                                ""nameSuffix"": null,
+                                ""additionalNameSuffix"": null,
+                                ""houseNumber"": null,
+                                ""milestone"": null,
+                                ""direction"": null
+                            },
+                            ""companyPostalCode"": null,
+                            ""industrialZone"": null,
+                            ""building"": null,
+                            ""floor"": null,
+                            ""door"": null
+                        },
+                        ""alternativePostalAddress"": null,
+                        ""roles"": [],
+                        ""externalId"": ""0bf60442-09a8-4f09-811b-8854626ed5a6_legalAddress"",
+                        ""legalEntityExternalId"": ""0bf60442-09a8-4f09-811b-8854626ed5a6"",
+                        ""siteExternalId"": null,
+                        ""bpna"": ""BPNA000000006GFG""
+                    },
+                    ""externalId"": ""0bf60442-09a8-4f09-811b-8854626ed5a6"",
+                    ""bpnl"": ""BPNL00000007QGTF""
+                }
+            ]
+        }";
 
         var httpMessageHandlerMock = new HttpMessageHandlerMock(
             HttpStatusCode.OK,
-            pagination.ToJsonContent(
-                options,
-                "application/json")
-            );
+            new StringContent(json));
         var httpClient = new HttpClient(httpMessageHandlerMock)
         {
             BaseAddress = new Uri("https://base.address.com")
@@ -145,7 +194,7 @@ public class BpdmServiceTests
         // Assert
         result.Should().NotBeNull();
         result.ExternalId.Should().Be(externalId);
-        result.Bpn.Should().Be("TESTBPN");
+        result.Bpn.Should().Be("BPNL00000007QGTF");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Adjusted the json property name for bpn within the BpdmLegalEntityOutputData

## Why

Currently the bpn fetch process will always be retriggered to a wrong conversion of the bpn which results in bpn will always be null. With this fix the bpn will be converted correctly and if set isn't null

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
