### PR TITLE
feat(searchpost): update pattern search same company name for post endpoint

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
@@ -21,6 +21,7 @@
 using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
@@ -29,11 +30,13 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Service;
+using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 
 public class InvitationBusinessLogic : IInvitationBusinessLogic
 {
+    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private readonly IProvisioningManager _provisioningManager;
     private readonly IUserProvisioningService _userProvisioningService;
     private readonly IPortalRepositories _portalRepositories;
@@ -71,6 +74,10 @@ public class InvitationBusinessLogic : IInvitationBusinessLogic
         if (string.IsNullOrWhiteSpace(invitationData.organisationName))
         {
             throw new ControllerArgumentException("organisationName must not be empty", "organisationName");
+        }
+        if (!string.IsNullOrEmpty(invitationData.organisationName) && !Company.IsMatch(invitationData.organisationName))
+        {
+            throw new ControllerArgumentException("OrganisationName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", "organisationName");
         }
         return ExecuteInvitationInternalAsync(invitationData);
     }

--- a/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
@@ -41,6 +41,7 @@ public class NetworkBusinessLogic : INetworkBusinessLogic
 {
     private static readonly Regex Name = new(ValidationExpressions.Name, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private static readonly Regex ExternalID = new("^[A-Za-z0-9\\-+_/,.]{6,36}$", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
     private readonly IPortalRepositories _portalRepositories;
     private readonly IIdentityData _identityData;
@@ -59,6 +60,10 @@ public class NetworkBusinessLogic : INetworkBusinessLogic
 
     public async Task HandlePartnerRegistration(PartnerRegistrationData data)
     {
+        if (!string.IsNullOrEmpty(data.Name) && !Company.IsMatch(data.Name))
+        {
+            throw new ControllerArgumentException("OrganisationName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", "organisationName");
+        }
         var ownerCompanyId = _identityData.CompanyId;
         var networkRepository = _portalRepositories.GetInstance<INetworkRepository>();
         var companyRepository = _portalRepositories.GetInstance<ICompanyRepository>();

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -93,6 +93,10 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
         {
             throw NotFoundException.Create(AdministrationRegistrationErrors.APPLICATION_NOT_FOUND, new ErrorParameter[] { new("applicationId", applicationId.ToString()) });
         }
+        if (!string.IsNullOrEmpty(companyWithAddress.Name) && !Company.IsMatch(companyWithAddress.Name))
+        {
+            throw new ControllerArgumentException("OrganisationName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", "organisationName");
+        }
 
         return new CompanyWithAddressData(
             companyWithAddress.CompanyId,

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -45,6 +45,8 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 {
     private static readonly Regex BpnRegex = new(@"(\w|\d){16}", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
+    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+
     private readonly IPortalRepositories _portalRepositories;
     private readonly RegistrationSettings _settings;
     private readonly IMailingService _mailingService;
@@ -123,6 +125,10 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
     public Task<Pagination.Response<CompanyApplicationDetails>> GetCompanyApplicationDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, string? companyName = null)
     {
+        if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
+        {
+            throw new ControllerArgumentException("CompanyName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name", "companyName");
+        }
         var applications = _portalRepositories.GetInstance<IApplicationRepository>()
             .GetCompanyApplicationsFilteredQuery(
                 companyName?.Length >= 3 ? companyName : null,
@@ -161,6 +167,10 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
     public Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName = null)
     {
+        if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
+        {
+            throw new ControllerArgumentException("CompanyName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name", "companyName");
+        }
         var applications = _portalRepositories.GetInstance<IApplicationRepository>().GetAllCompanyApplicationsDetailsQuery(companyName);
 
         return Pagination.CreateResponseAsync(

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -24,5 +24,6 @@ public static class ValidationExpressions
 {
     public const string Name = @"^.+$"; // TODO: should be @"^(([A-Za-zÀ-ÿ]{1,40}?([-,.'\s]?[A-Za-zÀ-ÿ]{1,40}?)){1,8})$";
     public const string Bpn = @"^(BPNL|bpnl)[\w|\d]{12}$";
-    public const string Company = @"^\d*?[A-Za-zÀ-ÿ]\d?([A-Za-z0-9À-ÿ-_+=.,:;!?'\x22&#@()]\s?){3,80}$";
+
+    public const string Company = @"^[^*+=#%\s]{0,2}[A-Za-zÀ-ÖØ-öø-ÿ&@$€¥0-9.,:;\-'\x22!?«»“”‘’()\/+^%#\\s]{3,40}$";
 }

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -24,6 +24,5 @@ public static class ValidationExpressions
 {
     public const string Name = @"^.+$"; // TODO: should be @"^(([A-Za-zÀ-ÿ]{1,40}?([-,.'\s]?[A-Za-zÀ-ÿ]{1,40}?)){1,8})$";
     public const string Bpn = @"^(BPNL|bpnl)[\w|\d]{12}$";
-
-    public const string Company = @"^[^*+=#%\s]{0,2}[A-Za-zÀ-ÖØ-öø-ÿ&@$€¥0-9.,:;\-'\x22!?«»“”‘’()\/+^%#\\s]{3,40}$";
+    public const string Company = @"^\d*?[A-Za-zÀ-ÿ]\d?([A-Za-z0-9À-ÿ-_+=.,:;!?'\x22&#@()]\s?){2,40}$";
 }

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -32,6 +32,7 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
+using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Apps.Service.BusinessLogic;
 
@@ -40,6 +41,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Apps.Service.BusinessLogic;
 /// </summary>
 public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
 {
+    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private readonly IPortalRepositories _portalRepositories;
     private readonly AppsSettings _settings;
     private readonly IOfferService _offerService;
@@ -188,6 +190,11 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
             throw new ControllerArgumentException("Use Case Ids must not be null or empty", nameof(appRequestModel.UseCaseIds));
         }
 
+        if (!string.IsNullOrEmpty(appRequestModel.Provider) && !Company.IsMatch(appRequestModel.Provider))
+        {
+            throw new ControllerArgumentException("Provider length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", nameof(appRequestModel.Provider));
+        }
+
         return this.CreateAppAsync(appRequestModel);
     }
 
@@ -261,6 +268,11 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
         if (!appData.IsUserOfProvider)
         {
             throw new ForbiddenException($"Company {companyId} is not the app provider.");
+        }
+
+        if (!string.IsNullOrEmpty(appRequestModel.Provider) && !Company.IsMatch(appRequestModel.Provider))
+        {
+            throw new ControllerArgumentException("Provider length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", nameof(appRequestModel.Provider));
         }
 
         if (appRequestModel.SalesManagerId.HasValue)

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -214,7 +214,6 @@ public class InvitationBusinessLogicTests
         A.CallTo(() => _mailingService.SendMails(A<string>._, A<Dictionary<string, string>>._, A<List<string>>._)).MustNotHaveHappened();
     }
 
-
     [Fact]
     public async Task TestExecuteInvitationCreateUserErrorThrows()
     {

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -186,6 +186,36 @@ public class InvitationBusinessLogicTests
     }
 
     [Fact]
+    public async Task TestExecuteInvitationWrongPatternOrganisationNameThrows()
+    {
+        SetupFakes();
+
+        var invitationData = _fixture.Build<CompanyInvitationData>()
+            .With(x => x.organisationName, "*Catena")
+            .WithNamePattern(x => x.firstName)
+            .WithNamePattern(x => x.lastName)
+            .WithEmailPattern(x => x.email)
+            .Create();
+
+        var sut = new InvitationBusinessLogic(
+            _provisioningManager,
+            _userProvisioningService,
+            _portalRepositories,
+            _mailingService,
+            _options);
+
+        Task Act() => sut.ExecuteInvitation(invitationData);
+
+        var error = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
+        error.Message.Should().Be("OrganisationName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name (Parameter 'organisationName')");
+
+        A.CallTo(() => _provisioningManager.GetNextCentralIdentityProviderNameAsync()).MustNotHaveHappened();
+        A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
+        A.CallTo(() => _mailingService.SendMails(A<string>._, A<Dictionary<string, string>>._, A<List<string>>._)).MustNotHaveHappened();
+    }
+
+
+    [Fact]
     public async Task TestExecuteInvitationCreateUserErrorThrows()
     {
         SetupFakes();

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -214,6 +214,7 @@ public class InvitationBusinessLogicTests
         A.CallTo(() => _mailingService.SendMails(A<string>._, A<Dictionary<string, string>>._, A<List<string>>._)).MustNotHaveHappened();
     }
 
+
     [Fact]
     public async Task TestExecuteInvitationCreateUserErrorThrows()
     {

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -252,10 +252,19 @@ public class AppReleaseBusinessLogicTest
     [Fact]
     public async Task AddAppAsync_WithSalesManagerValidData_ReturnsExpected()
     {
-        // Arrange
-        var data = _fixture.Build<AppRequestModel>()
-            .With(x => x.SalesManagerId, _companyUser.Id)
-            .Create();
+        var data = new AppRequestModel(
+            "Titlebfd7fa50-cb36-4940-96f7-0442bbc41b70",
+            "ProviderXYZ",
+            _companyUser.Id,
+            Enumerable.Repeat(Guid.NewGuid(), 1),
+            Enumerable.Repeat(new LocalizedDescription("en", "ProviderXyz", "XYZ"), 1),
+            Enumerable.Repeat("en", 1),
+            "Price90b6fed6-799a-4238-bee2-5cd84bc3f167",
+            Enumerable.Repeat(PrivacyPolicyId.COMPANY_DATA, 1),
+            "ProviderUri5ef769cd-9be3-4d3f-8a3e-c886793a732b",
+            "ContactNumber13081a1d-24fc-4f32-8163-f77a8a7fb724",
+            "ContactEmailb6e3cdcc-7d08-4dd5-9e3c-c9564129558a"
+        );
 
         Offer? created = null;
         var offerId = Guid.NewGuid();
@@ -313,9 +322,19 @@ public class AppReleaseBusinessLogicTest
     public async Task AddAppAsync_WithNullSalesMangerValidData_ReturnsExpected()
     {
         // Arrange
-        var data = _fixture.Build<AppRequestModel>()
-            .With(x => x.SalesManagerId, (Guid?)null)
-            .Create();
+        var data = new AppRequestModel(
+            "Titlebfd7fa50-cb36-4940-96f7-0442bbc41b70",
+            "ProviderXYZ",
+            null,
+            Enumerable.Repeat(Guid.NewGuid(), 1),
+            Enumerable.Repeat(new LocalizedDescription("en", "ProviderXyz", "XYZ"), 1),
+            Enumerable.Repeat("en", 1),
+            "Price90b6fed6-799a-4238-bee2-5cd84bc3f167",
+            Enumerable.Repeat(PrivacyPolicyId.COMPANY_DATA, 1),
+            "ProviderUri5ef769cd-9be3-4d3f-8a3e-c886793a732b",
+            "ContactNumber13081a1d-24fc-4f32-8163-f77a8a7fb724",
+            "ContactEmailb6e3cdcc-7d08-4dd5-9e3c-c9564129558a"
+        );
 
         Offer? created = null;
         var offerId = Guid.NewGuid();
@@ -414,9 +433,19 @@ public class AppReleaseBusinessLogicTest
     {
         // Arrange
         SetupUpdateApp();
-        var data = _fixture.Build<AppRequestModel>()
-            .With(x => x.SupportedLanguageCodes, new[] { "de", "en", "invalid" })
-            .Create();
+        var data = new AppRequestModel(
+        "Titlebfd7fa50-cb36-4940-96f7-0442bbc41b70",
+        "ProviderXYZ",
+        _companyUser.Id,
+        Enumerable.Repeat(Guid.NewGuid(), 1),
+        Enumerable.Repeat(new LocalizedDescription("en", "ProviderXyz", "XYZ"), 1),
+        new[] { "de", "en", "invalid" },
+        "Price90b6fed6-799a-4238-bee2-5cd84bc3f167",
+        Enumerable.Repeat(PrivacyPolicyId.COMPANY_DATA, 1),
+        "ProviderUri5ef769cd-9be3-4d3f-8a3e-c886793a732b",
+        "ContactNumber13081a1d-24fc-4f32-8163-f77a8a7fb724",
+        "ContactEmailb6e3cdcc-7d08-4dd5-9e3c-c9564129558a"
+    );
 
         // Act
         async Task Act() => await _sut.UpdateAppReleaseAsync(_existingAppId, data).ConfigureAwait(false);
@@ -431,9 +460,19 @@ public class AppReleaseBusinessLogicTest
     {
         // Arrange
         SetupUpdateApp();
-        var data = _fixture.Build<AppRequestModel>()
-            .With(x => x.SupportedLanguageCodes, new[] { "de", "en" })
-            .Create();
+        var data = new AppRequestModel(
+        "Titlebfd7fa50-cb36-4940-96f7-0442bbc41b70",
+        "ProviderXYZ",
+        _companyUser.Id,
+        Enumerable.Repeat(Guid.NewGuid(), 1),
+        Enumerable.Repeat(new LocalizedDescription("en", "ProviderXyz", "XYZ"), 1),
+        new[] { "de", "en" },
+        "Price90b6fed6-799a-4238-bee2-5cd84bc3f167",
+        Enumerable.Repeat(PrivacyPolicyId.COMPANY_DATA, 1),
+        "ProviderUri5ef769cd-9be3-4d3f-8a3e-c886793a732b",
+        "ContactNumber13081a1d-24fc-4f32-8163-f77a8a7fb724",
+        "ContactEmailb6e3cdcc-7d08-4dd5-9e3c-c9564129558a"
+    );
 
         Offer? initial = null;
         Offer? modified = null;


### PR DESCRIPTION
## Description

adjust existing endpoints where company name is getting inserted with the same pattern as used for search of company names.
Changes occur in below endpoints:
POST: api/administration/invitation
GET: api/administration/registration/applicationsWithStatus?page=0&amp;size=15</remarks>
GET: api/administration/registration/applications?page=0&amp;size=4
POST: api/administration/registration/network/partnerRegistration
POST: api/registration/application/{applicationId}/companyDetailsWithAddress
PUT: /api/apps/appreleaseprocess/15507472-dfdc-4885-b165-8d4a8970a3e2
POST: /api/apps/appreleaseprocess/createapp

## Why

Pattern harmonization across all endpoints where the company name is entered.

## Issue

N/A Ref: CPLP-3564
N/A Ref: CPLP-3562

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
