### PR TITLE
fix(connector): fix /api/administration/connectors ep

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -48,7 +48,7 @@ public class ConnectorsRepository : IConnectorsRepository
             take,
             _context.Connectors.AsNoTracking()
                 .Where(x => x.ProviderId == companyId && x.StatusId != ConnectorStatusId.INACTIVE)
-                .GroupBy(c => c.HostId),
+                .GroupBy(c => c.ProviderId),
             connector => connector.OrderByDescending(connector => connector.Name),
             con => new ConnectorData(
                 con.Name,

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -20,6 +20,7 @@
 
 using Microsoft.EntityFrameworkCore;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Async;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Tests.Setup;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
@@ -56,15 +57,21 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetAllCompanyConnectorsForCompanyId(_userCompanyId).Invoke(0, 10).ConfigureAwait(false);
+        var result = await Pagination.CreateResponseAsync(
+            0,
+            10,
+            15,
+            sut.GetAllCompanyConnectorsForCompanyId(_userCompanyId)).ConfigureAwait(false);
 
         // Assert
         result.Should().NotBeNull();
-        result!.Data.Should().HaveCount(2).And.Satisfy(
+        result.Content.Should().HaveCount(3).And.Satisfy(
             x => x.Name == "Test Connector 6"
                 && x.TechnicalUser!.Id == new Guid("cd436931-8399-4c1d-bd81-7dffb298c7ca")
                 && x.TechnicalUser.Name == "test-user-service-accounts",
             x => x.Name == "Test Connector 1"
+                && x.TechnicalUser == null,
+            x => x.Name == "Test Connector 42"
                 && x.TechnicalUser == null);
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connectors.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connectors.test.json
@@ -99,5 +99,16 @@
     "host_id": "41fd2ab8-7123-4546-9bef-a388d91b2999",
     "location_id": "DE",
     "self_description_document_id": null
+  },
+  {
+    "id": "12481a39-ca13-4760-bbbb-f6ff98508007",
+    "name": "Test Connector 42",
+    "connector_url": "www.google.de",
+    "type_id": 1,
+    "status_id": 1,
+    "provider_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "host_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
+    "location_id": "DE",
+    "self_description_document_id": null
   }
 ]


### PR DESCRIPTION
## Description

Fix the pagination of /api/administration/connectors endpoint

## Why

Currently the pagination of connectors fails as soon as there are connectors with the same provider but different hosts. which this PR this error is fixed

## Issue

N/A - Jira Issue: CPLP-3240

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
