### PR TITLE
fix: adjust dbaccess path for maintenance docker

### DIFF
--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -23,7 +23,7 @@ FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/maintenance/Maintenance.App/ src/maintenance/Maintenance.App/
-COPY src/portalbackend/PortalBackend.DbAccess/ src/portalbackend/PortalBackend.DbAccess/
+COPY src/portalbackend/PortalBackend.DBAccess/ src/portalbackend/PortalBackend.DBAccess/
 COPY src/portalbackend/PortalBackend.PortalEntities/ src/portalbackend/PortalBackend.PortalEntities/
 COPY src/framework/Framework.BaseDependencies/ src/framework/Framework.BaseDependencies/
 COPY src/framework/Framework.DBAccess/ src/framework/Framework.DBAccess/


### PR DESCRIPTION
## Description

adjusted the path for  portal backend dbaccess in the maintenance docker image

## Why

currently the action to build the docker image fails because the given path cannot be found

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
