### PR TITLE
build: adjust get version script

### DIFF
--- a/.github/workflows/nuget-package-push.yml
+++ b/.github/workflows/nuget-package-push.yml
@@ -71,4 +71,4 @@ jobs:
     - name: Create git tag
       uses: rickstaa/action-create-tag@v1
       with:
-        tag: v${{ steps.nugetPackageVersion.outputs.version }}
+        tag: ${{ steps.nugetPackageVersion.outputs.version }}

--- a/scripts/get_current_version.sh
+++ b/scripts/get_current_version.sh
@@ -33,4 +33,4 @@ else
   version="$version_prefix-framework"
 fi
 
-echo "Version: $version"
+echo "v$version"


### PR DESCRIPTION
## Description

Adjust the get_current_version script to only return the tag name

## Why

The push Nuget Packages workflow fails due to an invalid tag name

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
