### PR TITLE
feat(notifications): add (optional) OR-semantics to search-query

### DIFF
--- a/src/framework/Framework.Models/SearchSemanticTypeId.cs
+++ b/src/framework/Framework.Models/SearchSemanticTypeId.cs
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
+
+public enum SearchSemanticTypeId
+{
+    OR = 1,
+    AND = 2
+}

--- a/src/notifications/Notifications.Service/BusinessLogic/INotificationBusinessLogic.cs
+++ b/src/notifications/Notifications.Service/BusinessLogic/INotificationBusinessLogic.cs
@@ -35,8 +35,9 @@ public interface INotificationBusinessLogic
     /// <param name="page">the requested page</param>
     /// <param name="size">the requested size</param>
     /// <param name="filters">additional filters to query notifications</param>
+    /// <param name="semantic">use AND or OR semantic</param>
     /// <returns>Returns a collection of the users notification</returns>
-    Task<Pagination.Response<NotificationDetailData>> GetNotificationsAsync(int page, int size, NotificationFilters filters);
+    Task<Pagination.Response<NotificationDetailData>> GetNotificationsAsync(int page, int size, NotificationFilters filters, SearchSemanticTypeId semantic);
 
     /// <summary>
     ///     Gets a specific notification for the given user.

--- a/src/notifications/Notifications.Service/BusinessLogic/NotificationBusinessLogic.cs
+++ b/src/notifications/Notifications.Service/BusinessLogic/NotificationBusinessLogic.cs
@@ -51,9 +51,9 @@ public class NotificationBusinessLogic : INotificationBusinessLogic
     }
 
     /// <inheritdoc />
-    public Task<Pagination.Response<NotificationDetailData>> GetNotificationsAsync(int page, int size, NotificationFilters filters) =>
+    public Task<Pagination.Response<NotificationDetailData>> GetNotificationsAsync(int page, int size, NotificationFilters filters, SearchSemanticTypeId semantic) =>
         Pagination.CreateResponseAsync(page, size, _settings.MaxPageSize, _portalRepositories.GetInstance<INotificationRepository>()
-                .GetAllNotificationDetailsByReceiver(_identityData.IdentityId, filters.IsRead, filters.TypeId, filters.TopicId, filters.OnlyDueDate, filters.Sorting ?? NotificationSorting.DateDesc, filters.DoneState, filters.SearchTypeIds, filters.SearchQuery));
+                .GetAllNotificationDetailsByReceiver(_identityData.IdentityId, semantic, filters.IsRead, filters.TypeId, filters.TopicId, filters.OnlyDueDate, filters.Sorting ?? NotificationSorting.DateDesc, filters.DoneState, filters.SearchTypeIds, filters.SearchQuery));
 
     /// <inheritdoc />
     public async Task<NotificationDetailData> GetNotificationDetailDataAsync(Guid notificationId)

--- a/src/notifications/Notifications.Service/Controllers/NotificationController.cs
+++ b/src/notifications/Notifications.Service/Controllers/NotificationController.cs
@@ -56,6 +56,7 @@ public class NotificationController : ControllerBase
     /// <param name="searchTypeIds">OPTIONAL: types for the search</param>
     /// <param name="page">The page to get</param>
     /// <param name="size">Amount of entries</param>
+    /// <param name="searchSemantic">OPTIONAL: choose AND or OR semantics (defaults to AND)</param>
     /// <param name="isRead">OPTIONAL: Filter for read or unread notifications</param>
     /// <param name="notificationTypeId">OPTIONAL: Type of the notifications</param>
     /// <param name="notificationTopicId">OPTIONAL: Topic of the notifications</param>
@@ -75,6 +76,7 @@ public class NotificationController : ControllerBase
         [FromQuery] IEnumerable<NotificationTypeId> searchTypeIds,
         [FromQuery] int page = 0,
         [FromQuery] int size = 15,
+        [FromQuery] SearchSemanticTypeId searchSemantic = SearchSemanticTypeId.AND,
         [FromQuery] bool? isRead = null,
         [FromQuery] NotificationTypeId? notificationTypeId = null,
         [FromQuery] NotificationTopicId? notificationTopicId = null,
@@ -83,7 +85,7 @@ public class NotificationController : ControllerBase
         [FromQuery] bool? doneState = null,
         [FromQuery] string? searchQuery = null
         ) =>
-        _logic.GetNotificationsAsync(page, size, new NotificationFilters(isRead, notificationTypeId, notificationTopicId, onlyDueDate, sorting, doneState, searchTypeIds, searchQuery));
+        _logic.GetNotificationsAsync(page, size, new NotificationFilters(isRead, notificationTypeId, notificationTopicId, onlyDueDate, sorting, doneState, searchTypeIds, searchQuery), searchSemantic);
 
     /// <summary>
     ///     Gets a notification for the logged in user

--- a/src/notifications/Notifications.Service/Models/NotificationFilters.cs
+++ b/src/notifications/Notifications.Service/Models/NotificationFilters.cs
@@ -30,8 +30,10 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Notifications.Service.Models;
 /// <param name="TypeId">OPTIONAL: The type of the notifications</param>
 /// <param name="TopicId">OPTIONAL: The topic of the notifications</param>
 /// <param name="OnlyDueDate">OPTIONAL: If true only notifications with a due date will be returned</param>
-/// <param name="Sorting">Kind of sorting for the notifications</param>
-/// <param name="DoneState">Kind of sorting for the notifications</param>
+/// <param name="Sorting">OPTIONAL: Kind of sorting for the notifications</param>
+/// <param name="DoneState">OPTIONAL: Kind of sorting for the notifications</param>
+/// <param name="SearchTypeIds">OPTIONAL: collection of notification types</param>
+/// <param name="SearchQuery">OPTIONAL: a search string</param>
 public record NotificationFilters(
     bool? IsRead,
     NotificationTypeId? TypeId,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
@@ -57,7 +57,7 @@ public interface INotificationRepository
     /// <param name="sorting"></param>
     /// <param name="doneState"></param>
     /// <returns>Returns a collection of NotificationDetailData</returns>
-    Func<int, int, Task<Pagination.Source<NotificationDetailData>?>> GetAllNotificationDetailsByReceiver(Guid receiverUserId, bool? isRead, NotificationTypeId? typeId, NotificationTopicId? topicId, bool onlyDueDate, NotificationSorting? sorting, bool? doneState, IEnumerable<NotificationTypeId> searchTypeIds, string? searchQuery);
+    Func<int, int, Task<Pagination.Source<NotificationDetailData>?>> GetAllNotificationDetailsByReceiver(Guid receiverUserId, SearchSemanticTypeId semantic, bool? isRead, NotificationTypeId? typeId, NotificationTopicId? topicId, bool onlyDueDate, NotificationSorting? sorting, bool? doneState, IEnumerable<NotificationTypeId> searchTypeIds, string? searchQuery);
 
     /// <summary>
     ///     Returns a notification for the given id and given user if it exists in the persistence layer, otherwise null

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
@@ -72,20 +72,28 @@ public class NotificationRepository : INotificationRepository
         _dbContext.Remove(new Notification(notificationId, Guid.Empty, default, default, default)).Entity;
 
     /// <inheritdoc />
-    public Func<int, int, Task<Pagination.Source<NotificationDetailData>?>> GetAllNotificationDetailsByReceiver(Guid receiverUserId, bool? isRead, NotificationTypeId? typeId, NotificationTopicId? topicId, bool onlyDueDate, NotificationSorting? sorting, bool? doneState, IEnumerable<NotificationTypeId> searchTypeIds, string? searchQuery) =>
+    public Func<int, int, Task<Pagination.Source<NotificationDetailData>?>> GetAllNotificationDetailsByReceiver(Guid receiverUserId, SearchSemanticTypeId semantic, bool? isRead, NotificationTypeId? typeId, NotificationTopicId? topicId, bool onlyDueDate, NotificationSorting? sorting, bool? doneState, IEnumerable<NotificationTypeId> searchTypeIds, string? searchQuery) =>
         (skip, take) => Pagination.CreateSourceQueryAsync(
             skip,
             take,
             _dbContext.Notifications.AsNoTracking()
                 .Where(notification =>
                     notification.ReceiverUserId == receiverUserId &&
-                    (!isRead.HasValue || notification.IsRead == isRead.Value) &&
-                    (!typeId.HasValue || notification.NotificationTypeId == typeId.Value) &&
-                    (!topicId.HasValue || notification.NotificationType!.NotificationTypeAssignedTopic!.NotificationTopicId == topicId.Value) &&
-                    (!onlyDueDate || notification.DueDate.HasValue) &&
-                    (!doneState.HasValue || notification.Done == doneState.Value) &&
-                    (!searchTypeIds.Any() || searchTypeIds.Contains(notification.NotificationTypeId)) &&
-                    (searchQuery == null || notification.Content != null && EF.Functions.ILike(notification.Content, $"%{searchQuery.EscapeForILike()}%")))
+                    semantic == SearchSemanticTypeId.AND
+                        ? ((!isRead.HasValue || notification.IsRead == isRead.Value) &&
+                           (!typeId.HasValue || notification.NotificationTypeId == typeId.Value) &&
+                           (!topicId.HasValue || notification.NotificationType!.NotificationTypeAssignedTopic!.NotificationTopicId == topicId.Value) &&
+                           (!onlyDueDate || notification.DueDate.HasValue) &&
+                           (!doneState.HasValue || notification.Done == doneState.Value) &&
+                           (!searchTypeIds.Any() || searchTypeIds.Contains(notification.NotificationTypeId)) &&
+                           (searchQuery == null || notification.Content != null && EF.Functions.ILike(notification.Content, $"%{searchQuery.EscapeForILike()}%")))
+                        : ((isRead.HasValue && notification.IsRead == isRead.Value) ||
+                           (typeId.HasValue && notification.NotificationTypeId == typeId.Value) ||
+                           (topicId.HasValue && notification.NotificationType!.NotificationTypeAssignedTopic!.NotificationTopicId == topicId.Value) ||
+                           (onlyDueDate && notification.DueDate.HasValue) ||
+                           (doneState.HasValue && notification.Done == doneState.Value) ||
+                           (searchTypeIds.Any() && searchTypeIds.Contains(notification.NotificationTypeId)) ||
+                           (searchQuery != null && notification.Content != null && EF.Functions.ILike(notification.Content, $"%{searchQuery.EscapeForILike()}%"))))
                 .GroupBy(notification => notification.ReceiverUserId),
             sorting switch
             {

--- a/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
+++ b/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
@@ -94,7 +94,7 @@ public class NotificationBusinessLogicTests
         }));
 
         // Act
-        var result = await sut.GetNotificationsAsync(0, 15, new NotificationFilters(status, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)).ConfigureAwait(false);
+        var result = await sut.GetNotificationsAsync(0, 15, new NotificationFilters(status, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null), SearchSemanticTypeId.AND).ConfigureAwait(false);
 
         // Assert
         var expectedCount = status ?
@@ -117,7 +117,7 @@ public class NotificationBusinessLogicTests
         }));
 
         // Act
-        var result = await sut.GetNotificationsAsync(0, 15, new NotificationFilters(null, null, null, false, sorting, null, Enumerable.Empty<NotificationTypeId>(), null)).ConfigureAwait(false);
+        var result = await sut.GetNotificationsAsync(0, 15, new NotificationFilters(null, null, null, false, sorting, null, Enumerable.Empty<NotificationTypeId>(), null), SearchSemanticTypeId.AND).ConfigureAwait(false);
 
         // Assert
         result.Meta.NumberOfElements.Should().Be(_notificationDetails.Count());
@@ -137,7 +137,7 @@ public class NotificationBusinessLogicTests
         }));
 
         // Act
-        var results = await sut.GetNotificationsAsync(1, 3, new NotificationFilters(null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)).ConfigureAwait(false);
+        var results = await sut.GetNotificationsAsync(1, 3, new NotificationFilters(null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null), SearchSemanticTypeId.AND).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -157,7 +157,7 @@ public class NotificationBusinessLogicTests
             MaxPageSize = 15
         }));
 
-        var Act = () => sut.GetNotificationsAsync(0, 20, new NotificationFilters(null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null));
+        var Act = () => sut.GetNotificationsAsync(0, 20, new NotificationFilters(null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null), SearchSemanticTypeId.AND);
 
         // Act & Assert
         await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
@@ -172,7 +172,7 @@ public class NotificationBusinessLogicTests
             MaxPageSize = 15
         }));
 
-        var Act = () => sut.GetNotificationsAsync(-1, 15, new NotificationFilters(null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null));
+        var Act = () => sut.GetNotificationsAsync(-1, 15, new NotificationFilters(null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null), SearchSemanticTypeId.AND);
 
         // Act & Assert
         await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
@@ -192,10 +192,10 @@ public class NotificationBusinessLogicTests
         var filter = _fixture.Create<NotificationFilters>();
 
         // Act
-        var result = await sut.GetNotificationsAsync(0, 20, filter).ConfigureAwait(false);
+        var result = await sut.GetNotificationsAsync(0, 20, filter, SearchSemanticTypeId.AND).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(userId, filter.IsRead, filter.TypeId, filter.TopicId, filter.OnlyDueDate, filter.Sorting, filter.DoneState, A<IEnumerable<NotificationTypeId>>.That.Matches(x => x.Count() == filter.SearchTypeIds.Count()), filter.SearchQuery))
+        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(userId, SearchSemanticTypeId.AND, filter.IsRead, filter.TypeId, filter.TopicId, filter.OnlyDueDate, filter.Sorting, filter.DoneState, A<IEnumerable<NotificationTypeId>>.That.Matches(x => x.Count() == filter.SearchTypeIds.Count()), filter.SearchQuery))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -485,11 +485,11 @@ public class NotificationBusinessLogicTests
         var readPaging = (int skip, int take) => Task.FromResult(new Pagination.Source<NotificationDetailData>(_readNotificationDetails.Count(), _readNotificationDetails.Skip(skip).Take(take)));
         var notificationsPaging = (int skip, int take) => Task.FromResult(new Pagination.Source<NotificationDetailData>(_notificationDetails.Count(), _notificationDetails.Skip(skip).Take(take)));
 
-        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identityId, false, null, null, false, A<NotificationSorting>._, null, A<IEnumerable<NotificationTypeId>>._, null))
+        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identityId, SearchSemanticTypeId.AND, false, null, null, false, A<NotificationSorting>._, null, A<IEnumerable<NotificationTypeId>>._, null))
             .Returns(unreadPaging);
-        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identityId, true, null, null, false, A<NotificationSorting>._, null, A<IEnumerable<NotificationTypeId>>._, null))
+        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identityId, SearchSemanticTypeId.AND, true, null, null, false, A<NotificationSorting>._, null, A<IEnumerable<NotificationTypeId>>._, null))
             .Returns(readPaging);
-        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identityId, null, null, null, false, A<NotificationSorting>._, null, A<IEnumerable<NotificationTypeId>>._, null))
+        A.CallTo(() => _notificationRepository.GetAllNotificationDetailsByReceiver(_identityId, SearchSemanticTypeId.AND, null, null, null, false, A<NotificationSorting>._, null, A<IEnumerable<NotificationTypeId>>._, null))
             .Returns(notificationsPaging);
     }
 

--- a/tests/notifications/Notifications.Service.Tests/Controllers/NotificationControllerTest.cs
+++ b/tests/notifications/Notifications.Service.Tests/Controllers/NotificationControllerTest.cs
@@ -63,14 +63,14 @@ public class NotificationControllerTest
         var sorting = _fixture.Create<NotificationSorting?>();
         var doneState = _fixture.Create<bool?>();
         var paginationResponse = new Pagination.Response<NotificationDetailData>(new Pagination.Metadata(15, 1, 1, 15), _fixture.CreateMany<NotificationDetailData>(5));
-        A.CallTo(() => _logic.GetNotificationsAsync(A<int>._, A<int>._, A<NotificationFilters>._))
+        A.CallTo(() => _logic.GetNotificationsAsync(A<int>._, A<int>._, A<NotificationFilters>._, SearchSemanticTypeId.AND))
             .ReturnsLazily(() => paginationResponse);
 
         //Act
         var result = await _controller.GetNotifications(isRead: isRead, notificationTypeId: typeId, notificationTopicId: topicId, onlyDueDate: onlyDueDate, sorting: sorting, doneState: doneState, searchTypeIds: Enumerable.Empty<NotificationTypeId>()).ConfigureAwait(false);
 
         //Assert
-        A.CallTo(() => _logic.GetNotificationsAsync(0, 15, A<NotificationFilters>.That.Matches(x => x.IsRead == isRead && x.TypeId == typeId && x.TopicId == topicId && x.OnlyDueDate == onlyDueDate && x.Sorting == sorting && x.DoneState == doneState))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetNotificationsAsync(0, 15, A<NotificationFilters>.That.Matches(x => x.IsRead == isRead && x.TypeId == typeId && x.TopicId == topicId && x.OnlyDueDate == onlyDueDate && x.Sorting == sorting && x.DoneState == doneState), SearchSemanticTypeId.AND)).MustHaveHappenedOnceExactly();
         Assert.IsType<Pagination.Response<NotificationDetailData>>(result);
         result.Content.Should().HaveCount(5);
     }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -19,6 +19,7 @@
  ********************************************************************************/
 
 using Microsoft.EntityFrameworkCore;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Tests.Setup;
@@ -194,7 +195,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -210,7 +211,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.DateAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, NotificationSorting.DateAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -225,7 +226,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.DateDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, NotificationSorting.DateDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -240,7 +241,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -255,7 +256,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, NotificationSorting.ReadStatusDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, NotificationSorting.ReadStatusDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -271,7 +272,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var results = await sut
-            .GetAllNotificationDetailsByReceiver(_companyUserId, false, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15)
+            .GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, false, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15)
             .ConfigureAwait(false);
 
         // Assert
@@ -288,7 +289,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var results = await sut
-            .GetAllNotificationDetailsByReceiver(_companyUserId, true, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15)
+            .GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, true, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15)
             .ConfigureAwait(false);
 
         // Assert
@@ -304,7 +305,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, true, NotificationTypeId.INFO, null, false, NotificationSorting.ReadStatusDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, true, NotificationTypeId.INFO, null, false, NotificationSorting.ReadStatusDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -319,7 +320,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, true, NotificationTypeId.ACTION, null, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, true, NotificationTypeId.ACTION, null, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -334,7 +335,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, NotificationTopicId.INFO, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, NotificationTopicId.INFO, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -352,7 +353,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, null, doneState, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, null, doneState, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -373,7 +374,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         await context.SaveChangesAsync().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
@@ -393,7 +394,7 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         await context.SaveChangesAsync().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, null, null, null, false, null, null, new[]
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, null, null, new[]
         {
             NotificationTypeId.WELCOME_SERVICE_PROVIDER,
             NotificationTypeId.APP_RELEASE_REQUEST


### PR DESCRIPTION
## Description

the search-filters of view_notifications endpoint now allows to combine the given search-criteria by OR instead of AND. An additional parameter 'searchSemantic' (valid values 'AND', 'OR', defaults to AND) has been added to control the behavior.

## Why

So far search-criteria were always combined by AND. That allows to narrow down a bigger result-set (with no filters specified the endpoint would return all notification for the specified user). The OR-semantic starts with an empty result-set (when no filter-parameters are specified) that can be increased by adding filters.

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
