### PR TITLE
fix(marketplace): set company policy for agreementConsents

### DIFF
--- a/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
@@ -146,6 +146,7 @@ public class AppReleaseProcessController : ControllerBase
     [HttpPost]
     [Authorize(Roles = "edit_apps")]
     [Authorize(Policy = PolicyTypes.CompanyUser)]
+    [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("consent/{appId}/agreementConsents")]
     [ProducesResponseType(typeof(IEnumerable<ConsentStatusData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]

--- a/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
@@ -144,6 +144,7 @@ public class ServiceReleaseController : ControllerBase
     [Route("consent/{serviceId}/agreementConsents")]
     [Authorize(Roles = "add_service_offering")]
     [Authorize(Policy = PolicyTypes.CompanyUser)]
+    [Authorize(Policy = PolicyTypes.ValidCompany)]
     [ProducesResponseType(typeof(IEnumerable<ConsentStatusData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]


### PR DESCRIPTION
## Description

set the companyId of the logged in user for

POST: /api/apps/appreleaseprocess/consent/{appId}/agreementConsents
POST: /api/services/servicerelease/consent/{serviceId}/agreementConsents

## Why

The user receives a 400 error because the company id is not set properly

## Issue

N/A - Jira Issue: CPLP-3722


## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
