### PR TITLE
fix(registration): disable duplicate bpn check

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
@@ -184,7 +184,8 @@ public class NetworkBusinessLogic : INetworkBusinessLogic
         await data.ValidateDatabaseData(
             bpn => _portalRepositories.GetInstance<ICompanyRepository>().CheckBpnExists(bpn),
             alpha2Code => countryRepository.CheckCountryExistsByAlpha2CodeAsync(alpha2Code),
-            (countryAlpha2Code, uniqueIdentifierIds) => countryRepository.GetCountryAssignedIdentifiers(countryAlpha2Code, uniqueIdentifierIds)).ConfigureAwait(false);
+            (countryAlpha2Code, uniqueIdentifierIds) => countryRepository.GetCountryAssignedIdentifiers(countryAlpha2Code, uniqueIdentifierIds),
+            true).ConfigureAwait(false);
 
         if (!data.CompanyRoles.Any())
         {

--- a/src/registration/Registration.Common/RegistrationValidation.cs
+++ b/src/registration/Registration.Common/RegistrationValidation.cs
@@ -74,9 +74,9 @@ public static class RegistrationValidation
         }
     }
 
-    public static async Task ValidateDatabaseData(this RegistrationData data, Func<string, Task<bool>> checkBpn, Func<string, Task<bool>> checkCountryExistByAlpha2Code, Func<string, IEnumerable<UniqueIdentifierId>, Task<(bool IsValidCountry, IEnumerable<UniqueIdentifierId> UniqueIdentifierIds)>> getCountryAssignedIdentifiers)
+    public static async Task ValidateDatabaseData(this RegistrationData data, Func<string, Task<bool>> checkBpn, Func<string, Task<bool>> checkCountryExistByAlpha2Code, Func<string, IEnumerable<UniqueIdentifierId>, Task<(bool IsValidCountry, IEnumerable<UniqueIdentifierId> UniqueIdentifierIds)>> getCountryAssignedIdentifiers, bool checkBpnAlreadyExists)
     {
-        if (data.BusinessPartnerNumber != null && await checkBpn(data.BusinessPartnerNumber.ToUpper()).ConfigureAwait(false))
+        if (data.BusinessPartnerNumber != null && checkBpnAlreadyExists && await checkBpn(data.BusinessPartnerNumber.ToUpper()).ConfigureAwait(false))
         {
             throw new ControllerArgumentException($"The Bpn {data.BusinessPartnerNumber} already exists", nameof(data.BusinessPartnerNumber));
         }

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -287,7 +287,8 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
                 _portalRepositories.GetInstance<ICountryRepository>()
                     .GetCountryAssignedIdentifiers(
                         countryAlpha2Code,
-                        uniqueIdentifierIds)).ConfigureAwait(false);
+                        uniqueIdentifierIds),
+            false).ConfigureAwait(false);
 
         var applicationRepository = _portalRepositories.GetInstance<IApplicationRepository>();
         var companyRepository = _portalRepositories.GetInstance<ICompanyRepository>();


### PR DESCRIPTION
## Description

disable the duplicate bpn check for endpoint /api/registration/application/{applicationId}/companyDetailsWithAddress

## Why

currently one can't update there date within the registration

## Issue

N/A - Jira Issue: CPLP-3665

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
