### PR TITLE
fix(keycloak): remove redundant package-references

### DIFF
--- a/src/keycloak/Keycloak.Authentication/Keycloak.Authentication.csproj
+++ b/src/keycloak/Keycloak.Authentication/Keycloak.Authentication.csproj
@@ -32,8 +32,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="System.Json" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

remove explicit dependencies on Microsoft.IdentityModel.JsonWebTokens and System.IdentityModel.Tokens.Jwt

## Why

those dependencies cause the authentication-framework to fail as they refer to incorrect versions. They are redundant as they are implicitly defined be the reference to Microsoft.AspNetCore.Authentication.JwtBearer

## Issue

#325

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally