### PR TITLE
chore:  update changelog for v.1.8.0-RC3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,18 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 ### Change
 - External Interface Details
   - BPDM interface refactored - bpdm push process was updated to support the new interface spec of the bpdm gate service
-  - Clearinghouse interface updated - possible generated clearinghouse service error content is getting saved inside the application comment level 
-- Email Template "cx_admin_invitation" enahnced by added the section and link of the decline url (portal-frontend implementation)
+  - Clearinghouse interface updated - possible generated clearinghouse service error content is getting saved inside the application comment level
+- Email Template "cx_admin_invitation" enhanced by adding the section and link of the decline url (portal-frontend implementation)
 
 ### Feature
-- Onbaording Service Provider Function
-  - enabled deactivation of managed idps (administration service ) via the existing idp status update endpoint
-  - enabled deletion of managed idps (administration service) via the existing idp status update endpoint
+- Onboarding Service Provider Function
+  - enabled deactivation of managed idps (administration service) via the existing idp status update endpoint
+  - enabled deletion of managed idps (administration service) via the existing idp delete endpoint
   - added new endpoint to enable customer to decline their own company application which was created by an osp
 
 ### Technical Support
 - Release workflow updated by adding additional image tag of type semver
-- Upgraded packages with security vulnerabilities security findings
+- Upgraded external packages with security vulnerabilities
 
 ### Bugfix
 - Endpoint authorization on valid companyId added for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X Portal Backend.
 
+## 1.8.0-RC3
+
+### Change
+- External Interface Details
+  - BPDM interface refactored - bpdm push process was updated to support the new interface spec of the bpdm gate service
+  - Clearinghouse interface updated - possible generated clearinghouse service error content is getting saved inside the application comment level 
+- Email Template "cx_admin_invitation" enahnced by added the section and link of the decline url (portal-frontend implementation)
+
+### Feature
+- Onbaording Service Provider Function
+  - enabled deactivation of managed idps (administration service ) via the existing idp status update endpoint
+  - enabled deletion of managed idps (administration service) via the existing idp status update endpoint
+  - added new endpoint to enable customer to decline their own company application which was created by an osp
+
+### Technical Support
+- Release workflow updated by adding additional image tag of type semver
+- Upgraded packages with security vulnerabilities security findings
+
+### Bugfix
+- Endpoint authorization on valid companyId added for
+  - POST: /api/apps/appreleaseprocess/consent/{appId}/agreementConsents
+  - POST: /api/services/servicerelease/consent/{serviceId}/agreementConsents
+- Adjusted endpoint GET: api/administration/serviceaccount/owncompany/serviceaccounts to filter for active service accounts by default if no parameter is submitted
+
 ## 1.8.0-RC2
 
 ### Bugfix

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>1.8.0</VersionPrefix>
-    <VersionSuffix>RC2</VersionSuffix>
+    <VersionSuffix>RC3</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Description

* update changelog for v1.8.0-RC3
* bump version for v1.8.0-RC3

## Why

To have all changes of the latest release available in the changelog and have a new version

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
