### PR TITLE
fix(release): adjust release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ on:
       - 'v*.*.*'
       - '!v*.*.*-RC*'
       - '!v*.*.*-iam*'
+      - '!v*.*.*-framework*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release_release_candidate.yml
+++ b/.github/workflows/release_release_candidate.yml
@@ -24,6 +24,7 @@ on:
     tags:
       - 'v*.*.*-RC*'
       - '!v*.*.*-iam*'
+      - '!v*.*.*-framework*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Description

do not run release workflow when a new framework version was published

## Why

When pushing a new framework tag the release workflow gets triggered which should not happen.

## Issue

Refs: CPLP-3400

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
