### PR TITLE
fix(clearinghouse): save error message when failing

### DIFF
--- a/src/externalsystems/Clearinghouse.Library/ClearinghouseService.cs
+++ b/src/externalsystems/Clearinghouse.Library/ClearinghouseService.cs
@@ -42,7 +42,10 @@ public class ClearinghouseService : IClearinghouseService
     {
         var httpClient = await _tokenService.GetAuthorizedClient<ClearinghouseService>(_settings, cancellationToken).ConfigureAwait(false);
 
+        async ValueTask<(bool, string?)> CreateErrorMessage(HttpResponseMessage errorResponse) =>
+            (false, (await errorResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false)));
+
         await httpClient.PostAsJsonAsync("/api/v1/validation", data, cancellationToken)
-            .CatchingIntoServiceExceptionFor("clearinghouse-post", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
+            .CatchingIntoServiceExceptionFor("clearinghouse-post", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE, CreateErrorMessage).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Description

Save the error content of the clearinghouse service

## Why

To display the user why the request to clearinghouse failed

## Issue

N/A - Jira Issue: CPLP-3730

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
