### PR TITLE
fix(agreement): adjust GET: companyRoleAgreementConsents endpoint

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRolesRepository.cs
@@ -80,10 +80,12 @@ public class CompanyRolesRepository : ICompanyRolesRepository
                 company.CompanyApplications.Any(application => application.Id == applicationId))
             .Select(company => new CompanyRoleAgreementConsents(
                 company.CompanyAssignedRoles.Select(companyAssignedRole => companyAssignedRole.CompanyRoleId),
-                company.Consents.Where(consent => consent.ConsentStatusId == ConsentStatusId.ACTIVE && consent.Agreement!.AgreementStatusId == AgreementStatusId.ACTIVE).Select(consent => new AgreementConsentStatus(
-                    consent.AgreementId,
-                    consent.ConsentStatusId
-                )))).SingleOrDefaultAsync();
+                company.Consents
+                    .Where(consent => consent.ConsentStatusId == ConsentStatusId.ACTIVE && consent.Agreement!.AgreementStatusId == AgreementStatusId.ACTIVE && consent.Agreement.AgreementAssignedCompanyRoles.Any())
+                    .Select(consent => new AgreementConsentStatus(
+                        consent.AgreementId,
+                        consent.ConsentStatusId
+                    )))).SingleOrDefaultAsync();
 
     public async IAsyncEnumerable<CompanyRoleData> GetCompanyRoleAgreementsUntrackedAsync()
     {

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/AgreementRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/AgreementRepositoryTests.cs
@@ -118,7 +118,7 @@ public class AgreementRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         results.Should().NotBeNullOrEmpty();
-        results.Should().HaveCount(6);
+        results.Should().HaveCount(7);
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/AgreementViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/AgreementViewTests.cs
@@ -48,7 +48,7 @@ public class AgreementViewTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var result = await sut.AgreementView.ToListAsync().ConfigureAwait(false);
-        result.Should().HaveCount(7);
+        result.Should().HaveCount(8);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -565,8 +565,9 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
             .And.Satisfy(
                 x => x.CompanyRoleId == CompanyRoleId.ACTIVE_PARTICIPANT && x.RoleDescription == activeDescription && x.CompanyRolesActive == false && x.Agreements.Count() == 2 && x.Agreements.All(agreement => agreement.ConsentStatus == 0),
                 x => x.CompanyRoleId == CompanyRoleId.APP_PROVIDER && x.RoleDescription == appDescription && x.CompanyRolesActive == false && x.Agreements.Count() == 1 && x.Agreements.All(agreement => agreement.ConsentStatus == 0),
-                x => x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER && x.RoleDescription == serviceDscription && x.CompanyRolesActive == true && x.Agreements.Count() == 2
-                    && x.Agreements.Any(agr => agr.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1094") && agr.DocumentId == null && agr.AgreementName == "Terms & Conditions - Consultant" && agr.ConsentStatus == ConsentStatusId.ACTIVE)
+                x => x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER && x.RoleDescription == serviceDscription && x.CompanyRolesActive == true && x.Agreements.Count() == 3
+                     && x.Agreements.Any(agr => agr.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1094") && agr.DocumentId == null && agr.AgreementName == "Terms & Conditions - Consultant" && agr.ConsentStatus == ConsentStatusId.ACTIVE)
+                     && x.Agreements.Any(agr => agr.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1018") && agr.DocumentId == null && agr.AgreementName == "Data Sharing Approval - allow CX to submit company data (company name, requester) to process the subscription" && agr.ConsentStatus == 0)
                     && x.Agreements.Any(agr => agr.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1017") && agr.DocumentId == new Guid("00000000-0000-0000-0000-000000000004") && agr.AgreementName == "Terms & Conditions Service Provider" && agr.ConsentStatus == 0),
                 x => x.CompanyRoleId == CompanyRoleId.ONBOARDING_SERVICE_PROVIDER && x.RoleDescription == onboardingServiceProviderDescription && x.CompanyRolesActive == false && x.Agreements.Count() == 1 && x.Agreements.All(agreement => agreement.ConsentStatus == 0));
     }
@@ -630,7 +631,7 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull()
-            .And.HaveCount(6)
+            .And.HaveCount(7)
             .And.Satisfy(
                 x => x.agreementStatusData.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1090")
                     && x.agreementStatusData.AgreementStatusId == AgreementStatusId.INACTIVE
@@ -641,15 +642,18 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
                 x => x.agreementStatusData.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1013")
                     && x.agreementStatusData.AgreementStatusId == AgreementStatusId.ACTIVE
                     && x.CompanyRoleId == CompanyRoleId.ACTIVE_PARTICIPANT,
-                x => x.agreementStatusData.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1094")
-                    && x.agreementStatusData.AgreementStatusId == AgreementStatusId.ACTIVE
-                    && x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER,
+                x => x.agreementStatusData.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1011")
+                     && x.agreementStatusData.AgreementStatusId == AgreementStatusId.ACTIVE
+                     && x.CompanyRoleId == CompanyRoleId.APP_PROVIDER,
+                x => x.agreementStatusData.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1018")
+                     && x.agreementStatusData.AgreementStatusId == AgreementStatusId.ACTIVE
+                     && x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER,
                 x => x.agreementStatusData.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1017")
                     && x.agreementStatusData.AgreementStatusId == AgreementStatusId.ACTIVE
                     && x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER,
-                x => x.agreementStatusData.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1011")
-                    && x.agreementStatusData.AgreementStatusId == AgreementStatusId.ACTIVE
-                    && x.CompanyRoleId == CompanyRoleId.APP_PROVIDER
+                x => x.agreementStatusData.AgreementId == new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1094")
+                     && x.agreementStatusData.AgreementStatusId == AgreementStatusId.ACTIVE
+                     && x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER
             );
         result.Select(x => x.CompanyRoleId).Should().BeInAscendingOrder();
     }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRolesRepositoryTests.cs
@@ -103,7 +103,7 @@ public class CompanyRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Arrange
         var activeAgreementIds = new[] { new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1010"), new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1013") };
         var appAgreementIds = new[] { new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1011") };
-        var serviceAgreementIds = new[] { new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1017"), new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1094") };
+        var serviceAgreementIds = new[] { new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1017"), new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1018"), new Guid("aa0a0000-7fbc-1f2f-817f-bce0502c1094") };
         var onboardingAgreementIds = new[] { new Guid("311aac58-932b-4622-be8b-34337e48d70d") };
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
@@ -116,7 +116,7 @@ public class CompanyRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
                 x.AgreementIds.SequenceEqual(activeAgreementIds),
             x => x.CompanyRoleId == CompanyRoleId.APP_PROVIDER && x.AgreementIds.Count() == 1 &&
                 x.AgreementIds.SequenceEqual(appAgreementIds),
-            x => x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER && x.AgreementIds.Count() == 2 &&
+            x => x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER && x.AgreementIds.Count() == 3 &&
                 x.AgreementIds.SequenceEqual(serviceAgreementIds),
             x => x.CompanyRoleId == CompanyRoleId.ONBOARDING_SERVICE_PROVIDER && x.AgreementIds.Count() == 1 &&
                 x.AgreementIds.SequenceEqual(onboardingAgreementIds)

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NetworkRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NetworkRepositoryTests.cs
@@ -167,7 +167,7 @@ public class NetworkRepositoryTests
         // Assert
         result.Exists.Should().BeTrue();
         result.CompanyApplications.Should().BeEmpty();
-        result.CompanyRoleAgreementIds.Should().Satisfy(x => x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER && x.AgreementIds.Count() == 2);
+        result.CompanyRoleAgreementIds.Should().Satisfy(x => x.CompanyRoleId == CompanyRoleId.SERVICE_PROVIDER && x.AgreementIds.Count() == 3);
         result.ProcessId.Should().BeNull();
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/agreement_assigned_company_roles.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/agreement_assigned_company_roles.test.json
@@ -2,5 +2,9 @@
     {
         "agreement_id": "aa0a0000-7fbc-1f2f-817f-bce0502c1094",
         "company_role_id": 3
+    },
+    {
+      "agreement_id": "aa0a0000-7fbc-1f2f-817f-bce0502c1018",
+      "company_role_id": 3
     }
 ]


### PR DESCRIPTION
## Description

only return agreements with assigned companyRoles for endpoint /api/registration/application/{applicationId}/companyRoleAgreementConsents

## Why

Currently all consents are returned, even those for appMarketplace. The endpoint should only return consents which are related to agreements with companyRoles assigned

## Issue

N/A - Jira Issue: CPLP-3677

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
