### PR TITLE
fix(notifications): fix search-query resulting in 'Sequence contains more than one element'

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
@@ -79,7 +79,7 @@ public class NotificationRepository : INotificationRepository
             _dbContext.Notifications.AsNoTracking()
                 .Where(notification =>
                     notification.ReceiverUserId == receiverUserId &&
-                    semantic == SearchSemanticTypeId.AND
+                    (semantic == SearchSemanticTypeId.AND
                         ? ((!isRead.HasValue || notification.IsRead == isRead.Value) &&
                            (!typeId.HasValue || notification.NotificationTypeId == typeId.Value) &&
                            (!topicId.HasValue || notification.NotificationType!.NotificationTypeAssignedTopic!.NotificationTopicId == topicId.Value) &&
@@ -93,7 +93,7 @@ public class NotificationRepository : INotificationRepository
                            (onlyDueDate && notification.DueDate.HasValue) ||
                            (doneState.HasValue && notification.Done == doneState.Value) ||
                            (searchTypeIds.Any() && searchTypeIds.Contains(notification.NotificationTypeId)) ||
-                           (searchQuery != null && notification.Content != null && EF.Functions.ILike(notification.Content, $"%{searchQuery.EscapeForILike()}%"))))
+                           (searchQuery != null && notification.Content != null && EF.Functions.ILike(notification.Content, $"%{searchQuery.EscapeForILike()}%")))))
                 .GroupBy(notification => notification.ReceiverUserId),
             sorting switch
             {

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -188,158 +188,223 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #region GetAllAsDetailsByUserIdUntracked
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 6)]
+    [InlineData(SearchSemanticTypeId.OR, 0)]
+    public async Task GetAllAsDetailsByUserIdUntracked_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, null, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
-        results.Should().NotBeNull();
-        results!.Count.Should().Be(6);
-        results.Data.Count().Should().Be(6);
-        results.Data.Should().AllBeOfType<NotificationDetailData>();
+        if (count == 0)
+        {
+            results.Should().BeNull();
+        }
+        else
+        {
+            results.Should().NotBeNull();
+            results!.Count.Should().Be(count);
+            results.Data.Count().Should().Be(count);
+            results.Data.Should().AllBeOfType<NotificationDetailData>();
+        }
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_SortedByDateAsc_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 6)]
+    [InlineData(SearchSemanticTypeId.OR, 0)]
+    public async Task GetAllAsDetailsByUserIdUntracked_SortedByDateAsc_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, NotificationSorting.DateAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, null, null, null, false, NotificationSorting.DateAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
-        results.Should().NotBeNull();
-        results!.Data.Count().Should().Be(6);
-        results.Data.Should().BeInAscendingOrder(detailData => detailData.Created);
+        if (count == 0)
+        {
+            results.Should().BeNull();
+        }
+        else
+        {
+            results.Should().NotBeNull();
+            results!.Count.Should().Be(count);
+            results.Data.Count().Should().Be(count);
+            results.Data.Should().BeInAscendingOrder(detailData => detailData.Created);
+        }
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_SortedByDateDesc_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 6)]
+    [InlineData(SearchSemanticTypeId.OR, 0)]
+    public async Task GetAllAsDetailsByUserIdUntracked_SortedByDateDesc_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, NotificationSorting.DateDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, null, null, null, false, NotificationSorting.DateDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
-        results.Should().NotBeNull();
-        results!.Data.Count().Should().Be(6);
-        results.Data.Should().BeInDescendingOrder(detailData => detailData.Created);
+        if (count == 0)
+        {
+            results.Should().BeNull();
+        }
+        else
+        {
+            results.Should().NotBeNull();
+            results!.Count.Should().Be(count);
+            results.Data.Count().Should().Be(count);
+            results.Data.Should().BeInDescendingOrder(detailData => detailData.Created);
+        }
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_SortedByReadStatusAsc_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 6)]
+    [InlineData(SearchSemanticTypeId.OR, 0)]
+    public async Task GetAllAsDetailsByUserIdUntracked_SortedByReadStatusAsc_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, null, null, null, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
-        results.Should().NotBeNull();
-        results!.Data.Count().Should().Be(6);
-        results.Data.Should().BeInAscendingOrder(detailData => detailData.IsRead);
+        if (count == 0)
+        {
+            results.Should().BeNull();
+        }
+        else
+        {
+            results.Should().NotBeNull();
+            results!.Count.Should().Be(count);
+            results.Data.Count().Should().Be(count);
+            results.Data.Should().BeInAscendingOrder(detailData => detailData.IsRead);
+        }
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_SortedByReadStatusDesc_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 6)]
+    [InlineData(SearchSemanticTypeId.OR, 0)]
+    public async Task GetAllAsDetailsByUserIdUntracked_SortedByReadStatusDesc_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, NotificationSorting.ReadStatusDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, null, null, null, false, NotificationSorting.ReadStatusDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
-        results.Should().NotBeNull();
-        results!.Data.Count().Should().Be(6);
-        results.Data.Should().BeInDescendingOrder(detailData => detailData.IsRead);
+        if (count == 0)
+        {
+            results.Should().BeNull();
+        }
+        else
+        {
+            results.Should().NotBeNull();
+            results!.Count.Should().Be(count);
+            results.Data.Count().Should().Be(count);
+            results.Data.Should().BeInDescendingOrder(detailData => detailData.IsRead);
+        }
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_WithUnreadStatus_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 3)]
+    [InlineData(SearchSemanticTypeId.OR, 3)]
+    public async Task GetAllAsDetailsByUserIdUntracked_WithUnreadStatus_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
         var results = await sut
-            .GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, false, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15)
+            .GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, false, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15)
             .ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
-        results!.Data.Count().Should().Be(3);
+        results!.Data.Count().Should().Be(count);
         results.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x => x.IsRead == false));
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_WithReadStatus_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 3)]
+    [InlineData(SearchSemanticTypeId.OR, 3)]
+    public async Task GetAllAsDetailsByUserIdUntracked_WithReadStatus_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
         var results = await sut
-            .GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, true, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15)
+            .GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, true, null, null, false, null, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15)
             .ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
-        results!.Data.Count().Should().Be(3);
+        results!.Data.Count().Should().Be(count);
         results.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x => x.IsRead == true));
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_WithReadStatusAndInfoType_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 1)]
+    [InlineData(SearchSemanticTypeId.OR, 3)]
+    public async Task GetAllAsDetailsByUserIdUntracked_WithReadStatusAndInfoType_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, true, NotificationTypeId.INFO, null, false, NotificationSorting.ReadStatusDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, true, NotificationTypeId.INFO, null, false, NotificationSorting.ReadStatusDesc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
-        results!.Data.Count().Should().Be(1);
-        results.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x => x.IsRead == true && x.TypeId == NotificationTypeId.INFO));
+        results!.Data.Count().Should().Be(count);
+        results.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x =>
+            searchSemanticTypeId == SearchSemanticTypeId.AND
+            ? (x.IsRead == true && x.TypeId == NotificationTypeId.INFO)
+            : (x.IsRead == true || x.TypeId == NotificationTypeId.INFO)));
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_WithReadStatusAndActionType_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 1)]
+    [InlineData(SearchSemanticTypeId.OR, 3)]
+    public async Task GetAllAsDetailsByUserIdUntracked_WithReadStatusAndActionType_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, true, NotificationTypeId.ACTION, null, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, true, NotificationTypeId.ACTION, null, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
-        results!.Data.Count().Should().Be(1);
-        results.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x => x.IsRead == true && x.TypeId == NotificationTypeId.ACTION));
+        results!.Data.Count().Should().Be(count);
+        results.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x =>
+            searchSemanticTypeId == SearchSemanticTypeId.AND
+                ? (x.IsRead == true && x.TypeId == NotificationTypeId.ACTION)
+                : (x.IsRead == true || x.TypeId == NotificationTypeId.ACTION)));
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_WithTopic_ReturnsExpectedNotificationDetailData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 4)]
+    [InlineData(SearchSemanticTypeId.OR, 4)]
+    public async Task GetAllAsDetailsByUserIdUntracked_WithTopic_ReturnsExpectedNotificationDetailData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, NotificationTopicId.INFO, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, null, null, NotificationTopicId.INFO, false, NotificationSorting.ReadStatusAsc, null, Enumerable.Empty<NotificationTypeId>(), null)(0, 15).ConfigureAwait(false);
 
         // Assert
         results.Should().NotBeNull();
-        results!.Data.Count().Should().Be(4);
+        results!.Data.Count().Should().Be(count);
         results.Data.Should().AllSatisfy(detailData => detailData.Should().Match<NotificationDetailData>(x => x.NotificationTopic == NotificationTopicId.INFO));
     }
 
@@ -386,15 +451,17 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
         await trans.RollbackAsync().ConfigureAwait(false);
     }
 
-    [Fact]
-    public async Task GetAllAsDetailsByUserIdUntracked_WithSearchParams_ReturnsExpectedData()
+    [Theory]
+    [InlineData(SearchSemanticTypeId.AND, 2)]
+    [InlineData(SearchSemanticTypeId.OR, 3)]
+    public async Task GetAllAsDetailsByUserIdUntracked_WithSearchParams_ReturnsExpectedData(SearchSemanticTypeId searchSemanticTypeId, int count)
     {
         // Arrange
         var (sut, context) = await CreateSutWithContext().ConfigureAwait(false);
         await context.SaveChangesAsync().ConfigureAwait(false);
 
         // Act
-        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, SearchSemanticTypeId.AND, null, null, null, false, null, null, new[]
+        var results = await sut.GetAllNotificationDetailsByReceiver(_companyUserId, searchSemanticTypeId, null, null, null, false, null, null, new[]
         {
             NotificationTypeId.WELCOME_SERVICE_PROVIDER,
             NotificationTypeId.APP_RELEASE_REQUEST
@@ -402,12 +469,22 @@ public class NotificationRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         results.Should().NotBeNull();
-        results!.Count.Should().Be(2);
-        results.Data.Count().Should().Be(2);
+        results!.Count.Should().Be(count);
+        results.Data.Count().Should().Be(count);
         results.Data.Should().AllBeOfType<NotificationDetailData>();
-        results.Data.Should().Satisfy(
-            x => x.TypeId == NotificationTypeId.WELCOME_SERVICE_PROVIDER,
-            x => x.TypeId == NotificationTypeId.APP_RELEASE_REQUEST);
+        if (searchSemanticTypeId == SearchSemanticTypeId.AND)
+        {
+            results.Data.Should().Satisfy(
+                x => x.TypeId == NotificationTypeId.WELCOME_SERVICE_PROVIDER && x.Content == """{"offerId":"0fc768e5-d4cf-4d3d-a0db-379efedd60f5","provider":"DNS"}""",
+                x => x.TypeId == NotificationTypeId.APP_RELEASE_REQUEST && x.Content == """{"offerId":"0fc768e5-d4cf-4d3d-a0db-379efedd60f5","RequestorCompanyName":"DNS"}""");
+        }
+        else
+        {
+            results.Data.Should().Satisfy(
+                x => x.TypeId == NotificationTypeId.WELCOME_SERVICE_PROVIDER && x.Content == """{"offerId":"0fc768e5-d4cf-4d3d-a0db-379efedd60f5","provider":"DNS"}""",
+                x => x.TypeId == NotificationTypeId.APP_RELEASE_REQUEST && x.Content == """{"offerId":"0fc768e5-d4cf-4d3d-a0db-379efedd60f5","RequestorCompanyName":"DNS"}""",
+                x => x.TypeId == NotificationTypeId.ACTION && x.Content == """{"offerId":"deadbeef-dead-beef-dead-beefdeadbeef","provider":"DNS"}""");
+        }
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/notifications.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/notifications.test.json
@@ -14,7 +14,7 @@
     "id": "1450F1B2-FCE6-473E-865A-62D6DC0F5A5A",
     "receiver_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
     "date_created": "2022-08-10 18:01:33.570000 +00:00",
-    "content": null,
+    "content": "{\"offerId\":\"deadbeef-dead-beef-dead-beefdeadbeef\",\"provider\":\"DNS\"}",
     "notification_type_id": 2,
     "is_read": true,
     "due_date": "2022-09-10 18:01:33.570000 +00:00",
@@ -64,5 +64,27 @@
     "due_date": "2022-09-10 18:01:33.570000 +00:00",
     "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
     "done": null
+  },
+  {
+    "id": "95cfc685-932b-4f26-90c1-c0c83b3efebf",
+    "receiver_user_id": "ac1cf001-7fbc-1f2f-817f-bce058019994",
+    "date_created": "2022-08-10 18:01:33.570000 +00:00",
+    "content": null,
+    "notification_type_id": 1,
+    "is_read": true,
+    "due_date": "2022-09-10 18:01:33.570000 +00:00",
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
+    "done": true
+  },
+  {
+    "id": "61ceb049-3a02-45e2-9652-bf73d9491212",
+    "receiver_user_id": "ac1cf001-7fbc-1f2f-817f-bce058019994",
+    "date_created": "2022-08-10 18:01:33.570000 +00:00",
+    "content": null,
+    "notification_type_id": 2,
+    "is_read": true,
+    "due_date": "2022-09-10 18:01:33.570000 +00:00",
+    "creator_user_id": "ac1cf001-7fbc-1f2f-817f-bce058020001",
+    "done": true
   }
 ]


### PR DESCRIPTION
## Description

the search-query to retrieve all notification-details for the logged in user has been changed in respect to logical grouping and operator-precedence.
Unit-tests (both code and data) have been adjusted to cover the condition causing the error that has been fixed.

## Why

the given search-query runs into ef-core-error: 'Sequence contains more than one element' in case SearchSemantcTypeId.OR is being specified.
This error was introduced by https://github.com/eclipse-tractusx/portal-backend/pull/405

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
