### PR TITLE
fix(identity): change identity service to scoped

### DIFF
--- a/src/framework/Framework.ProcessIdentity/DependencyInjection/ProcessIdentityServiceCollectionExtensions.cs
+++ b/src/framework/Framework.ProcessIdentity/DependencyInjection/ProcessIdentityServiceCollectionExtensions.cs
@@ -44,7 +44,7 @@ public static class ProcessIdentityServiceCollectionExtensions
             .ValidateOnStart();
 
         return services
-            .AddTransient<IIdentityIdDetermination, ConfigurationIdentityIdDetermination>()
-            .AddTransient<IIdentityService, IdentityService>();
+            .AddScoped<IIdentityIdDetermination, ConfigurationIdentityIdDetermination>()
+            .AddScoped<IIdentityService, IdentityService>();
     }
 }

--- a/src/framework/Framework.Web/ClaimsIdentityServiceCollectionExtensions.cs
+++ b/src/framework/Framework.Web/ClaimsIdentityServiceCollectionExtensions.cs
@@ -29,6 +29,6 @@ public static class ClaimsIdentityServiceCollectionExtensions
     {
         return services
             .AddScoped<IIdentityIdDetermination, ClaimsIdentityIdDetermination>()
-            .AddTransient<IIdentityService, IdentityService>();
+            .AddScoped<IIdentityService, IdentityService>();
     }
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Identities/IdentityService.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Identities/IdentityService.cs
@@ -37,7 +37,9 @@ public class IdentityService : IIdentityService
 
     /// <inheritdoc />
     public async ValueTask<IdentityData> GetIdentityData() =>
-        _identityData ??= await _identityRepository.GetActiveIdentityDataByIdentityId(IdentityId).ConfigureAwait(false) ?? throw new ConflictException($"Identity {_identityIdDetermination.IdentityId} could not be found");
+        _identityData ?? (_identityData =
+            await _identityRepository.GetActiveIdentityDataByIdentityId(IdentityId).ConfigureAwait(false) ??
+            throw new ConflictException($"Identity {_identityIdDetermination.IdentityId} could not be found"));
 
     public IdentityData IdentityData => _identityData ?? throw new UnexpectedConditionException("identityData should never be null here (endpoint must be annotated with an identity policy / as an alternative GetIdentityData should be used)");
 


### PR DESCRIPTION
## Description

Change registration of identity service to scoped.

## Why

Currently with each access the _identityData needs to get set, this leads to an error that _identityData is only set for the PolicyClaim check but not for accessing the data later on in the process.

## Issue

N/A - Jira Issue: CPLP-3102

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
