### PR TITLE
feat(registration): add registrationType to response

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithStatus.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithStatus.cs
@@ -26,8 +26,10 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models
     (
         Guid ApplicationId,
         CompanyApplicationStatusId ApplicationStatus,
+        CompanyApplicationTypeId ApplicationType,
         IEnumerable<ApplicationChecklistData> ApplicationChecklist
     );
+
     public record ApplicationChecklistData(ApplicationChecklistEntryTypeId TypeId, ApplicationChecklistEntryStatusId StatusId);
 
     public record CompanyApplicationDeclineData(

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -48,6 +48,7 @@ public class UserRepository : IUserRepository
             .Select(companyApplication => new CompanyApplicationWithStatus(
                     companyApplication.Id,
                     companyApplication.ApplicationStatusId,
+                    companyApplication.CompanyApplicationTypeId,
                     companyApplication.ApplicationChecklistEntries.Select(ace =>
                         new ApplicationChecklistData(ace.ApplicationChecklistEntryTypeId, ace.ApplicationChecklistEntryStatusId))))
             .AsAsyncEnumerable();

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryTests.cs
@@ -370,7 +370,8 @@ public class UserRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result.Should().NotBeNull().And.Satisfy(x =>
             x.ApplicationId == new Guid("6b2d1263-c073-4a48-bfaf-704dc154ca9e") &&
-            x.ApplicationStatus == CompanyApplicationStatusId.SUBMITTED);
+            x.ApplicationStatus == CompanyApplicationStatusId.SUBMITTED &&
+            x.ApplicationType == CompanyApplicationTypeId.INTERNAL);
         result.Single().ApplicationChecklist.Should().Satisfy(
             y => y.TypeId == ApplicationChecklistEntryTypeId.APPLICATION_ACTIVATION && y.StatusId == ApplicationChecklistEntryStatusId.TO_DO,
             y => y.TypeId == ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER && y.StatusId == ApplicationChecklistEntryStatusId.DONE,

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -323,6 +323,7 @@ public class RegistrationBusinessLogicTest
             new CompanyApplicationWithStatus(
                 _fixture.Create<Guid>(),
                 CompanyApplicationStatusId.VERIFY,
+                CompanyApplicationTypeId.INTERNAL,
                 new[]
                 {
                     new ApplicationChecklistData(ApplicationChecklistEntryTypeId.APPLICATION_ACTIVATION,


### PR DESCRIPTION
## Description

adjust endpoint GET /api/registration/applications to response the registrationType as well

## Why

The additional information is needed to decide which path the frontend should take.

## Issue

Refs: #477

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
