### PR TITLE
feat(registration): add current user to applicationDeclineData

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithStatus.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithStatus.cs
@@ -33,6 +33,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models
     public record CompanyApplicationDeclineData(
         Guid ApplicationId,
         CompanyApplicationStatusId ApplicationStatus,
+        string User,
         string CompanyName,
         IEnumerable<string> Users
     );

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -36,7 +36,7 @@ public interface IApplicationRepository
     Task<CompanyApplicationUserEmailData?> GetOwnCompanyApplicationUserEmailDataAsync(Guid applicationId, Guid companyUserId, IEnumerable<DocumentTypeId> submitDocumentTypeIds);
     IQueryable<CompanyApplication> GetCompanyApplicationsFilteredQuery(string? companyName = null, IEnumerable<CompanyApplicationStatusId>? applicationStatusIds = null);
     Task<CompanyApplicationDetailData?> GetCompanyApplicationDetailDataAsync(Guid applicationId, Guid userCompanyId, Guid? companyId = null);
-    IAsyncEnumerable<CompanyApplicationDeclineData> GetCompanyApplicationsDeclineData(Guid userCompanyId, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
+    Task<(string CompanyName, string? FirstName, string? LastName, string? Email, IEnumerable<(Guid ApplicationId, CompanyApplicationStatusId ApplicationStatusId, IEnumerable<(string? FirstName, string? LastName, string? Email)> InvitedUsers)> Applications)> GetCompanyApplicationsDeclineData(Guid companyUserId, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
     Task<(bool IsValidApplicationId, Guid CompanyId, bool IsSubmitted)> GetCompanyIdSubmissionStatusForApplication(Guid applicationId);
     Task<(Guid CompanyId, string CompanyName, string? BusinessPartnerNumber, IEnumerable<string> IamIdpAliasse, CompanyApplicationTypeId ApplicationTypeId, Guid? NetworkRegistrationProcessId)> GetCompanyAndApplicationDetailsForApprovalAsync(Guid applicationId);
     Task<(Guid CompanyId, string CompanyName, string? BusinessPartnerNumber)> GetCompanyAndApplicationDetailsForCreateWalletAsync(Guid applicationId);

--- a/src/registration/Registration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -39,7 +39,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.BusinessLogic
         Task<(string FileName, byte[] Content, string MediaType)> GetDocumentContentAsync(Guid documentId);
 
         IAsyncEnumerable<CompanyApplicationWithStatus> GetAllApplicationsForUserWithStatus();
-        IAsyncEnumerable<CompanyApplicationDeclineData> GetApplicationsDeclineData();
+        Task<IEnumerable<CompanyApplicationDeclineData>> GetApplicationsDeclineData();
         Task<CompanyDetailData> GetCompanyDetailData(Guid applicationId);
         Task SetCompanyDetailDataAsync(Guid applicationId, CompanyDetailData companyDetails);
         Task<int> InviteNewUserAsync(Guid applicationId, UserCreationInfoWithMessage userCreationInfo);

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -223,14 +223,14 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
             if (email != null)
             {
-                sb.AppendFormat((firstName == null && lastName == null) ? "{0}" : " ({0})", email);
+                sb.AppendFormat(firstName == null && lastName == null ? "{0}" : " ({0})", email);
             }
 
             return firstName == null && lastName == null && email == null ? "unknown user" : sb.ToString();
         }
 
         var data = await _portalRepositories.GetInstance<IApplicationRepository>().GetCompanyApplicationsDeclineData(_identityData.IdentityId, _settings.ApplicationDeclineStatusIds).ConfigureAwait(false);
-        var user = CreateNameString(data.FirstName, data.LastName, data.Email) ?? "unknown user";
+        var user = CreateNameString(data.FirstName, data.LastName, data.Email);
 
         return data.Applications.Select(application =>
             new CompanyApplicationDeclineData(

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -34,11 +34,11 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library;
-using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Service;
 using Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
 using Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Model;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.BusinessLogic;
@@ -206,8 +206,41 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
     public IAsyncEnumerable<CompanyApplicationWithStatus> GetAllApplicationsForUserWithStatus() =>
         _portalRepositories.GetInstance<IUserRepository>().GetApplicationsWithStatusUntrackedAsync(_identityData.CompanyId);
 
-    public IAsyncEnumerable<CompanyApplicationDeclineData> GetApplicationsDeclineData() =>
-        _portalRepositories.GetInstance<IApplicationRepository>().GetCompanyApplicationsDeclineData(_identityData.CompanyId, _settings.ApplicationDeclineStatusIds);
+    public async Task<IEnumerable<CompanyApplicationDeclineData>> GetApplicationsDeclineData()
+    {
+        string CreateNameString(string? firstName, string? lastName, string? email)
+        {
+            var sb = new StringBuilder();
+            if (firstName != null)
+            {
+                sb.Append(firstName);
+            }
+
+            if (lastName != null)
+            {
+                sb.AppendFormat(firstName == null ? "{0}" : ", {0}", lastName);
+            }
+
+            if (email != null)
+            {
+                sb.AppendFormat((firstName == null && lastName == null) ? "{0}" : " ({0})", email);
+            }
+
+            return firstName == null && lastName == null && email == null ? "unknown user" : sb.ToString();
+        }
+
+        var data = await _portalRepositories.GetInstance<IApplicationRepository>().GetCompanyApplicationsDeclineData(_identityData.IdentityId, _settings.ApplicationDeclineStatusIds).ConfigureAwait(false);
+        var user = CreateNameString(data.FirstName, data.LastName, data.Email) ?? "unknown user";
+
+        return data.Applications.Select(application =>
+            new CompanyApplicationDeclineData(
+                application.ApplicationId,
+                application.ApplicationStatusId,
+                user,
+                data.CompanyName,
+                application.InvitedUsers.Select(user => CreateNameString(user.FirstName, user.LastName, user.Email))
+        ));
+    }
 
     public async Task<CompanyDetailData> GetCompanyDetailData(Guid applicationId)
     {

--- a/src/registration/Registration.Service/Controllers/RegistrationController.cs
+++ b/src/registration/Registration.Service/Controllers/RegistrationController.cs
@@ -175,10 +175,10 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Controllers
         /// <response code="200">Returns a list of company applications</response>
         [HttpGet]
         [Authorize(Roles = "view_registration")]
-        [Authorize(Policy = PolicyTypes.ValidCompany)]
+        [Authorize(Policy = PolicyTypes.CompanyUser)]
         [Route("applications/declinedata")]
         [ProducesResponseType(typeof(IAsyncEnumerable<CompanyApplicationDeclineData>), StatusCodes.Status200OK)]
-        public IAsyncEnumerable<CompanyApplicationDeclineData> GetApplicationsDeclineData() =>
+        public Task<IEnumerable<CompanyApplicationDeclineData>> GetApplicationsDeclineData() =>
             _registrationBusinessLogic.GetApplicationsDeclineData();
 
         /// <summary>

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
@@ -540,42 +540,59 @@ public class ApplicationRepositoryTests : IAssemblyFixture<TestDbFixture>
     public async Task GetCompanyApplicationsDeclineData_ReturnsExpected()
     {
         // Arrange
-        var sut = await CreateSut().ConfigureAwait(false);
+        var companyUserId = new Guid("ac1cf001-7fbc-1f2f-817f-bce058019994");
         var statusIds = new[] {
             CompanyApplicationStatusId.CREATED,
             CompanyApplicationStatusId.ADD_COMPANY_DATA,
             CompanyApplicationStatusId.INVITE_USER,
             CompanyApplicationStatusId.SELECT_COMPANY_ROLE,
             CompanyApplicationStatusId.UPLOAD_DOCUMENTS,
-            CompanyApplicationStatusId.VERIFY
+            CompanyApplicationStatusId.VERIFY,
+            CompanyApplicationStatusId.CONFIRMED,
+            CompanyApplicationStatusId.DECLINED
         };
+        var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetCompanyApplicationsDeclineData(CompanyId, statusIds).ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetCompanyApplicationsDeclineData(companyUserId, statusIds).ConfigureAwait(false);
 
         // Assert
-        result.Should().BeEmpty();
+        result.Should().NotBeNull().And.Match<(string CompanyName, string? FirstName, string? LastName, string? Email, IEnumerable<(Guid ApplicationId, CompanyApplicationStatusId ApplicationStatusId, IEnumerable<(string? FirstName, string? LastName, string? Email)> InvitedUsers)> Applications)>(x =>
+            x.CompanyName == "Security Company" &&
+            x.FirstName == "Test User" &&
+            x.LastName == "Company Admin 1" &&
+            x.Email == "company.admin1@acme.corp");
+
+        result.Applications.Should().BeEmpty();
     }
 
     [Fact]
     public async Task GetCompanyApplicationsDeclineData_WithSubmittedApplication_ReturnsExpected()
     {
         // Arrange
-        var sut = await CreateSut().ConfigureAwait(false);
+        var companyUserId = new Guid("ac1cf001-7fbc-1f2f-817f-bce058019994");
         var statusIds = new[] {
             CompanyApplicationStatusId.SUBMITTED
         };
+        var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetCompanyApplicationsDeclineData(CompanyId, statusIds).ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetCompanyApplicationsDeclineData(companyUserId, statusIds).ConfigureAwait(false);
 
         // Assert
-        result.Should().ContainSingle().Which.Should().Match<CompanyApplicationDeclineData>(x =>
-            x.ApplicationId == new Guid("6b2d1263-c073-4a48-bfaf-704dc154ca9f") &&
-            x.ApplicationStatus == CompanyApplicationStatusId.SUBMITTED &&
-            x.CompanyName == "CX-Test-Access" &&
-            x.Users.Count() == 1 &&
-            x.Users.First() == "cxadmin@acme.corp");
+        result.Should().NotBeNull().And.Match<(string CompanyName, string? FirstName, string? LastName, string? Email, IEnumerable<(Guid ApplicationId, CompanyApplicationStatusId ApplicationStatusId, IEnumerable<(string? FirstName, string? LastName, string? Email)> InvitedUsers)> Applications)>(x =>
+            x.CompanyName == "Security Company" &&
+            x.FirstName == "Test User" &&
+            x.LastName == "Company Admin 1" &&
+            x.Email == "company.admin1@acme.corp");
+
+        result.Applications.Should().ContainSingle().Which.Should().Match<(Guid ApplicationId, CompanyApplicationStatusId ApplicationStatusId, IEnumerable<(string? FirstName, string? LastName, string? Email)> InvitedUsers)>(x =>
+            x.ApplicationId == new Guid("6b2d1263-c073-4a48-bfaf-704dc154ca9e") &&
+            x.ApplicationStatusId == CompanyApplicationStatusId.SUBMITTED);
+
+        result.Applications.First().InvitedUsers.Should().HaveCount(2).And.Satisfy(
+            x => x.FirstName == "Test User" && x.LastName == "Company Admin 1" && x.Email == "company.admin1@acme.corp",
+            x => x.FirstName == "Test" && x.LastName == "User" && x.Email == "test@user.com");
     }
 
     #endregion


### PR DESCRIPTION
## Description

As a follow-up to https://github.com/eclipse-tractusx/portal-backend/pull/388 the current logged-in user has been added to response of endpoint 'applications/declinedata'
Unit-tests for repository and businesslogic have been added respectively adjusted.

## Why

application-decline-page needs to display currently logged-in user.

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
