### PR TITLE
fix(jwt): adjust Authentication.JwtBearer version

### DIFF
--- a/src/framework/Framework.Web/Framework.Web.csproj
+++ b/src/framework/Framework.Web/Framework.Web.csproj
@@ -73,7 +73,7 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl.Signed" Version="3.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
   </ItemGroup>

--- a/src/keycloak/Keycloak.Authentication/Keycloak.Authentication.csproj
+++ b/src/keycloak/Keycloak.Authentication/Keycloak.Authentication.csproj
@@ -31,9 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="System.Json" Version="4.7.1" />
   </ItemGroup>
 

--- a/tests/endtoend/EndToEnd.Tests.csproj
+++ b/tests/endtoend/EndToEnd.Tests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="MimeKit" Version="4.1.0" />
     <PackageReference Include="ReportPortal.XUnit" Version="2.5.0" />
     <PackageReference Include="RestAssured.Net" Version="4.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.extensibility.core" Version="2.5.0" />


### PR DESCRIPTION
## Description

Downgrade the Authentication.JwtBearer package

## Why

The version upgrade of the nuget package results in an error for the health check 

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
