### PR TITLE
fix(network): add validCompany to network registration

### DIFF
--- a/src/registration/Registration.Service/Controllers/NetworkController.cs
+++ b/src/registration/Registration.Service/Controllers/NetworkController.cs
@@ -56,6 +56,7 @@ public class NetworkController : ControllerBase
     [HttpPost]
     [Authorize(Roles = "submit_registration")]
     [Authorize(Policy = PolicyTypes.CompanyUser)]
+    [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("partnerRegistration/submit")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]


### PR DESCRIPTION
## Description

Add ValidCompany Attribute to endpoint POST: api/registration/network/{externalId}/decline to initialise the companyId of the current user correctly 

## Why

When sending a request to the endpoint it always returns `Org.Eclipse.TractusX.Portal.Backend.Web.Identity "companyId should never be null here (endpoint must be annotated with the a company policy)` as an error

## Issue

Refs: #505

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
