### PR TITLE
fix(name): Wrong name property value

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionDetailData.cs
@@ -25,7 +25,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
 public record SubscriptionTechnicalUserData(
     Guid Id,
-    string Name,
+    string? Name,
     IEnumerable<string> Permissions
 );
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -209,7 +209,7 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                         x.Company!.Name,
                         x.Company.BusinessPartnerNumber,
                         x.Company.Identities.Where(x => x.IdentityTypeId == IdentityTypeId.COMPANY_USER).Select(i => i.CompanyUser!).Where(cu => cu.Email != null && cu.Identity!.IdentityAssignedRoles.Select(ur => ur.UserRole!).Any(ur => userRoleIds.Contains(ur.Id))).Select(cu => cu.Email!),
-                        x.Subscription.CompanyServiceAccounts.Select(sa => new SubscriptionTechnicalUserData(sa.Id, sa.Name, sa.Identity!.IdentityAssignedRoles.Select(ur => ur.UserRole!).Select(ur => ur.UserRoleText))))
+                        x.Subscription.CompanyServiceAccounts.Select(sa => new SubscriptionTechnicalUserData(sa.Id, sa.ClientClientId, sa.Identity!.IdentityAssignedRoles.Select(ur => ur.UserRole!).Select(ur => ur.UserRoleText))))
                     : null))
             .SingleOrDefaultAsync();
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -243,7 +243,8 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
             x.Name == "SDE with EDC" &&
             x.Customer == "Catena-X" &&
             x.Contact.SequenceEqual(new[] { "tobeadded@cx.com" }) &&
-            x.OfferSubscriptionStatus == OfferSubscriptionStatusId.ACTIVE);
+            x.OfferSubscriptionStatus == OfferSubscriptionStatusId.ACTIVE
+            && x.TechnicalUserData.All(x => x.Id == new Guid("d0c8ae19-d4f3-49cc-9cb4-6c766d4680f2") && x.Name == "sa-x-4"));
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -5,7 +5,8 @@
     "description": "SA for offer subscription",
     "company_service_account_type_id": 2,
     "offer_subscription_id": "3DE6A31F-A5D1-4F60-AA3A-4B1A769BECBF",
-    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "client_client_id":"sa-x-4"
   },
   {
     "id": "d0c8ae19-d4f3-49cc-9cb4-6c766d4680f3",

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identity_assigned_roles.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identity_assigned_roles.test.json
@@ -58,5 +58,10 @@
     "identity_id": "8b42e6de-7b59-4217-a63c-198e83d93776",
     "user_role_id": "aabcdfeb-6669-4c74-89f0-19cda090873e",
     "last_editor_id": null
+  }  ,
+  {
+    "identity_id": "d0c8ae19-d4f3-49cc-9cb4-6c766d4680f2",
+    "user_role_id": "aabcdfeb-6669-4c74-89f0-19cda090873e",
+    "last_editor_id": null
   }  
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryTests.cs
@@ -447,7 +447,7 @@ public class UserRepositoryTests : IAssemblyFixture<TestDbFixture>
         results.Should().HaveCount(2)
             .And.Satisfy(
                 x => x.ClientClientId == "sa-x-2" && x.ServiceAccountId == new Guid("93eecd4e-ca47-4dd2-85bf-775ea72eb009"),
-                x => x.ClientClientId == "sa-x-1" && x.ServiceAccountId == new Guid("d0c8ae19-d4f3-49cc-9cb4-6c766d4680f4"));
+                x => x.ClientClientId == "sa-x-4" && x.ServiceAccountId == new Guid("d0c8ae19-d4f3-49cc-9cb4-6c766d4680f2"));
     }
 
     #endregion


### PR DESCRIPTION
## Description

Return clientClientId instead of the serviceAccount name for endpoint: GET /api/Services/{serviceId}/subscription/{subscriptionID}/provider

## Why

the service account name is getting responded 

## Issue

N/A - Jira Ref: CPLP-3505

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
