### PR TITLE
fix(maintenance): only delete not linked documents

### DIFF
--- a/src/maintenance/Maintenance.App/BatchDeleteService.cs
+++ b/src/maintenance/Maintenance.App/BatchDeleteService.cs
@@ -67,6 +67,10 @@ public class BatchDeleteService : BackgroundService
                 _logger.LogInformation("Getting documents and assignments older {Days} days", _days);
                 List<(Guid DocumentId, IEnumerable<Guid> AgreementIds, IEnumerable<Guid> OfferIds)> documentData = await dbContext.Documents.Where(x =>
                     x.DateCreated < DateTimeOffset.UtcNow.AddDays(-_days) &&
+                    !x.Companies.Any() &&
+                    x.Connector == null &&
+                    !x.Consents.Any() &&
+                    x.CompanySsiDetail == null &&
                     x.DocumentStatusId == DocumentStatusId.INACTIVE)
                     .Select(doc => new ValueTuple<Guid, IEnumerable<Guid>, IEnumerable<Guid>>(
                         doc.Id,


### PR DESCRIPTION
## Description

- excluding the documents which are linked to one of the following entities from the cleanup job:
  - companies
  - connector
  - consents
  - companySsiDetail

## Why

When deleting an active connector, the connector and the linked self description document will be set to inactive. The maintenance job was searching for all inactive documents which are older than 80 days. Therefor even still linked documents were selected and tried to be deleted. This resulted in an database error because the documents were still linked.

## Issue

N/A - Jira Issue: CPLP-3511

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
