### PR TITLE
fix(registration): delete idp on application decline

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -424,15 +424,15 @@ public class ApplicationRepository : IApplicationRepository
     /// </summary>
     /// <param name="applicationId">Id of the application</param>
     /// <returns>Returns the company id</returns>
-    public Task<(Guid CompanyId, string CompanyName, Guid? NetworkRegistrationProcessId, IEnumerable<(string IamAlias, IdentityProviderTypeId TypeId)> Idps, IEnumerable<Guid> CompanyUserIds)> GetCompanyIdNameForSubmittedApplication(Guid applicationId) =>
+    public Task<(Guid CompanyId, string CompanyName, Guid? NetworkRegistrationProcessId, IEnumerable<(Guid IdentityProviderId, string IamAlias, IdentityProviderTypeId TypeId)> Idps, IEnumerable<Guid> CompanyUserIds)> GetCompanyIdNameForSubmittedApplication(Guid applicationId) =>
         _dbContext.CompanyApplications
             .AsSplitQuery()
             .Where(x => x.Id == applicationId && x.ApplicationStatusId == CompanyApplicationStatusId.SUBMITTED)
-            .Select(x => new ValueTuple<Guid, string, Guid?, IEnumerable<(string, IdentityProviderTypeId)>, IEnumerable<Guid>>(
+            .Select(x => new ValueTuple<Guid, string, Guid?, IEnumerable<(Guid, string, IdentityProviderTypeId)>, IEnumerable<Guid>>(
                 x.CompanyId,
                 x.Company!.Name,
                 x.Company.NetworkRegistration!.ProcessId,
-                x.Company.IdentityProviders.Where(idp => idp.IdentityProviderTypeId != IdentityProviderTypeId.MANAGED).Select(idp => new ValueTuple<string, IdentityProviderTypeId>(idp.IamIdentityProvider!.IamIdpAlias, idp.IdentityProviderTypeId)),
+                x.Company.IdentityProviders.Select(idp => new ValueTuple<Guid, string, IdentityProviderTypeId>(idp.Id, idp.IamIdentityProvider!.IamIdpAlias, idp.IdentityProviderTypeId)),
                 x.Company.Identities.Where(i => i.IdentityTypeId == IdentityTypeId.COMPANY_USER && i.UserStatusId != UserStatusId.DELETED).Select(i => i.Id)))
             .SingleOrDefaultAsync();
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -96,7 +96,7 @@ public interface IApplicationRepository
     /// </summary>
     /// <param name="applicationId">Id of the application</param>
     /// <returns>The id of the company for the given application</returns>
-    Task<(Guid CompanyId, string CompanyName, Guid? NetworkRegistrationProcessId, IEnumerable<(string IamAlias, IdentityProviderTypeId TypeId)> Idps, IEnumerable<Guid> CompanyUserIds)> GetCompanyIdNameForSubmittedApplication(Guid applicationId);
+    Task<(Guid CompanyId, string CompanyName, Guid? NetworkRegistrationProcessId, IEnumerable<(Guid IdentityProviderId, string IamAlias, IdentityProviderTypeId TypeId)> Idps, IEnumerable<Guid> CompanyUserIds)> GetCompanyIdNameForSubmittedApplication(Guid applicationId);
 
     Task<bool> IsValidApplicationForCompany(Guid applicationId, Guid companyId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -96,7 +96,7 @@ public interface IApplicationRepository
     /// </summary>
     /// <param name="applicationId">Id of the application</param>
     /// <returns>The id of the company for the given application</returns>
-    Task<(Guid CompanyId, string CompanyName, Guid? NetworkRegistrationProcessId, IEnumerable<(string IamAlias, IdentityProviderTypeId TypeId)> Idps, IEnumerable<(Guid IdentityId, string? UserEntityId)> IdentityIds)> GetCompanyIdNameForSubmittedApplication(Guid applicationId);
+    Task<(Guid CompanyId, string CompanyName, Guid? NetworkRegistrationProcessId, IEnumerable<(string IamAlias, IdentityProviderTypeId TypeId)> Idps, IEnumerable<Guid> CompanyUserIds)> GetCompanyIdNameForSubmittedApplication(Guid applicationId);
 
     Task<bool> IsValidApplicationForCompany(Guid applicationId, Guid companyId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -96,7 +96,7 @@ public interface IApplicationRepository
     /// </summary>
     /// <param name="applicationId">Id of the application</param>
     /// <returns>The id of the company for the given application</returns>
-    Task<(Guid CompanyId, string CompanyName, Guid? NetworkRegistrationProcessId)> GetCompanyIdNameForSubmittedApplication(Guid applicationId);
+    Task<(Guid CompanyId, string CompanyName, Guid? NetworkRegistrationProcessId, IEnumerable<(string IamAlias, IdentityProviderTypeId TypeId)> Idps, IEnumerable<(Guid IdentityId, string? UserEntityId)> IdentityIds)> GetCompanyIdNameForSubmittedApplication(Guid applicationId);
 
     Task<bool> IsValidApplicationForCompany(Guid applicationId, Guid companyId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IIdentityProviderRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IIdentityProviderRepository.cs
@@ -29,8 +29,11 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositorie
 public interface IIdentityProviderRepository
 {
     IdentityProvider CreateIdentityProvider(IdentityProviderCategoryId identityProviderCategory, IdentityProviderTypeId identityProviderTypeId, Guid owner, Action<IdentityProvider>? setOptionalFields);
+    void DeleteIdentityProvider(Guid identityProviderId);
     IamIdentityProvider CreateIamIdentityProvider(Guid identityProviderId, string idpAlias);
+    void DeleteIamIdentityProvider(string idpAlias);
     CompanyIdentityProvider CreateCompanyIdentityProvider(Guid companyId, Guid identityProviderId);
+    void DeleteCompanyIdentityProvider(Guid companyId, Guid identityProviderId);
     void CreateCompanyIdentityProviders(IEnumerable<(Guid CompanyId, Guid IdentityProviderId)> companyIdIdentityProviderIds);
     Task<string?> GetSharedIdentityProviderIamAliasDataUntrackedAsync(Guid companyId);
     Task<(string? Alias, bool IsValidUser)> GetIdpCategoryIdByUserIdAsync(Guid companyUserId, Guid userCompanyId);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
@@ -21,7 +21,6 @@ using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 
@@ -123,4 +122,5 @@ public interface IUserRepository
     Identity AttachAndModifyIdentity(Guid identityId, Action<Identity>? initialize, Action<Identity> modify);
     CompanyUserAssignedIdentityProvider AddCompanyUserAssignedIdentityProvider(Guid companyUserId, Guid identityProviderId, string providerId, string userName);
     IAsyncEnumerable<CompanyUserIdentityProviderProcessData> GetUserAssignedIdentityProviderForNetworkRegistration(Guid networkRegistrationId);
+    void AttachAndModifyIdentities(IEnumerable<(Guid IdentityId, Action<Identity> Modify)> identityData);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IdentityProviderRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IdentityProviderRepository.cs
@@ -53,12 +53,18 @@ public class IdentityProviderRepository : IIdentityProviderRepository
             .Add(idp).Entity;
     }
 
+    public void DeleteIdentityProvider(Guid identityProviderId) =>
+        _context.IdentityProviders.Remove(new IdentityProvider(identityProviderId, default, default, Guid.Empty, default));
+
     public CompanyIdentityProvider CreateCompanyIdentityProvider(Guid companyId, Guid identityProviderId) =>
         _context.CompanyIdentityProviders
             .Add(new CompanyIdentityProvider(
                 companyId,
                 identityProviderId
             )).Entity;
+
+    public void DeleteCompanyIdentityProvider(Guid companyId, Guid identityProviderId) =>
+        _context.Remove(new CompanyIdentityProvider(companyId, identityProviderId));
 
     public void CreateCompanyIdentityProviders(IEnumerable<(Guid CompanyId, Guid IdentityProviderId)> companyIdIdentityProviderIds) =>
         _context.CompanyIdentityProviders
@@ -73,6 +79,9 @@ public class IdentityProviderRepository : IIdentityProviderRepository
             new IamIdentityProvider(
                 idpAlias,
                 identityProviderId)).Entity;
+
+    public void DeleteIamIdentityProvider(string idpAlias) =>
+        _context.IamIdentityProviders.Remove(new IamIdentityProvider(idpAlias, Guid.Empty));
 
     public Task<string?> GetSharedIdentityProviderIamAliasDataUntrackedAsync(Guid companyId) =>
         _context.IdentityProviders

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -24,7 +24,6 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 
@@ -446,4 +445,16 @@ public class UserRepository : IUserRepository
                     cu.CompanyUserAssignedIdentityProviders.Select(assigned => new ProviderLinkData(assigned.UserName, assigned.IdentityProvider!.IamIdentityProvider!.IamIdpAlias, assigned.ProviderId))
                 ))
             .ToAsyncEnumerable();
+
+    public void AttachAndModifyIdentities(IEnumerable<(Guid IdentityId, Action<Identity> Modify)> identityData)
+    {
+        var initial = identityData.Select(x =>
+            {
+                var identity = new Identity(x.IdentityId, default, Guid.Empty, default, default);
+                return (Identity: identity, x.Modify);
+            }
+        ).ToList();
+        _dbContext.AttachRange(initial.Select(x => x.Identity));
+        initial.ForEach(x => x.Modify(x.Identity));
+    }
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -501,7 +501,7 @@ public class RegistrationBusinessLogicTest
         // Arrange
         var applicationId = Guid.NewGuid();
         A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(applicationId))
-            .Returns(new ValueTuple<Guid, string, Guid?, IEnumerable<ValueTuple<string, IdentityProviderTypeId>>, IEnumerable<ValueTuple<Guid, string?>>>());
+            .Returns(default((Guid, string, Guid?, IEnumerable<(string, IdentityProviderTypeId)>, IEnumerable<Guid>)));
         async Task Act() => await _logic.DeclineRegistrationVerification(applicationId, "test", CancellationToken.None).ConfigureAwait(false);
 
         // Act
@@ -518,7 +518,7 @@ public class RegistrationBusinessLogicTest
         // Arrange
         var applicationId = Guid.NewGuid();
         A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(applicationId))
-            .Returns(new ValueTuple<Guid, string, Guid?, IEnumerable<ValueTuple<string, IdentityProviderTypeId>>, IEnumerable<ValueTuple<Guid, string?>>>(
+            .Returns((
                 Guid.NewGuid(),
                 "test",
                 null,
@@ -527,7 +527,7 @@ public class RegistrationBusinessLogicTest
                     ("idp1", IdentityProviderTypeId.SHARED),
                     ("idp2", IdentityProviderTypeId.SHARED)
                 },
-                Enumerable.Empty<ValueTuple<Guid, string?>>()));
+                Enumerable.Empty<Guid>()));
         async Task Act() => await _logic.DeclineRegistrationVerification(applicationId, "test", CancellationToken.None).ConfigureAwait(false);
 
         // Act
@@ -886,7 +886,10 @@ public class RegistrationBusinessLogicTest
             }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>()));
 
         A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(IdWithBpn))
-            .Returns((CompanyId, CompanyName, ExistingExternalId, Enumerable.Repeat((IamAliasId, idpTypeId), 1), Enumerable.Repeat<ValueTuple<Guid, string?>>((UserId, "user123"), 1)));
+            .Returns((CompanyId, CompanyName, ExistingExternalId, Enumerable.Repeat((IamAliasId, idpTypeId), 1), Enumerable.Repeat(UserId, 1)));
+
+        A.CallTo(() => _provisioningManager.GetUserByUserName(UserId.ToString()))
+            .Returns("user123");
 
         A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>?>._))
             .Invokes((IApplicationChecklistService.ManualChecklistProcessStepData _, Action<ApplicationChecklistEntry> _, Action<ApplicationChecklistEntry> action, IEnumerable<ProcessStepTypeId>? _) =>

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -33,6 +33,7 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library;
+using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
@@ -46,6 +47,7 @@ public class RegistrationBusinessLogicTest
     private const string AlreadyTakenBpn = "BPNL123698762666";
     private const string ValidBpn = "BPNL123698762345";
     private const string CompanyName = "TestCompany";
+    private const string IamAliasId = "idp1";
     private static readonly Guid IdWithBpn = new("c244f79a-7faf-4c59-bb85-fbfdf72ce46f");
     private static readonly Guid NotExistingApplicationId = new("9f0cfd0d-c512-438e-a07e-3198bce873bf");
     private static readonly Guid ActiveApplicationCompanyId = new("045abf01-7762-468b-98fb-84a30c39b7c7");
@@ -53,10 +55,10 @@ public class RegistrationBusinessLogicTest
     private static readonly Guid ExistingExternalId = Guid.NewGuid();
     private static readonly Guid IdWithoutBpn = new("d90995fe-1241-4b8d-9f5c-f3909acc6399");
     private static readonly Guid ApplicationId = new("6084d6e0-0e01-413c-850d-9f944a6c494c");
+    private static readonly Guid UserId = Guid.NewGuid();
 
     private readonly IPortalRepositories _portalRepositories;
     private readonly IApplicationRepository _applicationRepository;
-    private readonly IApplicationChecklistRepository _applicationChecklistRepository;
     private readonly IProcessStepRepository _processStepRepository;
     private readonly IUserRepository _userRepository;
     private readonly IFixture _fixture;
@@ -67,6 +69,7 @@ public class RegistrationBusinessLogicTest
     private readonly ISdFactoryBusinessLogic _sdFactoryBusinessLogic;
     private readonly IMailingService _mailingService;
     private readonly IDocumentRepository _documentRepository;
+    private readonly IProvisioningManager _provisioningManager;
 
     public RegistrationBusinessLogicTest()
     {
@@ -77,31 +80,31 @@ public class RegistrationBusinessLogicTest
 
         _portalRepositories = A.Fake<IPortalRepositories>();
         _applicationRepository = A.Fake<IApplicationRepository>();
-        _applicationChecklistRepository = A.Fake<IApplicationChecklistRepository>();
         _documentRepository = A.Fake<IDocumentRepository>();
         _processStepRepository = A.Fake<IProcessStepRepository>();
         _userRepository = A.Fake<IUserRepository>();
         _companyRepository = A.Fake<ICompanyRepository>();
 
         var options = A.Fake<IOptions<RegistrationSettings>>();
+        var settings = A.Fake<RegistrationSettings>();
+        settings.ApplicationsMaxPageSize = 15;
+        A.CallTo(() => options.Value).Returns(settings);
+
         _clearinghouseBusinessLogic = A.Fake<IClearinghouseBusinessLogic>();
         _sdFactoryBusinessLogic = A.Fake<ISdFactoryBusinessLogic>();
         _checklistService = A.Fake<IApplicationChecklistService>();
         _mailingService = A.Fake<IMailingService>();
-        var settings = A.Fake<RegistrationSettings>();
-        settings.ApplicationsMaxPageSize = 15;
+        _provisioningManager = A.Fake<IProvisioningManager>();
 
         A.CallTo(() => _portalRepositories.GetInstance<IApplicationRepository>()).Returns(_applicationRepository);
-        A.CallTo(() => _portalRepositories.GetInstance<IApplicationChecklistRepository>()).Returns(_applicationChecklistRepository);
         A.CallTo(() => _portalRepositories.GetInstance<IDocumentRepository>()).Returns(_documentRepository);
         A.CallTo(() => _portalRepositories.GetInstance<IUserRepository>()).Returns(_userRepository);
         A.CallTo(() => _portalRepositories.GetInstance<ICompanyRepository>()).Returns(_companyRepository);
         A.CallTo(() => _portalRepositories.GetInstance<IProcessStepRepository>()).Returns(_processStepRepository);
-        A.CallTo(() => options.Value).Returns(settings);
 
         var logger = A.Fake<ILogger<RegistrationBusinessLogic>>();
 
-        _logic = new RegistrationBusinessLogic(_portalRepositories, options, _mailingService, _checklistService, _clearinghouseBusinessLogic, _sdFactoryBusinessLogic, logger);
+        _logic = new RegistrationBusinessLogic(_portalRepositories, options, _mailingService, _checklistService, _clearinghouseBusinessLogic, _sdFactoryBusinessLogic, _provisioningManager, logger);
     }
 
     #region GetCompanyApplicationDetailsAsync
@@ -446,9 +449,11 @@ public class RegistrationBusinessLogicTest
     }
 
     [Theory]
-    [InlineData(ApplicationChecklistEntryStatusId.TO_DO)]
-    [InlineData(ApplicationChecklistEntryStatusId.DONE)]
-    public async Task DeclineRegistrationVerification_WithDecline_StateAndCommentSetCorrectly(ApplicationChecklistEntryStatusId checklistStatusId)
+    [InlineData(ApplicationChecklistEntryStatusId.TO_DO, IdentityProviderTypeId.SHARED)]
+    [InlineData(ApplicationChecklistEntryStatusId.DONE, IdentityProviderTypeId.SHARED)]
+    [InlineData(ApplicationChecklistEntryStatusId.TO_DO, IdentityProviderTypeId.OWN)]
+    [InlineData(ApplicationChecklistEntryStatusId.DONE, IdentityProviderTypeId.OWN)]
+    public async Task DeclineRegistrationVerification_WithDecline_StateAndCommentSetCorrectly(ApplicationChecklistEntryStatusId checklistStatusId, IdentityProviderTypeId idpTypeId)
     {
         // Arrange
         const string comment = "application rejected because of reasons.";
@@ -456,7 +461,7 @@ public class RegistrationBusinessLogicTest
         var entry = new ApplicationChecklistEntry(IdWithBpn, ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, checklistStatusId, DateTimeOffset.UtcNow);
         var company = new Company(CompanyId, null!, CompanyStatusId.PENDING, DateTimeOffset.UtcNow);
         var application = new CompanyApplication(ApplicationId, company.Id, CompanyApplicationStatusId.SUBMITTED, CompanyApplicationTypeId.INTERNAL, DateTimeOffset.UtcNow);
-        SetupForDeclineRegistrationVerification(entry, application, company, checklistStatusId);
+        SetupForDeclineRegistrationVerification(entry, application, company, checklistStatusId, idpTypeId);
         A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)>>._))
             .Invokes((IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)> processStepData) =>
             {
@@ -479,6 +484,57 @@ public class RegistrationBusinessLogicTest
         processSteps.Should().ContainSingle().Which.Should().Match<ProcessStep>(x =>
             x.ProcessStepStatusId == ProcessStepStatusId.TODO &&
             x.ProcessStepTypeId == ProcessStepTypeId.TRIGGER_CALLBACK_OSP_DECLINED);
+        if (idpTypeId == IdentityProviderTypeId.SHARED)
+        {
+            A.CallTo(() => _provisioningManager.DeleteSharedIdpRealmAsync(IamAliasId))
+            .MustHaveHappenedOnceExactly();
+        }
+        A.CallTo(() => _provisioningManager.DeleteCentralIdentityProviderAsync(IamAliasId))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _provisioningManager.DeleteCentralRealmUserAsync("user123"))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task DeclineRegistrationVerification_WithApplicationNotFound_ThrowsArgumentException()
+    {
+        // Arrange
+        var applicationId = Guid.NewGuid();
+        A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(applicationId))
+            .Returns(new ValueTuple<Guid, string, Guid?, IEnumerable<ValueTuple<string, IdentityProviderTypeId>>, IEnumerable<ValueTuple<Guid, string?>>>());
+        async Task Act() => await _logic.DeclineRegistrationVerification(applicationId, "test", CancellationToken.None).ConfigureAwait(false);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ArgumentException>(Act);
+
+        // Assert
+        ex.Message.Should().Be($"CompanyApplication {applicationId} is not in status SUBMITTED (Parameter 'applicationId')");
+        ex.ParamName.Should().Be("applicationId");
+    }
+
+    [Fact]
+    public async Task DeclineRegistrationVerification_WithMultipleIdps_ThrowsUnexpectedConditionException()
+    {
+        // Arrange
+        var applicationId = Guid.NewGuid();
+        A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(applicationId))
+            .Returns(new ValueTuple<Guid, string, Guid?, IEnumerable<ValueTuple<string, IdentityProviderTypeId>>, IEnumerable<ValueTuple<Guid, string?>>>(
+                Guid.NewGuid(),
+                "test",
+                null,
+                new[]
+                {
+                    ("idp1", IdentityProviderTypeId.SHARED),
+                    ("idp2", IdentityProviderTypeId.SHARED)
+                },
+                Enumerable.Empty<ValueTuple<Guid, string?>>()));
+        async Task Act() => await _logic.DeclineRegistrationVerification(applicationId, "test", CancellationToken.None).ConfigureAwait(false);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
+
+        // Assert
+        ex.Message.Should().Be($"There should only be one idp for application {applicationId}");
     }
 
     #endregion
@@ -808,15 +864,12 @@ public class RegistrationBusinessLogicTest
             {
                 { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, new ValueTuple<ApplicationChecklistEntryStatusId, string?>(ApplicationChecklistEntryStatusId.DONE, null) }
             }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>()));
-
-        A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(IdWithBpn))
-            .Returns((CompanyId, CompanyName, ExistingExternalId));
     }
 
-    private void SetupForDeclineRegistrationVerification(ApplicationChecklistEntry applicationChecklistEntry, CompanyApplication application, Company company, ApplicationChecklistEntryStatusId checklistStatusId)
+    private void SetupForDeclineRegistrationVerification(ApplicationChecklistEntry applicationChecklistEntry, CompanyApplication application, Company company, ApplicationChecklistEntryStatusId checklistStatusId, IdentityProviderTypeId idpTypeId)
     {
         A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>?>._))
-            .Invokes((IApplicationChecklistService.ManualChecklistProcessStepData _, Action<ApplicationChecklistEntry>? initail, Action<ApplicationChecklistEntry> action, IEnumerable<ProcessStepTypeId>? _) =>
+            .Invokes((IApplicationChecklistService.ManualChecklistProcessStepData _, Action<ApplicationChecklistEntry>? _, Action<ApplicationChecklistEntry> action, IEnumerable<ProcessStepTypeId>? _) =>
             {
                 action.Invoke(applicationChecklistEntry);
             });
@@ -833,10 +886,10 @@ public class RegistrationBusinessLogicTest
             }.ToImmutableDictionary(), Enumerable.Empty<ProcessStep>()));
 
         A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(IdWithBpn))
-            .Returns((CompanyId, CompanyName, ExistingExternalId));
+            .Returns((CompanyId, CompanyName, ExistingExternalId, Enumerable.Repeat((IamAliasId, idpTypeId), 1), Enumerable.Repeat<ValueTuple<Guid, string?>>((UserId, "user123"), 1)));
 
         A.CallTo(() => _checklistService.FinalizeChecklistEntryAndProcessSteps(A<IApplicationChecklistService.ManualChecklistProcessStepData>._, A<Action<ApplicationChecklistEntry>>._, A<Action<ApplicationChecklistEntry>>._, A<IEnumerable<ProcessStepTypeId>?>._))
-            .Invokes((IApplicationChecklistService.ManualChecklistProcessStepData _, Action<ApplicationChecklistEntry> initial, Action<ApplicationChecklistEntry> action, IEnumerable<ProcessStepTypeId>? _) =>
+            .Invokes((IApplicationChecklistService.ManualChecklistProcessStepData _, Action<ApplicationChecklistEntry> _, Action<ApplicationChecklistEntry> action, IEnumerable<ProcessStepTypeId>? _) =>
             {
                 action.Invoke(applicationChecklistEntry);
             });


### PR DESCRIPTION
## Description

When declining an application the idp of the company is set to disabled

## Why

When declining an application a user is still able to login for the idp of the declined company, this shouldn't be possible

## Issue

N/A - Jira Issue: TEST-1642

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
