### PR TITLE
fix(osp): change company name to idp display name

### DIFF
--- a/src/mailing/Mailing.Template/EmailTemplates/osp_welcome_email.html
+++ b/src/mailing/Mailing.Template/EmailTemplates/osp_welcome_email.html
@@ -99,7 +99,7 @@
                                                                     conditions is needed. <br /><br /> Please follow the link below to access your registration data and to confirm the company role related terms & conditions.
                                                                     <br /> Please note: for the login use your <strong><i>{osp}</i></strong> account can get used*. Make sure you select at the login page the following tenant:
                                                                     <br /> <br />
-                                                                    {companyName}
+                                                                    {idpAlias}
                                                                     <br /> <br /> * and entering your {osp} user credentials. In case the authentication
                                                                     runs on errors, please have a look at the
                                                                     <a href="{hostname}/documentation/?path=docs%2F09.+Others%28s%29%2F01.+Login.md"

--- a/src/processes/NetworkRegistration.Library/Models/UserMailInformation.cs
+++ b/src/processes/NetworkRegistration.Library/Models/UserMailInformation.cs
@@ -19,4 +19,4 @@
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Processes.NetworkRegistration.Library.Models;
 
-public record UserMailInformation(string Email, string? FirstName, string? LastName, IEnumerable<string> IdpAliasse);
+public record UserMailInformation(string Email, string? FirstName, string? LastName, IEnumerable<string> IdpDisplayNames);

--- a/src/processes/NetworkRegistration.Library/Models/UserMailInformation.cs
+++ b/src/processes/NetworkRegistration.Library/Models/UserMailInformation.cs
@@ -19,4 +19,4 @@
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Processes.NetworkRegistration.Library.Models;
 
-public record UserMailInformation(string Email, string? FirstName, string? LastName, string CompanyName);
+public record UserMailInformation(string Email, string? FirstName, string? LastName, IEnumerable<string> IdpAliasse);

--- a/src/processes/NetworkRegistration.Library/NetworkRegistrationHandler.cs
+++ b/src/processes/NetworkRegistration.Library/NetworkRegistrationHandler.cs
@@ -153,7 +153,7 @@ public class NetworkRegistrationHandler : INetworkRegistrationHandler
                 { "hostname", _settings.BasePortalAddress },
                 { "osp", ospName },
                 { "url", _settings.BasePortalAddress },
-                { "companyName", string.Join(",", displayNames) }
+                { "idpAlias", string.Join(",", displayNames) }
             };
             await _mailingService.SendMails(receiver, mailParameters, templates).ConfigureAwait(false);
         }

--- a/src/processes/NetworkRegistration.Library/NetworkRegistrationHandler.cs
+++ b/src/processes/NetworkRegistration.Library/NetworkRegistrationHandler.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.NetworkRegistration.Library.DependencyInjection;
@@ -112,10 +113,7 @@ public class NetworkRegistrationHandler : INetworkRegistrationHandler
             }
         }
 
-        var idpAliasse = companyAssignedIdentityProviders.SelectMany(x => x.ProviderLinkData.Select(pld => pld.Alias!)).Distinct();
-        var aliasDisplayNameMapping = await GetDisplayNamesForIdpAlias(idpAliasse).ConfigureAwait(false);
-
-        await SendMails(companyAssignedIdentityProviders.Select(x => new UserMailInformation(x.Email!, x.FirstName, x.LastName, x.ProviderLinkData.Select(pld => pld.Alias!))), ospName, aliasDisplayNameMapping).ConfigureAwait(false);
+        await SendMails(GetUserMailInformation(companyAssignedIdentityProviders), ospName).ConfigureAwait(false);
         return new ValueTuple<IEnumerable<ProcessStepTypeId>?, ProcessStepStatusId, bool, string?>(
             null,
             ProcessStepStatusId.DONE,
@@ -123,29 +121,42 @@ public class NetworkRegistrationHandler : INetworkRegistrationHandler
             null);
     }
 
-    private async Task<IDictionary<string, string>> GetDisplayNamesForIdpAlias(IEnumerable<string> idpAliasse)
+    private async IAsyncEnumerable<UserMailInformation> GetUserMailInformation(IEnumerable<CompanyUserIdentityProviderProcessData> companyUserIdentityProviderProcessData)
     {
         var mapping = new Dictionary<string, string>();
-        foreach (var idpAlias in idpAliasse)
-        {
-            var displayName = await _provisioningManager.GetIdentityProviderDisplayName(idpAlias).ConfigureAwait(false);
-            if (string.IsNullOrWhiteSpace(displayName))
-            {
-                throw new ConflictException($"DisplayName for idpAlias {idpAlias} couldn't be determined");
-            }
 
-            mapping.Add(idpAlias, displayName);
+        async Task<string> GetDisplayName(string idpAlias)
+        {
+            if (!mapping.TryGetValue(idpAlias, out var displayName))
+            {
+                displayName = await _provisioningManager.GetIdentityProviderDisplayName(idpAlias).ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(displayName))
+                {
+                    throw new ConflictException($"DisplayName for idpAlias {idpAlias} couldn't be determined");
+                }
+                mapping.Add(idpAlias, displayName);
+            }
+            return displayName;
         }
 
-        return mapping;
+        foreach (var userData in companyUserIdentityProviderProcessData)
+        {
+            yield return new UserMailInformation(
+                userData.Email ?? throw new UnexpectedConditionException("userData.Email should never be null here"),
+                userData.FirstName,
+                userData.LastName,
+                await Task.WhenAll(
+                    userData.ProviderLinkData.Select(pld =>
+                        GetDisplayName(pld.Alias ?? throw new UnexpectedConditionException("providerLinkData.Alias should never be null here")))).ConfigureAwait(false));
+        }
     }
 
-    private async Task SendMails(IEnumerable<UserMailInformation> companyUserWithRoleIdForCompany, string ospName, IDictionary<string, string> aliasDisplayNameMapping)
+    private static readonly IEnumerable<string> MailTemplates = Enumerable.Repeat("OspWelcomeMail", 1);
+
+    private async Task SendMails(IAsyncEnumerable<UserMailInformation> companyUserWithRoleIdForCompany, string ospName)
     {
-        var templates = Enumerable.Repeat("OspWelcomeMail", 1);
-        foreach (var (receiver, firstName, lastName, idpAliasse) in companyUserWithRoleIdForCompany)
+        await foreach (var (receiver, firstName, lastName, displayNames) in companyUserWithRoleIdForCompany)
         {
-            var displayNames = idpAliasse.Select(x => aliasDisplayNameMapping[x]);
             var userName = string.Join(" ", firstName, lastName);
             var mailParameters = new Dictionary<string, string>
             {
@@ -155,7 +166,7 @@ public class NetworkRegistrationHandler : INetworkRegistrationHandler
                 { "url", _settings.BasePortalAddress },
                 { "idpAlias", string.Join(",", displayNames) }
             };
-            await _mailingService.SendMails(receiver, mailParameters, templates).ConfigureAwait(false);
+            await _mailingService.SendMails(receiver, mailParameters, MailTemplates).ConfigureAwait(false);
         }
     }
 }

--- a/src/processes/NetworkRegistration.Library/NetworkRegistrationHandler.cs
+++ b/src/processes/NetworkRegistration.Library/NetworkRegistrationHandler.cs
@@ -133,7 +133,7 @@ public class NetworkRegistrationHandler : INetworkRegistrationHandler
             {
                 throw new ConflictException($"DisplayName for idpAlias {idpAlias} couldn't be determined");
             }
-            
+
             mapping.Add(idpAlias, displayName);
         }
 

--- a/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
@@ -148,6 +148,12 @@ public partial class ProvisioningManager
         }
     }
 
+    public async Task<string?> GetIdentityProviderDisplayName(string alias)
+    {
+        var identityProvider = await GetCentralIdentityProviderAsync(alias).ConfigureAwait(false);
+        return identityProvider.DisplayName;
+    }
+
     private async ValueTask EnableCentralIdentityProviderAsync(string alias)
     {
         var identityProvider = await GetCentralIdentityProviderAsync(alias).ConfigureAwait(false);

--- a/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
@@ -148,11 +148,8 @@ public partial class ProvisioningManager
         }
     }
 
-    public async Task<string?> GetIdentityProviderDisplayName(string alias)
-    {
-        var identityProvider = await GetCentralIdentityProviderAsync(alias).ConfigureAwait(false);
-        return identityProvider.DisplayName;
-    }
+    public async Task<string?> GetIdentityProviderDisplayName(string alias) =>
+        (await GetCentralIdentityProviderAsync(alias).ConfigureAwait(false)).DisplayName;
 
     private async ValueTask EnableCentralIdentityProviderAsync(string alias)
     {

--- a/src/provisioning/Provisioning.Library/IProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/IProvisioningManager.cs
@@ -70,4 +70,5 @@ public interface IProvisioningManager
     Task DeleteClientRolesFromCentralUserAsync(string centralUserId, IDictionary<string, IEnumerable<string>> clientRoleNames);
     ValueTask UpdateSharedRealmTheme(string alias, string loginTheme);
     Task<string?> GetUserByUserName(string userName);
+    Task<string?> GetIdentityProviderDisplayName(string alias);
 }

--- a/tests/processes/NetworkRegistration.Executor.Tests/NetworkRegistrationProcessTypeExecutorTests.cs
+++ b/tests/processes/NetworkRegistration.Executor.Tests/NetworkRegistrationProcessTypeExecutorTests.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Microsoft.AspNetCore.Mvc.Filters;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.OnboardingServiceProvider.Library;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;

--- a/tests/provisioning/Provisioning.Library.Tests/ProvisioningManagerTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/ProvisioningManagerTests.cs
@@ -215,4 +215,21 @@ public class ProvisioningManagerTests
             .WithVerb(HttpMethod.Put)
             .Times(1);
     }
+
+    [Fact]
+    public async Task GetIdentityProviderDisplayName_CallsExpected()
+    {
+        // Arrange
+        const string alias = "idp123";
+        using var httpTest = new HttpTest();
+        httpTest.WithAuthorization()
+            .WithGetIdentityProviderAsync(alias, new IdentityProvider.IdentityProvider { DisplayName = "test", Config = new IdentityProvider.Config() });
+
+        // Act
+        var displayName = await _sut.GetIdentityProviderDisplayName(alias).ConfigureAwait(false);
+
+        // Arrange
+        displayName.Should().NotBeNullOrWhiteSpace();
+        displayName.Should().Be("test");
+    }
 }


### PR DESCRIPTION
## Description

Change the companyName to the idp display name in the osp welcome mail

## Why

To give the user which got registered to Catena an easy to understand introduction the company name has been changed to the idp display name

## Issue

N/A - Jira Issue: CPLP-3470

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
