### PR TITLE
fix(decline): adjust user rights for keycloak user

### DIFF
--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -40,6 +40,13 @@
       "ClientSecret": "",
       "AuthRealm": "",
       "UseAuthTrail": false
+    },
+    "shareddelete": {
+      "ConnectionString": "",
+      "ClientId": "",
+      "ClientSecret": "",
+      "AuthRealm": "",
+      "UseAuthTrail": false
     }
   },
   "ConnectionStrings": {

--- a/src/provisioning/Provisioning.Library/ProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningManager.cs
@@ -72,7 +72,7 @@ public partial class ProvisioningManager : IProvisioningManager
 
     public async ValueTask DeleteSharedIdpRealmAsync(string alias)
     {
-        var sharedKeycloak = _Factory.CreateKeycloakClient("shared");
+        var sharedKeycloak = _Factory.CreateKeycloakClient("shareddelete");
         await sharedKeycloak.DeleteRealmAsync(alias).ConfigureAwait(false);
         await DeleteSharedIdpServiceAccountAsync(sharedKeycloak, alias);
     }

--- a/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
@@ -27,6 +27,12 @@
       "ClientId": "",
       "ClientSecret": "",
       "AuthRealm": ""
+    },
+    "shareddelete": {
+      "ConnectionString": "",
+      "ClientId": "",
+      "ClientSecret": "",
+      "AuthRealm": ""
     }
   },
   "JwtBearerOptions": {


### PR DESCRIPTION
## Description

to be able to successfully delete a realm a new user was introduced to the shared idp

## Why

The user which is used for shared idp interactions is missing the admin role, to add a bit of security a new user was introduced with only the admin role, which is only used for the delete action.

## Issue

Refs: #451

## Corresponding CD PR

[#161](https://github.com/eclipse-tractusx/portal-cd/pull/161)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
