### PR TITLE
feat(registration): add endpoint for decline registration data

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithStatus.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithStatus.cs
@@ -29,4 +29,11 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models
         IEnumerable<ApplicationChecklistData> ApplicationChecklist
     );
     public record ApplicationChecklistData(ApplicationChecklistEntryTypeId TypeId, ApplicationChecklistEntryStatusId StatusId);
+
+    public record CompanyApplicationDeclineData(
+        Guid ApplicationId,
+        CompanyApplicationStatusId ApplicationStatus,
+        string CompanyName,
+        IEnumerable<string> Users
+    );
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -165,6 +165,20 @@ public class ApplicationRepository : IApplicationRepository
                     .Select(identifier => new ValueTuple<UniqueIdentifierId, string>(identifier.UniqueIdentifierId, identifier.Value))))
             .SingleOrDefaultAsync();
 
+    public IAsyncEnumerable<CompanyApplicationDeclineData> GetCompanyApplicationsDeclineData(Guid userCompanyId, IEnumerable<CompanyApplicationStatusId> applicationStatusIds) =>
+        _dbContext.CompanyApplications
+            .AsNoTracking()
+            .Where(application =>
+                application.Company!.Id == userCompanyId &&
+                applicationStatusIds.Contains(application.ApplicationStatusId))
+            .Select(application => new CompanyApplicationDeclineData(
+                application.Id,
+                application.ApplicationStatusId,
+                application.Company!.Name,
+                application.Company!.Identities.Where(identity => identity.CompanyUser!.Email != null).Select(
+                    identity => identity.CompanyUser!.Email!)))
+            .AsAsyncEnumerable();
+
     public Task<(bool IsValidApplicationId, Guid CompanyId, bool IsSubmitted)> GetCompanyIdSubmissionStatusForApplication(Guid applicationId) =>
         _dbContext.CompanyApplications
             .AsNoTracking()

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -36,6 +36,7 @@ public interface IApplicationRepository
     Task<CompanyApplicationUserEmailData?> GetOwnCompanyApplicationUserEmailDataAsync(Guid applicationId, Guid companyUserId, IEnumerable<DocumentTypeId> submitDocumentTypeIds);
     IQueryable<CompanyApplication> GetCompanyApplicationsFilteredQuery(string? companyName = null, IEnumerable<CompanyApplicationStatusId>? applicationStatusIds = null);
     Task<CompanyApplicationDetailData?> GetCompanyApplicationDetailDataAsync(Guid applicationId, Guid userCompanyId, Guid? companyId = null);
+    IAsyncEnumerable<CompanyApplicationDeclineData> GetCompanyApplicationsDeclineData(Guid userCompanyId, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
     Task<(bool IsValidApplicationId, Guid CompanyId, bool IsSubmitted)> GetCompanyIdSubmissionStatusForApplication(Guid applicationId);
     Task<(Guid CompanyId, string CompanyName, string? BusinessPartnerNumber, IEnumerable<string> IamIdpAliasse, CompanyApplicationTypeId ApplicationTypeId, Guid? NetworkRegistrationProcessId)> GetCompanyAndApplicationDetailsForApprovalAsync(Guid applicationId);
     Task<(Guid CompanyId, string CompanyName, string? BusinessPartnerNumber)> GetCompanyAndApplicationDetailsForCreateWalletAsync(Guid applicationId);

--- a/src/registration/Registration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -39,6 +39,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.BusinessLogic
         Task<(string FileName, byte[] Content, string MediaType)> GetDocumentContentAsync(Guid documentId);
 
         IAsyncEnumerable<CompanyApplicationWithStatus> GetAllApplicationsForUserWithStatus();
+        IAsyncEnumerable<CompanyApplicationDeclineData> GetApplicationsDeclineData();
         Task<CompanyDetailData> GetCompanyDetailData(Guid applicationId);
         Task SetCompanyDetailDataAsync(Guid applicationId, CompanyDetailData companyDetails);
         Task<int> InviteNewUserAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo);

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -206,6 +206,9 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
     public IAsyncEnumerable<CompanyApplicationWithStatus> GetAllApplicationsForUserWithStatus() =>
         _portalRepositories.GetInstance<IUserRepository>().GetApplicationsWithStatusUntrackedAsync(_identityData.CompanyId);
 
+    public IAsyncEnumerable<CompanyApplicationDeclineData> GetApplicationsDeclineData() =>
+        _portalRepositories.GetInstance<IApplicationRepository>().GetCompanyApplicationsDeclineData(_identityData.CompanyId, _settings.ApplicationDeclineStatusIds);
+
     public async Task<CompanyDetailData> GetCompanyDetailData(Guid applicationId)
     {
         var result = await _portalRepositories.GetInstance<IApplicationRepository>().GetCompanyApplicationDetailDataAsync(applicationId, _identityData.CompanyId).ConfigureAwait(false);

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationSettings.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationSettings.cs
@@ -48,13 +48,22 @@ public class RegistrationSettings
     public IEnumerable<DocumentTypeId> DocumentTypeIds { get; set; } = null!;
 
     /// <summary>
-    /// Document Type Id
+    /// ApplicationStatusIds that permit deletion of documents
     /// </summary>
     /// <value></value>
     [Required]
     [EnumEnumeration]
     [DistinctValues]
     public IEnumerable<CompanyApplicationStatusId> ApplicationStatusIds { get; set; } = null!;
+
+    /// <summary>
+    /// ApplicationStatusIds that permit decline of application by invited user
+    /// </summary>
+    /// <value></value>
+    [Required]
+    [EnumEnumeration]
+    [DistinctValues]
+    public IEnumerable<CompanyApplicationStatusId> ApplicationDeclineStatusIds { get; set; } = null!;
 
     /// <summary>
     /// RegistrationDocument Type Id

--- a/src/registration/Registration.Service/Controllers/RegistrationController.cs
+++ b/src/registration/Registration.Service/Controllers/RegistrationController.cs
@@ -168,6 +168,20 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Controllers
             _registrationBusinessLogic.GetAllApplicationsForUserWithStatus();
 
         /// <summary>
+        /// Gets the applications with each status, company-name and linked users
+        /// </summary>
+        /// <returns>Returns a list of company applications</returns>
+        /// <remarks>Example: Get: /api/registration/applications/declinedata</remarks>
+        /// <response code="200">Returns a list of company applications</response>
+        [HttpGet]
+        [Authorize(Roles = "view_registration")]
+        [Authorize(Policy = PolicyTypes.ValidCompany)]
+        [Route("applications/declinedata")]
+        [ProducesResponseType(typeof(IAsyncEnumerable<CompanyApplicationDeclineData>), StatusCodes.Status200OK)]
+        public IAsyncEnumerable<CompanyApplicationDeclineData> GetApplicationsDeclineData() =>
+            _registrationBusinessLogic.GetApplicationsDeclineData();
+
+        /// <summary>
         /// Sets the status of a specific application.
         /// </summary>
         /// <param name="applicationId" example="4f0146c6-32aa-4bb1-b844-df7e8babdcb4">Id of the application which status should be set.</param>

--- a/src/registration/Registration.Service/appsettings.json
+++ b/src/registration/Registration.Service/appsettings.json
@@ -30,6 +30,7 @@
     "KeycloakClientID": "",
     "BasePortalAddress": "https://portal.example.org/registration",
     "ApplicationStatusIds": [],
+    "ApplicationDeclineStatusIds": [],
     "DocumentTypeIds": [],
     "RegistrationDocumentTypeIds": [],
     "SubmitDocumentTypeIds": []

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
@@ -19,6 +19,7 @@
  ********************************************************************************/
 
 using Microsoft.EntityFrameworkCore;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Tests.Setup;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
@@ -529,6 +530,52 @@ public class ApplicationRepositoryTests : IAssemblyFixture<TestDbFixture>
             x => x.State == EntityState.Modified && ((CompanyApplication)x.Entity).Id == companyApplicationData[2].applicationId && ((CompanyApplication)x.Entity).ApplicationStatusId == CompanyApplicationStatusId.DECLINED,
             x => x.State == EntityState.Unchanged && ((CompanyApplication)x.Entity).Id == companyApplicationData[3].applicationId && ((CompanyApplication)x.Entity).ApplicationStatusId == CompanyApplicationStatusId.CONFIRMED
         );
+    }
+
+    #endregion
+
+    #region GetCompanyApplicationsDeclineData
+
+    [Fact]
+    public async Task GetCompanyApplicationsDeclineData_ReturnsExpected()
+    {
+        // Arrange
+        var sut = await CreateSut().ConfigureAwait(false);
+        var statusIds = new[] {
+            CompanyApplicationStatusId.CREATED,
+            CompanyApplicationStatusId.ADD_COMPANY_DATA,
+            CompanyApplicationStatusId.INVITE_USER,
+            CompanyApplicationStatusId.SELECT_COMPANY_ROLE,
+            CompanyApplicationStatusId.UPLOAD_DOCUMENTS,
+            CompanyApplicationStatusId.VERIFY
+        };
+
+        // Act
+        var result = await sut.GetCompanyApplicationsDeclineData(CompanyId, statusIds).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCompanyApplicationsDeclineData_WithSubmittedApplication_ReturnsExpected()
+    {
+        // Arrange
+        var sut = await CreateSut().ConfigureAwait(false);
+        var statusIds = new[] {
+            CompanyApplicationStatusId.SUBMITTED
+        };
+
+        // Act
+        var result = await sut.GetCompanyApplicationsDeclineData(CompanyId, statusIds).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().ContainSingle().Which.Should().Match<CompanyApplicationDeclineData>(x =>
+            x.ApplicationId == new Guid("6b2d1263-c073-4a48-bfaf-704dc154ca9f") &&
+            x.ApplicationStatus == CompanyApplicationStatusId.SUBMITTED &&
+            x.CompanyName == "CX-Test-Access" &&
+            x.Users.Count() == 1 &&
+            x.Users.First() == "cxadmin@acme.corp");
     }
 
     #endregion


### PR DESCRIPTION
## Description
 
A new endpoint has been added that returns data that is required by the decline-application-by-invited-user page.
 
Corresponding PR in CD with new config-values for the applicationStatusIds that allow decline of application by the invited user: https://github.com/eclipse-tractusx/portal-cd/pull/136
 
## Why
 
When a company is being invited to catena-x a user that received an invitation email shall be able to decline the application that is being created with the invitation. The page that implements this functionality shall display the application-status, the company-name and users of the respective company
 
## Issue
 
N/A (CPLP-3549)
 
## Checklist
 
Please delete options that are not relevant.
 
- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes