### PR TITLE
chore(trg-4-07): enable container for readOnlyRootFilesystem 

### DIFF
--- a/docker/Dockerfile-administration-service
+++ b/docker/Dockerfile-administration-service
@@ -30,6 +30,7 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS http://+:8080
+ENV COMPlus_EnableDiagnostics=0
 EXPOSE 8080
 RUN chown -R 1000:3000 /app
 USER 1000:3000

--- a/docker/Dockerfile-administration-service
+++ b/docker/Dockerfile-administration-service
@@ -27,10 +27,10 @@ WORKDIR /src/administration/Administration.Service
 RUN dotnet publish "Administration.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS http://+:8080
-ENV COMPlus_EnableDiagnostics=0
 EXPOSE 8080
 RUN chown -R 1000:3000 /app
 USER 1000:3000

--- a/docker/Dockerfile-iam-seeding
+++ b/docker/Dockerfile-iam-seeding
@@ -35,6 +35,7 @@ WORKDIR /src/keycloak/Keycloak.Seeding
 RUN dotnet publish "Keycloak.Seeding.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
 RUN chown -R 1000:3000 /app

--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -42,8 +42,6 @@ FROM base AS final
 ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENV ASPNETCORE_URLS http://+:8080
-EXPOSE 8080
 RUN chown -R 1000:3000 /app
 USER 1000:3000
 ENTRYPOINT ["dotnet", "Org.Eclipse.TractusX.Portal.Backend.Maintenance.App.dll"]

--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -39,6 +39,7 @@ WORKDIR /src/maintenance/Maintenance.App
 RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS http://+:8080

--- a/docker/Dockerfile-marketplace-app-service
+++ b/docker/Dockerfile-marketplace-app-service
@@ -27,6 +27,7 @@ WORKDIR /src/marketplace/Apps.Service
 RUN dotnet publish "Apps.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS http://+:8080

--- a/docker/Dockerfile-notification-service
+++ b/docker/Dockerfile-notification-service
@@ -27,6 +27,7 @@ WORKDIR /src/notifications/Notifications.Service
 RUN dotnet publish "Notifications.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS http://+:8080

--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -39,8 +39,6 @@ FROM base AS final
 ENV COMPlus_EnableDiagnostics=0
 WORKDIR /migrations
 COPY --from=publish /migrations/publish .
-ENV ASPNETCORE_URLS http://+:8080
-EXPOSE 8080
 RUN chown -R 1000:3000 /migrations
 USER 1000:3000
 ENTRYPOINT ["dotnet", "Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations.dll"]

--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -36,6 +36,7 @@ WORKDIR /src/portalbackend/PortalBackend.Migrations
 RUN dotnet publish "PortalBackend.Migrations.csproj" -c Release -o /migrations/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /migrations
 COPY --from=publish /migrations/publish .
 ENV ASPNETCORE_URLS http://+:8080

--- a/docker/Dockerfile-processes-worker
+++ b/docker/Dockerfile-processes-worker
@@ -28,6 +28,7 @@ WORKDIR /src/processes/Processes.Worker
 RUN dotnet publish "Processes.Worker.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
 

--- a/docker/Dockerfile-processes-worker
+++ b/docker/Dockerfile-processes-worker
@@ -31,7 +31,6 @@ FROM base AS final
 ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
-
 RUN chown -R 1000:3000 /app
 USER 1000:3000
 ENTRYPOINT ["dotnet", "Org.Eclipse.TractusX.Portal.Backend.Processes.Worker.dll"]

--- a/docker/Dockerfile-provisioning-migrations
+++ b/docker/Dockerfile-provisioning-migrations
@@ -33,6 +33,7 @@ WORKDIR /src/provisioning/Provisioning.Migrations
 RUN dotnet publish "Provisioning.Migrations.csproj" -c Release -o /migrations/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /migrations
 COPY --from=publish /migrations/publish .
 ENV ASPNETCORE_URLS http://+:8080

--- a/docker/Dockerfile-provisioning-migrations
+++ b/docker/Dockerfile-provisioning-migrations
@@ -36,8 +36,6 @@ FROM base AS final
 ENV COMPlus_EnableDiagnostics=0
 WORKDIR /migrations
 COPY --from=publish /migrations/publish .
-ENV ASPNETCORE_URLS http://+:8080
-EXPOSE 8080
 RUN chown -R 1000:3000 /migrations
 USER 1000:3000
 ENTRYPOINT ["dotnet", "Org.CatenaX.Ng.Portal.Backend.Provisioning.Migrations.dll"]

--- a/docker/Dockerfile-registration-service
+++ b/docker/Dockerfile-registration-service
@@ -27,6 +27,7 @@ WORKDIR /src/registration/Registration.Service
 RUN dotnet publish "Registration.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS http://+:8080

--- a/docker/Dockerfile-services-service
+++ b/docker/Dockerfile-services-service
@@ -27,6 +27,7 @@ WORKDIR /src/marketplace/Services.Service
 RUN dotnet publish "Services.Service.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV COMPlus_EnableDiagnostics=0
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS http://+:8080


### PR DESCRIPTION
## Description

- add env COMPlus_EnableDiagnostics=0
- remove unnecessary env var and port for dotnet apps

## Why

https://eclipse-tractusx.github.io/docs/release/trg-0/trg-4-07

## Issue

https://github.com/eclipse-tractusx/portal-cd/issues/159

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally