### PR TITLE
fix(registration): exclude inactive agreements

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRolesRepository.cs
@@ -65,7 +65,7 @@ public class CompanyRolesRepository : ICompanyRolesRepository
             .Where(companyRole => companyRole.CompanyRoleRegistrationData!.IsRegistrationRole && companyRoleIds.Contains(companyRole.Id))
             .Select(companyRole => new ValueTuple<CompanyRoleId, IEnumerable<AgreementStatusData>>(
                 companyRole.Id,
-                companyRole.AgreementAssignedCompanyRoles!
+                companyRole.AgreementAssignedCompanyRoles.Where(x => x.Agreement!.AgreementStatusId == AgreementStatusId.ACTIVE)
                     .Select(agreementAssignedCompanyRole => new AgreementStatusData(
                         agreementAssignedCompanyRole.AgreementId,
                         agreementAssignedCompanyRole.Agreement!.AgreementStatusId

--- a/src/registration/Registration.Service/Controllers/RegistrationController.cs
+++ b/src/registration/Registration.Service/Controllers/RegistrationController.cs
@@ -250,7 +250,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Controllers
         /// </summary>
         /// <param name="applicationId" example="4f0146c6-32aa-4bb1-b844-df7e8babdcb4">Id of the application to set the company for.</param>
         /// <param name="companyDetailData">The company with its address</param>
-        /// <remarks>Example: Post: /api/registration/application/4f0146c6-32aa-4bb1-b844-df7e8babdcb4/companyDetailsWithAddress</remarks>
+        /// <remarks>Example: Post: /api/registration/application/{applicationId}/companyDetailsWithAddress</remarks>
         /// <response code="200">Successfully set the company with its address</response>
         /// <response code="400">A request parameter was incorrect.</response>
         /// <response code="404">CompanyApplication was not found for the given id.</response>


### PR DESCRIPTION
## Description

when submitting agreements with endpoint
/api/registration/application/{applicationId}/companyRoleAgreementConsents we only check for active agreements

## Why

currently there is a inactive agreement in the database, which results in the endpoint throwing an error the user can't fix

## Issue

N/A - Jira Issue: CPLP-3667

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
