### PR TITLE
fix(n2n): ignore inactive agreements

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/NetworkRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/NetworkRepository.cs
@@ -78,7 +78,7 @@ public class NetworkRepository : INetworkRepository
                         ca.OnboardingServiceProvider!.OnboardingServiceProviderDetail!.CallbackUrl)),
                 x.CompanyAssignedRoles.Select(assigned => new ValueTuple<CompanyRoleId, IEnumerable<Guid>>(
                         assigned.CompanyRoleId,
-                        assigned.CompanyRole!.AgreementAssignedCompanyRoles.Select(a => a.AgreementId))),
+                        assigned.CompanyRole!.AgreementAssignedCompanyRoles.Where(a => a.Agreement!.AgreementStatusId == AgreementStatusId.ACTIVE).Select(a => a.AgreementId))),
                 x.NetworkRegistration!.ProcessId
                 ))
             .SingleOrDefaultAsync();


### PR DESCRIPTION
## Description

Ignoring the inactive agreements which are assigned to company roles.

## Why

When submitting an external registration where an inactive agreement is assigned to one of the company roles of the company you won't be able to submit the registration successfully. Now the inactive agreements are filtered out.

## Issue

Refs: #505

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
