### PR TITLE
fix(mailing): make sender email configurable

### DIFF
--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -395,7 +395,8 @@
       "SmtpHost": "",
       "SmtpPort": 587,
       "SmtpUser": "",
-      "SmtpPassword": ""
+      "SmtpPassword": "",
+      "SenderEmail": ""
     }
   },
   "IdentityProviderAdmin": {

--- a/src/mailing/Mailing.SendMail/MailSettings.cs
+++ b/src/mailing/Mailing.SendMail/MailSettings.cs
@@ -20,6 +20,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using MimeKit;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail
@@ -33,13 +34,16 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail
         public int SmtpPort { get; set; } = 0;
         public string? HttpProxy { get; set; }
         public int HttpProxyPort { get; set; }
+        public string SenderEmail { get; set; } = null!;
 
         public bool Validate()
         {
             var validation = new ConfigurationValidation<MailSettings>()
                 .NotNullOrWhiteSpace(SmtpHost, () => nameof(SmtpHost))
                 .NotNullOrWhiteSpace(SmtpUser, () => nameof(SmtpUser))
-                .NotNullOrWhiteSpace(SmtpPassword, () => nameof(SmtpPassword));
+                .NotNullOrWhiteSpace(SmtpPassword, () => nameof(SmtpPassword))
+                .NotNullOrWhiteSpace(SenderEmail, () => nameof(SenderEmail));
+
             if (HttpProxy != null)
             {
                 validation.NotNullOrWhiteSpace(HttpProxy, () => nameof(HttpProxy));
@@ -48,7 +52,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail
         }
     }
 
-    public static class MailSettingsExtention
+    public static class MailSettingsExtension
     {
         public static IServiceCollection ConfigureMailSettings(
             this IServiceCollection services,

--- a/src/mailing/Mailing.SendMail/Mailing.SendMail.csproj
+++ b/src/mailing/Mailing.SendMail/Mailing.SendMail.csproj
@@ -1,6 +1,5 @@
 <!--
-- Copyright (c) 2021, 2023 BMW Group AG
-- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.
@@ -22,6 +21,7 @@
 
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail</AssemblyName>
+    <RootNamespace>Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail</RootNamespace>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/mailing/Mailing.SendMail/MailingService.cs
+++ b/src/mailing/Mailing.SendMail/MailingService.cs
@@ -18,6 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.Template;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
@@ -26,11 +27,13 @@ public class MailingService : IMailingService
 {
     private readonly ITemplateManager _templateManager;
     private readonly ISendMail _sendMail;
+    private readonly MailSettings _settings;
 
-    public MailingService(ITemplateManager templateManager, ISendMail sendMail)
+    public MailingService(ITemplateManager templateManager, ISendMail sendMail, IOptions<MailSettings> options)
     {
         _templateManager = templateManager;
         _sendMail = sendMail;
+        _settings = options.Value;
     }
 
     public async Task SendMails(string recipient, IDictionary<string, string> parameters, IEnumerable<string> templates)
@@ -38,7 +41,7 @@ public class MailingService : IMailingService
         foreach (var temp in templates)
         {
             var email = await _templateManager.ApplyTemplateAsync(temp, parameters).ConfigureAwait(false);
-            await _sendMail.Send("Notifications@catena-x.net", recipient, email.Subject, email.Body, email.isHtml).ConfigureAwait(false);
+            await _sendMail.Send(_settings.SenderEmail, recipient, email.Subject, email.Body, email.isHtml).ConfigureAwait(false);
         }
     }
 }

--- a/src/marketplace/Apps.Service/appsettings.json
+++ b/src/marketplace/Apps.Service/appsettings.json
@@ -113,7 +113,8 @@
       "SmtpHost": "",
       "SmtpPort": 587,
       "SmtpUser": "",
-      "SmtpPassword": ""
+      "SmtpPassword": "",
+      "SenderEmail": ""
     }
   },
   "Provisioning": {

--- a/src/marketplace/Services.Service/appsettings.json
+++ b/src/marketplace/Services.Service/appsettings.json
@@ -107,7 +107,8 @@
       "SmtpHost": "",
       "SmtpPort": 587,
       "SmtpUser": "",
-      "SmtpPassword": ""
+      "SmtpPassword": "",
+      "SenderEmail": ""
     }
   },
   "Provisioning": {

--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -366,7 +366,8 @@
       "SmtpHost": "",
       "SmtpPort": 587,
       "SmtpUser": "",
-      "SmtpPassword": ""
+      "SmtpPassword": "",
+      "SenderEmail": ""
     }
   },
   "OfferSubscriptionProcess": {

--- a/src/registration/Registration.Service/appsettings.json
+++ b/src/registration/Registration.Service/appsettings.json
@@ -71,7 +71,8 @@
       "SmtpHost": "",
       "SmtpPort": 587,
       "SmtpUser": "",
-      "SmtpPassword": ""
+      "SmtpPassword": "",
+      "SenderEmail": ""
     }
   },
   "Keycloak": {

--- a/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
@@ -391,7 +391,8 @@
       "SmtpHost": "test",
       "SmtpPort": 587,
       "SmtpUser": "test",
-      "SmtpPassword": "test"
+      "SmtpPassword": "test",
+      "SenderEmail": "test@example.org"
     }
   },
   "IdentityProviderAdmin": {

--- a/tests/marketplace/Apps.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/marketplace/Apps.Service.Tests/appsettings.IntegrationTests.json
@@ -245,7 +245,8 @@
       "SmtpHost": "test",
       "SmtpPort": 587,
       "SmtpUser": "test",
-      "SmtpPassword": "test"
+      "SmtpPassword": "test",
+      "SenderEmail": "test@example.org"
     }
   }
 }

--- a/tests/marketplace/Services.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/marketplace/Services.Service.Tests/appsettings.IntegrationTests.json
@@ -156,7 +156,8 @@
       "SmtpHost": "test",
       "SmtpPort": 587,
       "SmtpUser": "test",
-      "SmtpPassword": "test"
+      "SmtpPassword": "test",
+      "SenderEmail": "test@example.org"
     }
   }
 }


### PR DESCRIPTION
## Description

The sender mail is now configurable for all services

## Why

To give the possibility to configure the sender mail

## Issue

Refs: #425

## Corresponding CD PR

[#157](https://github.com/eclipse-tractusx/portal-cd/pull/157)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
