### PR TITLE
fix(authentication): fix forbidden errors for newly registered users

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IdentityRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IdentityRepository.cs
@@ -31,13 +31,14 @@ public class IdentityRepository : IIdentityRepository
     {
         _context = context;
     }
+
     public Task<Guid> GetActiveCompanyIdByIdentityId(Guid identityId) =>
-        _context.Identities.Where(x => x.Id == identityId && x.UserEntityId != null && x.UserStatusId == UserStatusId.ACTIVE)
+        _context.Identities.Where(x => x.Id == identityId && x.UserStatusId == UserStatusId.ACTIVE)
             .Select(x => x.CompanyId)
             .SingleOrDefaultAsync();
 
     public Task<(IdentityTypeId IdentityTypeId, Guid CompanyId)> GetActiveIdentityDataByIdentityId(Guid identityId) =>
-        _context.Identities.Where(x => x.Id == identityId && x.UserEntityId != null && x.UserStatusId == UserStatusId.ACTIVE)
+        _context.Identities.Where(x => x.Id == identityId && x.UserStatusId == UserStatusId.ACTIVE)
             .Select(x => new ValueTuple<IdentityTypeId, Guid>(
                 x.IdentityTypeId,
                 x.CompanyId))


### PR DESCRIPTION
## Description

this PR removes obsolete UserEntityId != null condition from queries being used in authorization.

## Why

existing Queries used in authorization refer still refer to UserEntityId being not null. As UserEntityId is to be deleted from schema and code has already been adjusted this condition causes ommits newly created users to access any endpoint that is annotated with 'ValidCompany'.

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
