### PR TITLE
feat: change search for notifications to or

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
@@ -84,8 +84,8 @@ public class NotificationRepository : INotificationRepository
                     (!topicId.HasValue || notification.NotificationType!.NotificationTypeAssignedTopic!.NotificationTopicId == topicId.Value) &&
                     (!onlyDueDate || notification.DueDate.HasValue) &&
                     (!doneState.HasValue || notification.Done == doneState.Value) &&
-                    (!searchTypeIds.Any() || searchTypeIds.Contains(notification.NotificationTypeId) ||
-                    searchQuery == null || notification.Content != null && EF.Functions.ILike(notification.Content, $"%{searchQuery.EscapeForILike()}%")))
+                    (!searchTypeIds.Any() || searchTypeIds.Contains(notification.NotificationTypeId)) &&
+                    (searchQuery == null || notification.Content != null && EF.Functions.ILike(notification.Content, $"%{searchQuery.EscapeForILike()}%")))
                 .GroupBy(notification => notification.ReceiverUserId),
             sorting switch
             {

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
@@ -84,8 +84,8 @@ public class NotificationRepository : INotificationRepository
                     (!topicId.HasValue || notification.NotificationType!.NotificationTypeAssignedTopic!.NotificationTopicId == topicId.Value) &&
                     (!onlyDueDate || notification.DueDate.HasValue) &&
                     (!doneState.HasValue || notification.Done == doneState.Value) &&
-                    (!searchTypeIds.Any() || searchTypeIds.Contains(notification.NotificationTypeId) &&
-                    (searchQuery == null || notification.Content != null && EF.Functions.ILike(notification.Content, $"%{searchQuery.EscapeForILike()}%"))))
+                    (!searchTypeIds.Any() || searchTypeIds.Contains(notification.NotificationTypeId) ||
+                    searchQuery == null || notification.Content != null && EF.Functions.ILike(notification.Content, $"%{searchQuery.EscapeForILike()}%")))
                 .GroupBy(notification => notification.ReceiverUserId),
             sorting switch
             {


### PR DESCRIPTION
## Description

Changing the search query for notifications instead of and to or

## Why

to enable a better searchability for the notifications

## Issue

Refs: CPLP-3045

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
