### PR TITLE
feat(serviceAccount): added filter and lasteditorData

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
@@ -32,6 +32,6 @@ public interface IServiceAccountBusinessLogic
     Task<ServiceAccountConnectorOfferData> GetOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId);
     Task<ServiceAccountDetails> UpdateOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId, ServiceAccountEditableDetails serviceAccountDetails);
     Task<ServiceAccountDetails> ResetOwnCompanyServiceAccountSecretAsync(Guid serviceAccountId);
-    Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, string? clientId, bool? isOwner);
+    Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, string? clientId, bool? isOwner, bool isUserStatusActive);
     IAsyncEnumerable<UserRoleWithDescription> GetServiceAccountRolesAsync(string? languageShortName);
 }

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -169,6 +169,8 @@ public class ServiceAccountBusinessLogic : IServiceAccountBusinessLogic
             authData.Secret,
             result.ConnectorData,
             result.OfferSubscriptionData,
+            result.CompanyLastEditorData!.Name,
+            result.CompanyLastEditorData.CompanyName,
             result.SubscriptionId);
     }
 
@@ -264,12 +266,12 @@ public class ServiceAccountBusinessLogic : IServiceAccountBusinessLogic
             result.OfferSubscriptionId);
     }
 
-    public Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, string? clientId, bool? isOwner) =>
+    public Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, string? clientId, bool? isOwner, bool isUserStatusActive) =>
         Pagination.CreateResponseAsync(
             page,
             size,
             15,
-            _portalRepositories.GetInstance<IServiceAccountRepository>().GetOwnCompanyServiceAccountsUntracked(_identityService.IdentityData.CompanyId, clientId, isOwner));
+            _portalRepositories.GetInstance<IServiceAccountRepository>().GetOwnCompanyServiceAccountsUntracked(_identityService.IdentityData.CompanyId, clientId, isOwner, isUserStatusActive ? UserStatusId.ACTIVE : UserStatusId.INACTIVE));
 
     public IAsyncEnumerable<UserRoleWithDescription> GetServiceAccountRolesAsync(string? languageShortName) =>
         _portalRepositories.GetInstance<IUserRolesRepository>().GetServiceAccountRolesAsync(_identityService.IdentityData.CompanyId, _settings.ClientId, languageShortName ?? Constants.DefaultLanguage);

--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -162,6 +162,7 @@ public class ServiceAccountController : ControllerBase
     /// <param name="size">number of service account data</param>
     /// <param name="isOwner">isOwner either true or false</param>
     /// <param name="clientId">clientId is string clientclientid</param>
+    /// <param name="isUserStatusActive">isUserStatusActive is True or False</param>
     /// <returns>Returns the specific number of service account data for the given page.</returns>
     /// <remarks>Example: GET: api/administration/serviceaccount/owncompany/serviceaccounts</remarks>
     /// <response code="200">Returns the specific number of service account data for the given page.</response>
@@ -170,8 +171,8 @@ public class ServiceAccountController : ControllerBase
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("owncompany/serviceaccounts")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyServiceAccountData>), StatusCodes.Status200OK)]
-    public Task<Pagination.Response<CompanyServiceAccountData>> GetServiceAccountsData([FromQuery] int page, [FromQuery] int size, [FromQuery] bool? isOwner, [FromQuery] string? clientId) =>
-        _logic.GetOwnCompanyServiceAccountsDataAsync(page, size, clientId, isOwner);
+    public Task<Pagination.Response<CompanyServiceAccountData>> GetServiceAccountsData([FromQuery] int page, [FromQuery] int size, [FromQuery] bool? isOwner, [FromQuery] string? clientId, [FromQuery] bool isUserStatusActive) =>
+        _logic.GetOwnCompanyServiceAccountsDataAsync(page, size, clientId, isOwner, isUserStatusActive);
 
     /// <summary>
     /// Get all service account roles

--- a/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
+++ b/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
@@ -36,5 +36,7 @@ public record ServiceAccountConnectorOfferData(
     [property: JsonPropertyName("secret")] string? Secret,
     [property: JsonPropertyName("connector")] ConnectorResponseData? Connector,
     [property: JsonPropertyName("offer")] OfferResponseData? Offer,
+    [property: JsonPropertyName("LastEditorName")] string? LastName,
+    [property: JsonPropertyName("LastEditorCompanyName")] string? CompanyName,
     [property: JsonPropertyName("subscriptionId")] Guid? SubscriptionId = null
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
@@ -40,4 +40,4 @@ public record ConnectorResponseData(Guid Id, string Name);
 
 public record OfferResponseData(Guid Id, OfferTypeId Type, string? Name, Guid? SubscriptionId);
 
-public record CompanyLastEditorData(string Name, string CompanyName);
+public record CompanyLastEditorData(string? Name, string CompanyName);

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
@@ -33,8 +33,11 @@ public record CompanyServiceAccountDetailedData(
     CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
     Guid? SubscriptionId,
     ConnectorResponseData? ConnectorData,
-    OfferResponseData? OfferSubscriptionData);
+    OfferResponseData? OfferSubscriptionData,
+    CompanyLastEditorData? CompanyLastEditorData);
 
 public record ConnectorResponseData(Guid Id, string Name);
 
 public record OfferResponseData(Guid Id, OfferTypeId Type, string? Name, Guid? SubscriptionId);
+
+public record CompanyLastEditorData(string Name, string CompanyName);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
@@ -39,6 +39,6 @@ public interface IServiceAccountRepository
     Task<CompanyServiceAccountWithRoleDataClientId?> GetOwnCompanyServiceAccountWithIamClientIdAsync(Guid serviceAccountId, Guid userCompanyId);
     Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientId, ConnectorStatusId? statusId, OfferSubscriptionStatusId? OfferStatusId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId);
     Task<CompanyServiceAccountDetailedData?> GetOwnCompanyServiceAccountDetailedDataUntrackedAsync(Guid serviceAccountId, Guid companyId);
-    Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnCompanyServiceAccountsUntracked(Guid userCompanyId, string? clientId, bool? isOwner);
+    Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnCompanyServiceAccountsUntracked(Guid userCompanyId, string? clientId, bool? isOwner, UserStatusId userStatusId);
     Task<bool> CheckActiveServiceAccountExistsForCompanyAsync(Guid technicalUserId, Guid companyId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -145,14 +145,11 @@ public class ServiceAccountRepository : IServiceAccountRepository
                             serviceAccount.OfferSubscription.Offer!.OfferTypeId,
                             serviceAccount.OfferSubscription.Offer.Name,
                             serviceAccount.OfferSubscription.Id),
-                    serviceAccount.Identity.LastEditor!.IdentityTypeId == IdentityTypeId.COMPANY_USER
-                        ? serviceAccount.Identity.LastEditor == null
-                            ? null
-                            : new CompanyLastEditorData(
-                                serviceAccount.Identity.LastEditor.CompanyUser!.Lastname!,
-                                serviceAccount.Identity.LastEditor.Company!.Name)
-                        : new CompanyLastEditorData(
-                            serviceAccount.Identity.LastEditor!.CompanyServiceAccount!.Name,
+                    serviceAccount.Identity.LastEditorId == null ? null :
+                        new CompanyLastEditorData(
+                            serviceAccount.Identity.LastEditor!.IdentityTypeId == IdentityTypeId.COMPANY_USER
+                                ? serviceAccount.Identity.LastEditor.CompanyUser!.Lastname
+                                : serviceAccount.Identity.LastEditor.CompanyServiceAccount!.Name,
                             serviceAccount.Identity.LastEditor.Company!.Name)))
             .SingleOrDefaultAsync();
 

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -374,19 +374,21 @@ public class ServiceAccountBusinessLogicTests
 
     #region GetOwnCompanyServiceAccountsDataAsync
 
-    [Fact]
-    public async Task GetOwnCompanyServiceAccountsDataAsync_GetsExpectedData()
+    [Theory]
+    [InlineData(UserStatusId.ACTIVE, true)]
+    [InlineData(UserStatusId.INACTIVE, false)]
+    public async Task GetOwnCompanyServiceAccountsDataAsync_GetsExpectedData(UserStatusId userStatusId, bool isUserStatusActive)
     {
         // Arrange
         var data = _fixture.CreateMany<CompanyServiceAccountData>(15);
-        A.CallTo(() => _serviceAccountRepository.GetOwnCompanyServiceAccountsUntracked(_identity.CompanyId, null, null))
+        A.CallTo(() => _serviceAccountRepository.GetOwnCompanyServiceAccountsUntracked(_identity.CompanyId, null, null, userStatusId))
             .Returns((int skip, int take) => Task.FromResult((Pagination.Source<CompanyServiceAccountData>?)new Pagination.Source<CompanyServiceAccountData>(data.Count(), data.Skip(skip).Take(take))));
 
         A.CallTo(() => _portalRepositories.GetInstance<IServiceAccountRepository>()).Returns(_serviceAccountRepository);
         var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService);
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsDataAsync(1, 10, null, null).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsDataAsync(1, 10, null, null, isUserStatusActive).ConfigureAwait(false);
 
         // Assert
         result.Should().NotBeNull();

--- a/tests/administration/Administration.Service.Tests/Controllers/ServiceAccountControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/ServiceAccountControllerTests.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Mvc;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Controllers;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
@@ -91,5 +92,36 @@ public class ServiceAccountControllerTests
 
         result.Should().NotBeNull();
         result.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task GetServiceAccountDetails_CallsExpected()
+    {
+        // Arrange
+        var serviceAcountId = _fixture.Create<Guid>();
+
+        // Act
+        await _controller.GetServiceAccountDetails(serviceAcountId).ConfigureAwait(false);
+
+        // Assert
+        A.CallTo(() => _logic.GetOwnCompanyServiceAccountDetailsAsync(serviceAcountId)).MustHaveHappenedOnceExactly();
+
+    }
+
+    [Fact]
+    public async Task GetServiceAccountsData_CallsExpected()
+    {
+        //Arrange
+        var paginationResponse = new Pagination.Response<CompanyServiceAccountData>(new Pagination.Metadata(15, 1, 1, 15), _fixture.CreateMany<CompanyServiceAccountData>(5));
+        A.CallTo(() => _logic.GetOwnCompanyServiceAccountsDataAsync(0, 15, null, null, true))
+                  .Returns(paginationResponse);
+
+        //Act
+        var result = await this._controller.GetServiceAccountsData(0, 15, null, null, true).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.GetOwnCompanyServiceAccountsDataAsync(0, 15, null, null, true)).MustHaveHappenedOnceExactly();
+        Assert.IsType<Pagination.Response<CompanyServiceAccountData>>(result);
+        result.Content.Should().HaveCount(5);
     }
 }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -58,5 +58,14 @@
     "offer_subscription_id": null,
     "company_id": "729e0af2-6723-4a7f-85a1-833d84b39bdf",
     "client_client_id": "sa-x-inactive"
+  },
+  {
+    "id": "38c92162-6328-40ce-80f3-22e3f3e9b94e",
+    "name": "test-user-service-account-0",
+    "description": "test-user-service-account-desc-0",
+    "company_service_account_type_id": 1,
+    "offer_subscription_id": null,
+    "company_id": "729e0af2-6723-4a7f-85a1-833d84b39bdf",
+    "client_client_id": "sa-x-0"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
@@ -158,5 +158,14 @@
     "user_status_id": 2,
     "user_entity_id": null,
     "identity_type_id": 2
+  },
+  {
+    "id": "38c92162-6328-40ce-80f3-22e3f3e9b94e",
+    "date_created": "2022-06-01 18:01:33.439000 +00:00",
+    "company_id": "729e0af2-6723-4a7f-85a1-833d84b39bdf",
+    "user_status_id": 1,
+    "user_entity_id": "3d8142f1-860b-48aa-8c2b-1ccb18699f66",
+    "identity_type_id": 2,
+    "last_editor_id":"8b42e6de-7b59-4217-a63c-198e83d93777"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -173,22 +173,6 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         result.Should().NotBeNull();
         result!.CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN);
         result.CompanyLastEditorData!.CompanyName.Should().Be("CX-Test-Access");
-        result.CompanyLastEditorData.Name.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task GetOwnCompanyServiceAccountDetailedDataUntrackedAsync_comapnyUserEditors_ReturnsExpectedResult()
-    {
-        // Arrange
-        var (sut, _) = await CreateSut().ConfigureAwait(false);
-
-        // Act
-        var result = await sut.GetOwnCompanyServiceAccountDetailedDataUntrackedAsync(new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94e"), new Guid("729e0af2-6723-4a7f-85a1-833d84b39bdf")).ConfigureAwait(false);
-
-        // Assert
-        result.Should().NotBeNull();
-        result!.CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.MANAGED);
-        result.CompanyLastEditorData!.CompanyName.Should().Be("CX-Test-Access");
         result.CompanyLastEditorData.Name.Should().Be("CX Admin");
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -172,6 +172,24 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result.Should().NotBeNull();
         result!.CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN);
+        result.CompanyLastEditorData!.CompanyName.Should().Be("CX-Test-Access");
+        result.CompanyLastEditorData.Name.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountDetailedDataUntrackedAsync_comapnyUserEditors_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountDetailedDataUntrackedAsync(new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94e"), new Guid("729e0af2-6723-4a7f-85a1-833d84b39bdf")).ConfigureAwait(false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.MANAGED);
+        result.CompanyLastEditorData!.CompanyName.Should().Be("CX-Test-Access");
+        result.CompanyLastEditorData.Name.Should().Be("CX Admin");
     }
 
     [Fact]
@@ -228,7 +246,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var newvalidCompanyId = new Guid("41fd2ab8-71cd-4546-9bef-a388d91b2542");
         var (sut, _) = await CreateSut().ConfigureAwait(false);
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(newvalidCompanyId, null, null)(page, size).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(newvalidCompanyId, null, null, UserStatusId.ACTIVE)(page, size).ConfigureAwait(false);
 
         // Assert
         result.Should().NotBeNull();
@@ -248,7 +266,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-1", true)(0, 10).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-1", true, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
 
         // Assert
         result!.Count.Should().Be(1);
@@ -263,7 +281,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new("41fd2ab8-71cd-4546-9bef-a388d91b2543"), "sa-x-2", false)(0, 10).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new("41fd2ab8-71cd-4546-9bef-a388d91b2543"), "sa-x-2", false, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
 
         // Assert
         result!.Count.Should().Be(1);
@@ -278,7 +296,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-1", null)(0, 10).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-1", null, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
 
         // Assert
         result!.Count.Should().Be(1);
@@ -293,11 +311,29 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null)(0, 10).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
 
         // Assert
         result!.Count.Should().Be(11);
         result.Data.Should().HaveCount(10);
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithUserStatusId_InActive_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new Guid("729e0af2-6723-4a7f-85a1-833d84b39bdf"), null, null, UserStatusId.INACTIVE)(0, 10).ConfigureAwait(false);
+
+        // Assert
+        result!.Count.Should().Be(1);
+        result.Data.Should().HaveCount(1)
+            .And.Satisfy(x =>
+                x.ServiceAccountId == new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94d")
+                && x.ClientId == "sa-x-inactive"
+                && x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED);
     }
 
     #endregion


### PR DESCRIPTION
## Description

Added filter and lastEditor Data for serviceAccount

## Why

Added filter to fetch active and inactive ServiceAccountdetails and added lasteditor fields for a specific service account

## Issue

N/A Ref : CPLP-3137

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
