### PR TITLE
chore: fix security vulnerability

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -19,7 +19,6 @@ nuget/nuget/-/Mono.TextTemplating/2.2.1, MIT, approved, clearlydefined
 nuget/nuget/-/NHamcrest/3.2.0, MIT, approved, #9299
 nuget/nuget/-/NJsonSchema/10.9.0, MIT, approved, #9300
 nuget/nuget/-/Namotion.Reflection/2.1.2, MIT, approved, #9320
-nuget/nuget/-/Newtonsoft.Json/12.0.2, MIT AND BSD-3-Clause, approved, #11114
 nuget/nuget/-/Newtonsoft.Json/13.0.1, MIT AND BSD-3-Clause, approved, #3266
 nuget/nuget/-/Newtonsoft.Json/13.0.3, MIT AND BSD-3-Clause, approved, #3266
 nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL/7.0.4, PostgreSQL AND MIT AND Apache-2.0, approved, #10081

--- a/src/keycloak/Keycloak.ErrorHandling/Keycloak.ErrorHandling.csproj
+++ b/src/keycloak/Keycloak.ErrorHandling/Keycloak.ErrorHandling.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl.Http.Signed" Version="3.2.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Updated the Newtonsoft.Json package to fix a high security finding

## Why

The referenced package used by an external package has an high security finding.

## Issue

n/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
