### PR TITLE
fix(e2e): adjust bpn for wallet creation test

### DIFF
--- a/tests/endtoend/InterfacePartnerHealthCheck/WalletEndPointTests.cs
+++ b/tests/endtoend/InterfacePartnerHealthCheck/WalletEndPointTests.cs
@@ -48,7 +48,7 @@ public class WalletEndpointTests : EndToEndTestBase
     [Fact]
     public void WalletCreationInterface_CreateAndDuplicationCheck()
     {
-        Bpn = $"TestAutomation_{DateTime.Now:s}";
+        Bpn = $"BPNLTEST{DateTime.Now:DDhhmmss}";
         InterfaceHealthCheckTechUserToken = TechTokenRetriever.GetToken(TokenUrl, Secrets.InterfaceHealthCheckTechClientId, Secrets.InterfaceHealthCheckTechClientSecret);
         if (InterfaceHealthCheckTechUserToken.IsNullOrEmpty())
             throw new Exception("Could not fetch token for interface partner health check");


### PR DESCRIPTION
## Description

set bpn to match the validation schema for wallet creation test

## Why

e2e test step WalletCreationInterface_CreateAndDuplicationCheck fails due to an invalid bpn

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
