### PR TITLE
fix(seeding): set correct baseUrl for keycloak clients

### DIFF
--- a/src/keycloak/Keycloak.Seeding/BusinessLogic/ClientsUpdater.cs
+++ b/src/keycloak/Keycloak.Seeding/BusinessLogic/ClientsUpdater.cs
@@ -144,7 +144,7 @@ public class ClientsUpdater : IClientsUpdater
         RootUrl = client?.RootUrl ?? update.RootUrl, // only set the root url if no url is already set
         Name = update.Name,
         Description = update.Description,
-        BaseUrl = client?.RootUrl ?? update.BaseUrl, // only set the base url if no url is already set
+        BaseUrl = client?.BaseUrl ?? update.BaseUrl, // only set the base url if no url is already set
         SurrogateAuthRequired = update.SurrogateAuthRequired,
         Enabled = update.Enabled,
         AlwaysDisplayInConsole = update.AlwaysDisplayInConsole,


### PR DESCRIPTION
## Description

set the correct base url for keycloak clients when seeding them

## Why

currently the root url was set as baseurl which led to an 400 error in the keycloak seeding

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
