### PR TITLE
feat(swagger): support nonnullable referenceTypes

### DIFF
--- a/src/framework/Framework.Swagger/SwaggerGenConfiguration.cs
+++ b/src/framework/Framework.Swagger/SwaggerGenConfiguration.cs
@@ -35,6 +35,7 @@ public static class SwaggerGenConfiguration
         c.SwaggerDoc(version, new OpenApiInfo { Title = assemblyName, Version = version });
 
         c.MapType(typeof(IFormFile), () => new OpenApiSchema { Type = "file", Format = "binary" });
+        c.SupportNonNullableReferenceTypes();
 
         c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
         {


### PR DESCRIPTION


## Description

 support nonnullable referenceTypes

## Why

In Swagger Document schema, even the fields are non nullable type it shows as nullable, now it is fixed

## Issue

N/A Ref : CPLP-3407

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
