### PR TITLE
fix(identityprovider): add cancellationtoken to UpdateOwnCompanyIdentityProvider

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IIdentityProviderBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IIdentityProviderBusinessLogic.cs
@@ -31,7 +31,7 @@ public interface IIdentityProviderBusinessLogic
     ValueTask<IdentityProviderDetails> CreateOwnCompanyIdentityProviderAsync(IamIdentityProviderProtocol protocol, IdentityProviderTypeId typeId, string? displayName);
     ValueTask<IdentityProviderDetails> GetOwnCompanyIdentityProviderAsync(Guid identityProviderId);
     ValueTask<IdentityProviderDetails> SetOwnCompanyIdentityProviderStatusAsync(Guid identityProviderId, bool enabled);
-    ValueTask<IdentityProviderDetails> UpdateOwnCompanyIdentityProviderAsync(Guid identityProviderId, IdentityProviderEditableDetails details);
+    ValueTask<IdentityProviderDetails> UpdateOwnCompanyIdentityProviderAsync(Guid identityProviderId, IdentityProviderEditableDetails details, CancellationToken cancellationToken);
     ValueTask DeleteCompanyIdentityProviderAsync(Guid identityProviderId);
     IAsyncEnumerable<UserIdentityProviderData> GetOwnCompanyUsersIdentityProviderDataAsync(IEnumerable<Guid> identityProviderIds, bool unlinkedUsersOnly);
     (Stream FileStream, string ContentType, string FileName, Encoding Encoding) GetOwnCompanyUsersIdentityProviderLinkDataStream(IEnumerable<Guid> identityProviderIds, bool unlinkedUsersOnly);

--- a/src/administration/Administration.Service/BusinessLogic/IdentityProviderBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IdentityProviderBusinessLogic.cs
@@ -252,7 +252,7 @@ public class IdentityProviderBusinessLogic : IIdentityProviderBusinessLogic
         return (identityProviderCategory, alias, identityProviderTypeId, companyUsersLinked, ownerCompanyName, metadataUrl);
     }
 
-    public async ValueTask<IdentityProviderDetails> UpdateOwnCompanyIdentityProviderAsync(Guid identityProviderId, IdentityProviderEditableDetails details)
+    public async ValueTask<IdentityProviderDetails> UpdateOwnCompanyIdentityProviderAsync(Guid identityProviderId, IdentityProviderEditableDetails details, CancellationToken cancellationToken)
     {
         var (category, alias, typeId, metadataUrl) = await ValidateUpdateOwnCompanyIdentityProviderArguments(identityProviderId, details).ConfigureAwait(false);
 
@@ -262,7 +262,7 @@ public class IdentityProviderBusinessLogic : IIdentityProviderBusinessLogic
                 await UpdateIdentityProviderShared(alias, details).ConfigureAwait(false);
                 return await GetIdentityProviderDetailsOidc(identityProviderId, alias, category, typeId, null).ConfigureAwait(false);
             case IdentityProviderCategoryId.KEYCLOAK_OIDC:
-                await UpdateIdentityProviderOidc(alias, metadataUrl, details).ConfigureAwait(false);
+                await UpdateIdentityProviderOidc(alias, metadataUrl, details, cancellationToken).ConfigureAwait(false);
                 return await GetIdentityProviderDetailsOidc(identityProviderId, alias, category, typeId, details.Oidc?.MetadataUrl).ConfigureAwait(false);
             case IdentityProviderCategoryId.KEYCLOAK_SAML:
                 await UpdateIdentityProviderSaml(alias, details).ConfigureAwait(false);
@@ -294,7 +294,7 @@ public class IdentityProviderBusinessLogic : IIdentityProviderBusinessLogic
         return (identityProviderCategory, alias, identityProviderTypeId, metadataUrl);
     }
 
-    private async ValueTask UpdateIdentityProviderOidc(string alias, string? metadataUrl, IdentityProviderEditableDetails details)
+    private async ValueTask UpdateIdentityProviderOidc(string alias, string? metadataUrl, IdentityProviderEditableDetails details, CancellationToken cancellationToken)
     {
         if (details.Oidc == null)
         {
@@ -312,7 +312,7 @@ public class IdentityProviderBusinessLogic : IIdentityProviderBusinessLogic
                 details.Oidc.ClientAuthMethod,
                 details.Oidc.ClientId,
                 details.Oidc.Secret,
-                details.Oidc.SignatureAlgorithm))
+                details.Oidc.SignatureAlgorithm), cancellationToken)
             .ConfigureAwait(false);
         _portalRepositories.GetInstance<IIdentityProviderRepository>()
             .AttachAndModifyIamIdentityProvider(

--- a/src/administration/Administration.Service/Controllers/IdentityProviderController.cs
+++ b/src/administration/Administration.Service/Controllers/IdentityProviderController.cs
@@ -170,6 +170,7 @@ public class IdentityProviderController : ControllerBase
     /// </summary>
     /// <param name="identityProviderId">Id of the identity provider</param>
     /// <param name="details">possible changes for the identity provider</param>
+    /// <param name="cancellationToken">the CancellationToken for this request (provided by the Controller)</param>
     /// <returns>Returns details of the identity provider</returns>
     /// <remarks>
     /// Example: PUT: api/administration/identityprovider/owncompany/identityproviders/6CFEEF93-CB37-405B-B65A-02BEEB81629F
@@ -190,8 +191,8 @@ public class IdentityProviderController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status502BadGateway)]
-    public ValueTask<IdentityProviderDetails> UpdateOwnCompanyIdentityProvider([FromRoute] Guid identityProviderId, [FromBody] IdentityProviderEditableDetails details) =>
-        _businessLogic.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, details);
+    public ValueTask<IdentityProviderDetails> UpdateOwnCompanyIdentityProvider([FromRoute] Guid identityProviderId, [FromBody] IdentityProviderEditableDetails details, CancellationToken cancellationToken) =>
+        _businessLogic.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, details, cancellationToken);
 
     /// <summary>
     /// Deletes the identity provider with the given id

--- a/src/keycloak/Keycloak.Library/IdentityProviders/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/IdentityProviders/KeycloakClient.cs
@@ -41,7 +41,7 @@ public partial class KeycloakClient
             .ReceiveJson<IDictionary<string, object>>()
             .ConfigureAwait(false);
 
-    public async Task<IDictionary<string, object>> ImportIdentityProviderFromUrlAsync(string realm, string url) =>
+    public async Task<IDictionary<string, object>> ImportIdentityProviderFromUrlAsync(string realm, string url, CancellationToken cancellationToken = default) =>
         await (await GetBaseUrlAsync(realm).ConfigureAwait(false))
             .AppendPathSegment("/admin/realms/")
             .AppendPathSegment(realm, true)
@@ -50,7 +50,7 @@ public partial class KeycloakClient
             {
                 ["fromUrl"] = url,
                 ["providerId"] = "oidc"
-            })
+            }, cancellationToken)
             .ReceiveJson<IDictionary<string, object>>()
             .ConfigureAwait(false);
 

--- a/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
@@ -82,9 +82,9 @@ public partial class ProvisioningManager
         await _CentralIdp.UpdateIdentityProviderAsync(_Settings.CentralRealm, alias, identityProvider).ConfigureAwait(false);
     }
 
-    private async ValueTask<IdentityProvider> SetIdentityProviderMetadataFromUrlAsync(IdentityProvider identityProvider, string url)
+    private async ValueTask<IdentityProvider> SetIdentityProviderMetadataFromUrlAsync(IdentityProvider identityProvider, string url, CancellationToken cancellationToken)
     {
-        var metadata = await _CentralIdp.ImportIdentityProviderFromUrlAsync(_Settings.CentralRealm, url).ConfigureAwait(false);
+        var metadata = await _CentralIdp.ImportIdentityProviderFromUrlAsync(_Settings.CentralRealm, url, cancellationToken).ConfigureAwait(false);
         if (!metadata.Any())
         {
             throw new ServiceException("failed to import identityprovider metadata", HttpStatusCode.NotFound);

--- a/src/provisioning/Provisioning.Library/IProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/IProvisioningManager.cs
@@ -60,7 +60,7 @@ public interface IProvisioningManager
     ValueTask SetSharedIdentityProviderStatusAsync(string alias, bool enabled);
     ValueTask SetCentralIdentityProviderStatusAsync(string alias, bool enabled);
     ValueTask UpdateSharedIdentityProviderAsync(string alias, string displayName);
-    ValueTask UpdateCentralIdentityProviderDataOIDCAsync(IdentityProviderEditableConfigOidc identityProviderConfigOidc);
+    ValueTask UpdateCentralIdentityProviderDataOIDCAsync(IdentityProviderEditableConfigOidc identityProviderConfigOidc, CancellationToken cancellationToken);
     ValueTask<IdentityProviderConfigSaml> GetCentralIdentityProviderDataSAMLAsync(string alias);
     ValueTask UpdateCentralIdentityProviderDataSAMLAsync(IdentityProviderEditableConfigSaml identityProviderEditableConfigSaml);
     Task DeleteCentralIdentityProviderAsync(string alias);

--- a/src/provisioning/Provisioning.Library/ProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningManager.cs
@@ -222,7 +222,7 @@ public partial class ProvisioningManager : IProvisioningManager
         await UpdateCentralIdentityProviderAsync(alias, identityProvider).ConfigureAwait(false);
     }
 
-    public ValueTask UpdateCentralIdentityProviderDataOIDCAsync(IdentityProviderEditableConfigOidc identityProviderConfigOidc)
+    public ValueTask UpdateCentralIdentityProviderDataOIDCAsync(IdentityProviderEditableConfigOidc identityProviderConfigOidc, CancellationToken cancellationToken)
     {
         if (identityProviderConfigOidc.Secret == null)
         {
@@ -247,13 +247,13 @@ public partial class ProvisioningManager : IProvisioningManager
                     break;
             }
         }
-        return UpdateCentralIdentityProviderDataOIDCInternalAsync(identityProviderConfigOidc);
+        return UpdateCentralIdentityProviderDataOIDCInternalAsync(identityProviderConfigOidc, cancellationToken);
     }
 
-    private async ValueTask UpdateCentralIdentityProviderDataOIDCInternalAsync(IdentityProviderEditableConfigOidc identityProviderConfigOidc)
+    private async ValueTask UpdateCentralIdentityProviderDataOIDCInternalAsync(IdentityProviderEditableConfigOidc identityProviderConfigOidc, CancellationToken cancellationToken)
     {
         var (alias, displayName, metadataUrl, clientAuthMethod, clientId, secret, signatureAlgorithm) = identityProviderConfigOidc;
-        var identityProvider = await SetIdentityProviderMetadataFromUrlAsync(await GetCentralIdentityProviderAsync(alias).ConfigureAwait(false), metadataUrl).ConfigureAwait(false);
+        var identityProvider = await SetIdentityProviderMetadataFromUrlAsync(await GetCentralIdentityProviderAsync(alias).ConfigureAwait(false), metadataUrl, cancellationToken).ConfigureAwait(false);
         identityProvider.DisplayName = displayName;
         identityProvider.Config.ClientAuthMethod = IamIdentityProviderClientAuthMethodToInternal(clientAuthMethod);
         identityProvider.Config.ClientId = clientId;

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/IdentityProviderBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/IdentityProviderBusinessLogicTests.cs
@@ -1489,7 +1489,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns(default((bool, string?, IdentityProviderCategoryId, IdentityProviderTypeId, string?)));
 
         // Act
-        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
@@ -1517,7 +1517,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns(default((bool, string?, IdentityProviderCategoryId, IdentityProviderTypeId, string?)));
 
         // Act
-        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
@@ -1545,7 +1545,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns((false, "cl1", IdentityProviderCategoryId.KEYCLOAK_OIDC, IdentityProviderTypeId.OWN, null));
 
         // Act
-        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
@@ -1574,7 +1574,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns((true, "cl1", IdentityProviderCategoryId.KEYCLOAK_OIDC, IdentityProviderTypeId.OWN, null));
 
         // Act
-        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
@@ -1604,7 +1604,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns((true, "cl1", IdentityProviderCategoryId.KEYCLOAK_OIDC, IdentityProviderTypeId.OWN, null));
 
         // Act
-        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
@@ -1630,6 +1630,7 @@ public class IdentityProviderBusinessLogicTests
             _mailingService,
             _options,
             _logger);
+        var cancellationToken = CancellationToken.None;
         A.CallTo(() => _identityProviderRepository.GetOwnCompanyIdentityProviderUpdateData(A<Guid>._, A<Guid>._))
             .Returns((true, "cl1", IdentityProviderCategoryId.KEYCLOAK_OIDC, IdentityProviderTypeId.OWN, "http://old"));
         A.CallTo(() => _provisioningManager.GetCentralIdentityProviderDataOIDCAsync("cl1"))
@@ -1646,10 +1647,10 @@ public class IdentityProviderBusinessLogicTests
             });
 
         // Act
-        var result = await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        var result = await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, cancellationToken).ConfigureAwait(false);
 
         // Assert
-        A.CallTo(() => _provisioningManager.UpdateCentralIdentityProviderDataOIDCAsync(A<IdentityProviderEditableConfigOidc>.That.Matches(x => x.Secret == "test" && x.Alias == "cl1" && x.MetadataUrl == "http://new")))
+        A.CallTo(() => _provisioningManager.UpdateCentralIdentityProviderDataOIDCAsync(A<IdentityProviderEditableConfigOidc>.That.Matches(x => x.Secret == "test" && x.Alias == "cl1" && x.MetadataUrl == "http://new"), cancellationToken))
             .MustHaveHappenedOnceExactly();
         result.Mappers.Should().HaveCount(3);
         result.DisplayName.Should().Be("dis-oidc");
@@ -1686,7 +1687,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns((true, "cl1", IdentityProviderCategoryId.KEYCLOAK_SAML, IdentityProviderTypeId.OWN, null));
 
         // Act
-        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
@@ -1716,7 +1717,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns((true, "cl1", IdentityProviderCategoryId.KEYCLOAK_SAML, IdentityProviderTypeId.OWN, null));
 
         // Act
-        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
@@ -1750,7 +1751,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns(_fixture.CreateMany<IdentityProviderMapperModel>(2).ToAsyncEnumerable());
 
         // Act
-        var result = await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        var result = await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         A.CallTo(() => _provisioningManager.UpdateCentralIdentityProviderDataSAMLAsync(A<IdentityProviderEditableConfigSaml>.That.Matches(x => x.singleSignOnServiceUrl == "https://sso.com" && x.alias == "cl1")))
@@ -1782,7 +1783,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns((true, "cl1", IdentityProviderCategoryId.KEYCLOAK_OIDC, IdentityProviderTypeId.SHARED, null));
 
         // Act
-        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
@@ -1812,7 +1813,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns((true, "cl1", IdentityProviderCategoryId.KEYCLOAK_OIDC, IdentityProviderTypeId.SHARED, null));
 
         // Act
-        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        async Task Act() => await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
@@ -1846,7 +1847,7 @@ public class IdentityProviderBusinessLogicTests
             .Returns(_fixture.CreateMany<IdentityProviderMapperModel>(2).ToAsyncEnumerable());
 
         // Act
-        var result = await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data).ConfigureAwait(false);
+        var result = await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None).ConfigureAwait(false);
 
         // Assert
         A.CallTo(() => _provisioningManager.UpdateSharedIdentityProviderAsync("cl1", "dis-shared"))

--- a/tests/administration/Administration.Service.Tests/Controllers/IdentityProviderControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/IdentityProviderControllerTests.cs
@@ -34,7 +34,7 @@ public class IdentityProviderControllerTests
     {
         _fixture = new Fixture();
         _logic = A.Fake<IIdentityProviderBusinessLogic>();
-        this._controller = new IdentityProviderController(_logic);
+        _controller = new IdentityProviderController(_logic);
     }
 
     [Fact]
@@ -43,15 +43,16 @@ public class IdentityProviderControllerTests
         //Arrange
         var id = Guid.NewGuid();
         var data = _fixture.Create<IdentityProviderDetails>();
-        A.CallTo(() => _logic.UpdateOwnCompanyIdentityProviderAsync(A<Guid>._, A<IdentityProviderEditableDetails>._))
+        A.CallTo(() => _logic.UpdateOwnCompanyIdentityProviderAsync(A<Guid>._, A<IdentityProviderEditableDetails>._, A<CancellationToken>._))
             .Returns(data);
+        var cancellationToken = CancellationToken.None;
 
         //Act
-        var result = await this._controller.UpdateOwnCompanyIdentityProvider(id, new IdentityProviderEditableDetails("test")).ConfigureAwait(false);
+        var result = await this._controller.UpdateOwnCompanyIdentityProvider(id, new IdentityProviderEditableDetails("test"), cancellationToken).ConfigureAwait(false);
 
         //Assert
         result.Should().Be(data);
-        A.CallTo(() => _logic.UpdateOwnCompanyIdentityProviderAsync(id, A<IdentityProviderEditableDetails>.That.Matches(x => x.DisplayName == "test"))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.UpdateOwnCompanyIdentityProviderAsync(id, A<IdentityProviderEditableDetails>.That.Matches(x => x.DisplayName == "test"), cancellationToken)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]


### PR DESCRIPTION
## Description

CancellationToken from controllerframework is forwarded to external call of centralIdentityProvider.ImportIdentityProviderFromUrlAsync()

## Why

external call ImportIdentityProviderFromUrlAsync() will cause the called keycloak to itself execute an external call to retrieve identityProvider metadata. In case the response of this call is delayed the service-call will also wait for the response. Forwarding the CancellationToken will help to cancel the outstanding call whenever the FE closes the connection.

## Issue

#452

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
