### PR TITLE
chore: merge migrations into one

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20231122165021_1.7.0-rc4.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20231122165021_1.7.0-rc4.Designer.cs
@@ -28,8 +28,8 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    [Migration("20231115145343_CPLP-3511-AuditAdjustment")]
-    partial class CPLP3511AuditAdjustment
+    [Migration("20231122165021_1.7.0-rc4")]
+    partial class _170rc4
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20231122165021_1.7.0-rc4.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20231122165021_1.7.0-rc4.cs
@@ -24,7 +24,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations.Migrations
 {
     /// <inheritdoc />
-    public partial class CPLP3511AuditAdjustment : Migration
+    public partial class _170rc4 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
## Description

Merge all migrations since release v1.7.0-RC3 into one migration

## Why

To have only one migration per releasee

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
