### PR TITLE
fix(claims): make clientId claim configurable

### DIFF
--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -422,5 +422,8 @@
   },
   "OnboardingServiceProvider": {
     "EncryptionKey": ""
+  },
+  "ClaimHandler": {
+    "ClientIdClaim": ""
   }
 }

--- a/src/framework/Framework.Models/PortalClaimTypes.cs
+++ b/src/framework/Framework.Models/PortalClaimTypes.cs
@@ -22,7 +22,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 public static class PortalClaimTypes
 {
     public const string Sub = "sub";
-    public const string ClientId = "clientId";
+    public const string ClientId = "client_id";
     public const string PreferredUserName = "preferred_username";
     public const string ResourceAccess = "resource_access";
 }

--- a/src/framework/Framework.Web/IdentityClaimHandlerSettings.cs
+++ b/src/framework/Framework.Web/IdentityClaimHandlerSettings.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
+
+public class IdentityClaimHandlerSettings
+{
+    public string? ClientIdClaim { get; set; }
+}
+
+public static class IdentityClaimHandlerStartupExtensions
+{
+    public static IServiceCollection AddClientIdClaimConfiguration(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOptions<IdentityClaimHandlerSettings>()
+            .Bind(configuration.GetSection("ClaimHandler"))
+            .ValidateOnStart();
+
+        return services;
+    }
+}

--- a/src/framework/Framework.Web/StartupServiceExtensions.cs
+++ b/src/framework/Framework.Web/StartupServiceExtensions.cs
@@ -69,7 +69,9 @@ public static class StartupServiceExtensions
                 };
             }
         });
-        services.AddTransient<IAuthorizationHandler, MandatoryIdentityClaimHandler>();
+        services
+            .AddClientIdClaimConfiguration(configuration)
+            .AddTransient<IAuthorizationHandler, MandatoryIdentityClaimHandler>();
         services.AddAuthorization(options =>
         {
             options.AddPolicy(PolicyTypes.ValidIdentity, policy => policy.Requirements.Add(new MandatoryIdentityClaimRequirement(PolicyTypeId.ValidIdentity)));

--- a/src/marketplace/Apps.Service/appsettings.json
+++ b/src/marketplace/Apps.Service/appsettings.json
@@ -214,5 +214,8 @@
       "publicClient": false,
       "protocol": "openid-connect"
     }
+  },
+  "ClaimHandler": {
+    "ClientIdClaim": ""
   }
 }

--- a/src/marketplace/Services.Service/appsettings.json
+++ b/src/marketplace/Services.Service/appsettings.json
@@ -208,5 +208,8 @@
       "publicClient": false,
       "protocol": "openid-connect"
     }
+  },
+  "ClaimHandler": {
+    "ClientIdClaim": ""
   }
 }

--- a/src/notifications/Notifications.Service/appsettings.json
+++ b/src/notifications/Notifications.Service/appsettings.json
@@ -61,5 +61,8 @@
   },
   "Notifications": {
     "MaxPageSize": 20
+  },
+  "ClaimHandler": {
+    "ClientIdClaim": ""
   }
 }

--- a/src/registration/Registration.Service/appsettings.json
+++ b/src/registration/Registration.Service/appsettings.json
@@ -120,5 +120,8 @@
       "enabled":true,
       "emailVerified":true
     }
+  },
+  "ClaimHandler": {
+    "ClientIdClaim": ""
   }
 }

--- a/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
@@ -243,7 +243,7 @@
     "DocumentTypeIds": [
       "COMMERCIAL_REGISTER_EXTRACT"
     ],
-    "HelpAddress": "https://test.com/help",
+    "HelpAddress": "https://test.com/help"
   },
   "Invitation": {
     "RegistrationAppAddress": "https://test-registration.azurewebsites.net",
@@ -451,5 +451,8 @@
     "ClientSecret": "test",
     "Scope": "test",
     "KeycloakTokenAddress": "test"
+  },
+  "ClaimHandler": {
+    "ClientIdClaim": "clientId"
   }
 }

--- a/tests/framework/Framework.Web.Tests/MandatoryIdentityClaimHandlerTests.cs
+++ b/tests/framework/Framework.Web.Tests/MandatoryIdentityClaimHandlerTests.cs
@@ -19,6 +19,7 @@
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
@@ -113,7 +114,7 @@ public class MandatoryIdentityClaimHandlerTests
                 : new[] { new ClaimsIdentity(new[] { new Claim(claim, value) }) });
 
         var context = new AuthorizationHandlerContext(Enumerable.Repeat(new MandatoryIdentityClaimRequirement(policyType), 1), principal, null);
-        var sut = new MandatoryIdentityClaimHandler(_claimsIdentityDataBuilder, _portalRepositories, _logger);
+        var sut = new MandatoryIdentityClaimHandler(_claimsIdentityDataBuilder, _portalRepositories, Options.Create(new IdentityClaimHandlerSettings { ClientIdClaim = "clientId" }), _logger);
 
         // Act
         await sut.HandleAsync(context).ConfigureAwait(false);


### PR DESCRIPTION
## Description

Make the clientId claim to an optional configurable value

## Why

The client id claim within the token differentiate within our environments. For dev & rc it is clientId, for int it is client_id.

## Issue

Refs: #457

## Corresponding CD PR

[#160](https://github.com/eclipse-tractusx/portal-cd/pull/160)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
