### PR TITLE
feat(document): get company certificate by document id

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -607,6 +607,25 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
             _settings.MaxPageSize,
             _portalRepositories.GetInstance<ICompanyCertificateRepository>().GetActiveCompanyCertificatePaginationSource(sorting, certificateStatus, certificateType, _identityData.CompanyId));
 
+    /// <inheritdoc />
+    public async Task<(byte[] Content, string FileName, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId)
+    {
+        var documentDetails = await _portalRepositories.GetInstance<ICompanyCertificateRepository>()
+            .GetCompanyCertificateDocumentDataAsync(documentId)
+            .ConfigureAwait(false);
+        if (documentDetails == default)
+        {
+            throw new NotFoundException($"Document {documentId} does not exist");
+        }
+
+        if (documentDetails.Content == null)
+        {
+            throw new UnexpectedConditionException("documentContent should never be null here");
+        }
+
+        return (documentDetails.Content, documentDetails.FileName, documentDetails.MediaTypeId.MapToMediaType());
+    }
+
     public async Task<int> DeleteCompanyCertificateAsync(Guid documentId)
     {
         var companyCertificateRepository = _portalRepositories.GetInstance<ICompanyCertificateRepository>();

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -608,22 +608,18 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
             _portalRepositories.GetInstance<ICompanyCertificateRepository>().GetActiveCompanyCertificatePaginationSource(sorting, certificateStatus, certificateType, _identityData.CompanyId));
 
     /// <inheritdoc />
-    public async Task<(byte[] Content, string FileName, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId)
+    public async Task<(string FileName, byte[] Content, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId)
     {
         var documentDetails = await _portalRepositories.GetInstance<ICompanyCertificateRepository>()
-            .GetCompanyCertificateDocumentDataAsync(documentId)
+            .GetCompanyCertificateDocumentDataAsync(documentId, DocumentTypeId.COMPANY_CERTIFICATE)
             .ConfigureAwait(false);
-        if (documentDetails == default)
+
+        if (!documentDetails.IsExist)
         {
-            throw new NotFoundException($"Document {documentId} does not exist");
+            throw new NotFoundException($"Company certificate document {documentId} does not exist");
         }
 
-        if (documentDetails.Content == null)
-        {
-            throw new UnexpectedConditionException("documentContent should never be null here");
-        }
-
-        return (documentDetails.Content, documentDetails.FileName, documentDetails.MediaTypeId.MapToMediaType());
+        return (documentDetails.FileName, documentDetails.Content, documentDetails.MediaTypeId.MapToMediaType());
     }
 
     public async Task<int> DeleteCompanyCertificateAsync(Guid documentId)

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -645,4 +645,23 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
 
         return await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
+
+    /// <inheritdoc />
+    public async Task<(byte[] Content, string FileName, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId)
+    {
+        var documentDetails = await _portalRepositories.GetInstance<ICompanyCertificateRepository>()
+            .GetCompanyCertificateDocumentDataAsync(documentId)
+            .ConfigureAwait(false);
+        if (documentDetails == default)
+        {
+            throw new NotFoundException($"Document {documentId} does not exist");
+        }
+
+        if (documentDetails.Content == null)
+        {
+            throw new UnexpectedConditionException("documentContent should never be null here");
+        }
+
+        return (documentDetails.Content, documentDetails.FileName, documentDetails.MediaTypeId.MapToMediaType());
+    }
 }

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -653,9 +653,13 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
             .GetCompanyCertificateDocumentDataAsync(documentId, DocumentTypeId.COMPANY_CERTIFICATE)
             .ConfigureAwait(false);
 
-        if (!documentDetails.IsExist)
+        if (!documentDetails.IsExists)
         {
             throw new NotFoundException($"Company certificate document {documentId} does not exist");
+        }
+        if (!documentDetails.IsStatusLocked)
+        {
+            throw new ForbiddenException($"Document {documentId} status is not Locked");
         }
 
         return (documentDetails.FileName, documentDetails.Content, documentDetails.MediaTypeId.MapToMediaType());

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -647,21 +647,17 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
     }
 
     /// <inheritdoc />
-    public async Task<(byte[] Content, string FileName, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId)
+    public async Task<(string FileName, byte[] Content, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId)
     {
         var documentDetails = await _portalRepositories.GetInstance<ICompanyCertificateRepository>()
-            .GetCompanyCertificateDocumentDataAsync(documentId)
+            .GetCompanyCertificateDocumentDataAsync(documentId, DocumentTypeId.COMPANY_CERTIFICATE)
             .ConfigureAwait(false);
-        if (documentDetails == default)
+
+        if (!documentDetails.IsExist)
         {
-            throw new NotFoundException($"Document {documentId} does not exist");
+            throw new NotFoundException($"Company certificate document {documentId} does not exist");
         }
 
-        if (documentDetails.Content == null)
-        {
-            throw new UnexpectedConditionException("documentContent should never be null here");
-        }
-
-        return (documentDetails.Content, documentDetails.FileName, documentDetails.MediaTypeId.MapToMediaType());
+        return (documentDetails.FileName, documentDetails.Content, documentDetails.MediaTypeId.MapToMediaType());
     }
 }

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -607,21 +607,6 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
             _settings.MaxPageSize,
             _portalRepositories.GetInstance<ICompanyCertificateRepository>().GetActiveCompanyCertificatePaginationSource(sorting, certificateStatus, certificateType, _identityData.CompanyId));
 
-    /// <inheritdoc />
-    public async Task<(string FileName, byte[] Content, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId)
-    {
-        var documentDetails = await _portalRepositories.GetInstance<ICompanyCertificateRepository>()
-            .GetCompanyCertificateDocumentDataAsync(documentId, DocumentTypeId.COMPANY_CERTIFICATE)
-            .ConfigureAwait(false);
-
-        if (!documentDetails.IsExist)
-        {
-            throw new NotFoundException($"Company certificate document {documentId} does not exist");
-        }
-
-        return (documentDetails.FileName, documentDetails.Content, documentDetails.MediaTypeId.MapToMediaType());
-    }
-
     public async Task<int> DeleteCompanyCertificateAsync(Guid documentId)
     {
         var companyCertificateRepository = _portalRepositories.GetInstance<ICompanyCertificateRepository>();
@@ -668,13 +653,13 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
             .GetCompanyCertificateDocumentDataAsync(documentId, DocumentTypeId.COMPANY_CERTIFICATE)
             .ConfigureAwait(false);
 
-        if (!documentDetails.IsExists)
+        if (!documentDetails.Exists)
         {
             throw new NotFoundException($"Company certificate document {documentId} does not exist");
         }
         if (!documentDetails.IsStatusLocked)
         {
-            throw new ForbiddenException($"Document {documentId} status is not Locked");
+            throw new ForbiddenException($"Document {documentId} status is not locked");
         }
 
         return (documentDetails.FileName, documentDetails.Content, documentDetails.MediaTypeId.MapToMediaType());

--- a/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
@@ -58,7 +58,7 @@ public interface ICompanyDataBusinessLogic
 
     Task CreateCompanyCertificate(CompanyCertificateCreationData data, CancellationToken cancellationToken);
 
-    Task<(byte[] Content, string FileName, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId);
+    Task<(string FileName, byte[] Content, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId);
 
     Task<int> DeleteCompanyCertificateAsync(Guid documentId);
 

--- a/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
@@ -58,6 +58,8 @@ public interface ICompanyDataBusinessLogic
 
     Task CreateCompanyCertificate(CompanyCertificateCreationData data, CancellationToken cancellationToken);
 
+    Task<(byte[] Content, string FileName, string MediaType)> GetCompanyCertificateDocumentAsync(Guid documentId);
+
     Task<int> DeleteCompanyCertificateAsync(Guid documentId);
 
     Task<Pagination.Response<CompanyCertificateData>> GetAllCompanyCertificatesAsync(int page, int size, CertificateSorting? sorting, CompanyCertificateStatusId? certificateStatus, CompanyCertificateTypeId? certificateType);

--- a/src/administration/Administration.Service/Controllers/CompanyDataController.cs
+++ b/src/administration/Administration.Service/Controllers/CompanyDataController.cs
@@ -332,6 +332,31 @@ public class CompanyDataController : ControllerBase
         _logic.GetAllCompanyCertificatesAsync(page, size, sorting, certificateStatus, certificateType);
 
     /// <summary>
+    /// Retrieves a specific company certificate document for the given id.
+    /// </summary>
+    /// <param name="documentId" example="4ad087bb-80a1-49d3-9ba9-da0b175cd4e3">Id of the document to get.</param>
+    /// <returns>Returns the file.</returns>
+    /// <remarks>Example: GET /api/administration/companydata/companyCertificates/documents/4ad087bb-80a1-49d3-9ba9-da0b175cd4e3</remarks>
+    /// <response code="200">Returns the file.</response>
+    /// <response code="403">The document which is not in status "ACTIVE".</response>
+    /// <response code="404">The document was not found.</response>
+    /// <response code="503">document Content is null.</response>
+    [HttpGet]
+    [Route("companyCertificates/documents/{documentId}")]
+    [Authorize(Roles = "view_certificates")]
+    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [Authorize(Policy = PolicyTypes.CompanyUser)]
+    [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult> GetCompanyCertificateDocumentContentFileAsync([FromRoute] Guid documentId)
+    {
+        var (fileName, content, mediaType) = await _logic.GetCompanyCertificateDocumentAsync(documentId).ConfigureAwait(false);
+        return File(fileName, content, mediaType);
+    }
+
+    /// <summary>
     /// Deletes the company certificate with the given id
     /// </summary>
     /// <param name="documentId" example="4ad087bb-80a1-49d3-9ba9-da0b175cd4e3"></param>

--- a/src/administration/Administration.Service/Controllers/CompanyDataController.cs
+++ b/src/administration/Administration.Service/Controllers/CompanyDataController.cs
@@ -353,7 +353,7 @@ public class CompanyDataController : ControllerBase
     public async Task<ActionResult> GetCompanyCertificateDocumentContentFileAsync([FromRoute] Guid documentId)
     {
         var (fileName, content, mediaType) = await _logic.GetCompanyCertificateDocumentAsync(documentId).ConfigureAwait(false);
-        return File(fileName, content, mediaType);
+        return File(content, mediaType, fileName);
     }
 
     /// <summary>

--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -389,7 +389,7 @@
       "SmtpPort": 587,
       "SmtpUser": "",
       "SmtpPassword": "",
-      "SenderEmail": ""
+      "SenderEmail": "xyz@gmail.com"
     }
   },
   "IdentityProviderAdmin": {

--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -389,7 +389,7 @@
       "SmtpPort": 587,
       "SmtpUser": "",
       "SmtpPassword": "",
-      "SenderEmail": "xyz@gmail.com"
+      "SenderEmail": ""
     }
   },
   "IdentityProviderAdmin": {

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyCertificateRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyCertificateRepository.cs
@@ -100,6 +100,17 @@ public class CompanyCertificateRepository : ICompanyCertificateRepository
                 ))
         .SingleOrDefaultAsync();
 
+    public Task<(byte[]? Content, string FileName, MediaTypeId MediaTypeId)> GetCompanyCertificateDocumentDataAsync(Guid documentId) =>
+            _context.Documents
+            .Where(x => x.Id == documentId &&
+                   x.DocumentStatusId == DocumentStatusId.LOCKED &&
+                   x.DocumentTypeId == DocumentTypeId.COMPANY_CERTIFICATE)
+            .Select(x => new ValueTuple<byte[]?, string, MediaTypeId>(
+                x.DocumentContent,
+                x.DocumentName,
+                x.MediaTypeId))
+            .SingleOrDefaultAsync();
+
     public Task<(Guid DocumentId, DocumentStatusId DocumentStatusId, IEnumerable<Guid> CompanyCertificateId, bool IsSameCompany)> GetCompanyCertificateDocumentDetailsForIdUntrackedAsync(Guid documentId, Guid companyId) =>
             _context.Documents
             .AsNoTracking()

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyCertificateRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyCertificateRepository.cs
@@ -100,12 +100,11 @@ public class CompanyCertificateRepository : ICompanyCertificateRepository
                 ))
         .SingleOrDefaultAsync();
 
-    public Task<(byte[] Content, string FileName, MediaTypeId MediaTypeId, bool IsExist)> GetCompanyCertificateDocumentDataAsync(Guid documentId, DocumentTypeId documentTypeId) =>
+    public Task<(byte[] Content, string FileName, MediaTypeId MediaTypeId, bool IsExists, bool IsStatusLocked)> GetCompanyCertificateDocumentDataAsync(Guid documentId, DocumentTypeId documentTypeId) =>
             _context.Documents
             .Where(x => x.Id == documentId &&
-                   x.DocumentStatusId == DocumentStatusId.LOCKED &&
                    x.DocumentTypeId == documentTypeId)
-            .Select(x => new ValueTuple<byte[], string, MediaTypeId, bool>(x.DocumentContent, x.DocumentName, x.MediaTypeId, x.Id == documentId))
+            .Select(x => new ValueTuple<byte[], string, MediaTypeId, bool, bool>(x.DocumentContent, x.DocumentName, x.MediaTypeId, x.Id == documentId, x.DocumentStatusId == DocumentStatusId.LOCKED))
         .SingleOrDefaultAsync();
 
     public Task<(Guid DocumentId, DocumentStatusId DocumentStatusId, IEnumerable<Guid> CompanyCertificateId, bool IsSameCompany)> GetCompanyCertificateDocumentDetailsForIdUntrackedAsync(Guid documentId, Guid companyId) =>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyCertificateRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyCertificateRepository.cs
@@ -100,16 +100,13 @@ public class CompanyCertificateRepository : ICompanyCertificateRepository
                 ))
         .SingleOrDefaultAsync();
 
-    public Task<(byte[]? Content, string FileName, MediaTypeId MediaTypeId)> GetCompanyCertificateDocumentDataAsync(Guid documentId) =>
+    public Task<(byte[] Content, string FileName, MediaTypeId MediaTypeId, bool IsExist)> GetCompanyCertificateDocumentDataAsync(Guid documentId, DocumentTypeId documentTypeId) =>
             _context.Documents
             .Where(x => x.Id == documentId &&
                    x.DocumentStatusId == DocumentStatusId.LOCKED &&
-                   x.DocumentTypeId == DocumentTypeId.COMPANY_CERTIFICATE)
-            .Select(x => new ValueTuple<byte[]?, string, MediaTypeId>(
-                x.DocumentContent,
-                x.DocumentName,
-                x.MediaTypeId))
-            .SingleOrDefaultAsync();
+                   x.DocumentTypeId == documentTypeId)
+            .Select(x => new ValueTuple<byte[], string, MediaTypeId, bool>(x.DocumentContent, x.DocumentName, x.MediaTypeId, x.Id == documentId))
+        .SingleOrDefaultAsync();
 
     public Task<(Guid DocumentId, DocumentStatusId DocumentStatusId, IEnumerable<Guid> CompanyCertificateId, bool IsSameCompany)> GetCompanyCertificateDocumentDetailsForIdUntrackedAsync(Guid documentId, Guid companyId) =>
             _context.Documents

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyCertificateRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyCertificateRepository.cs
@@ -100,11 +100,11 @@ public class CompanyCertificateRepository : ICompanyCertificateRepository
                 ))
         .SingleOrDefaultAsync();
 
-    public Task<(byte[] Content, string FileName, MediaTypeId MediaTypeId, bool IsExists, bool IsStatusLocked)> GetCompanyCertificateDocumentDataAsync(Guid documentId, DocumentTypeId documentTypeId) =>
+    public Task<(byte[] Content, string FileName, MediaTypeId MediaTypeId, bool Exists, bool IsStatusLocked)> GetCompanyCertificateDocumentDataAsync(Guid documentId, DocumentTypeId documentTypeId) =>
             _context.Documents
             .Where(x => x.Id == documentId &&
                    x.DocumentTypeId == documentTypeId)
-            .Select(x => new ValueTuple<byte[], string, MediaTypeId, bool, bool>(x.DocumentContent, x.DocumentName, x.MediaTypeId, x.Id == documentId, x.DocumentStatusId == DocumentStatusId.LOCKED))
+            .Select(x => new ValueTuple<byte[], string, MediaTypeId, bool, bool>(x.DocumentContent, x.DocumentName, x.MediaTypeId, true, x.DocumentStatusId == DocumentStatusId.LOCKED))
         .SingleOrDefaultAsync();
 
     public Task<(Guid DocumentId, DocumentStatusId DocumentStatusId, IEnumerable<Guid> CompanyCertificateId, bool IsSameCompany)> GetCompanyCertificateDocumentDetailsForIdUntrackedAsync(Guid documentId, Guid companyId) =>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyCertificateRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyCertificateRepository.cs
@@ -20,6 +20,7 @@
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
@@ -68,7 +69,7 @@ public interface ICompanyCertificateRepository
     /// </summary>
     /// <param name="documentId">id of the document</param>   
     /// <returns>Returns the document data</returns>
-    Task<(byte[] Content, string FileName, MediaTypeId MediaTypeId, bool IsExist)> GetCompanyCertificateDocumentDataAsync(Guid documentId, DocumentTypeId documentTypeId);
+    Task<(byte[] Content, string FileName, MediaTypeId MediaTypeId, bool Exists, bool IsStatusLocked)> GetCompanyCertificateDocumentDataAsync(Guid documentId, DocumentTypeId documentTypeId);
 
     Task<(Guid DocumentId, DocumentStatusId DocumentStatusId, IEnumerable<Guid> CompanyCertificateId, bool IsSameCompany)> GetCompanyCertificateDocumentDetailsForIdUntrackedAsync(Guid documentId, Guid companyId);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyCertificateRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyCertificateRepository.cs
@@ -65,6 +65,13 @@ public interface ICompanyCertificateRepository
     /// <returns>Returns an Pagination</returns>
     Func<int, int, Task<Pagination.Source<CompanyCertificateData>?>> GetActiveCompanyCertificatePaginationSource(CertificateSorting? sorting, CompanyCertificateStatusId? certificateStatus, CompanyCertificateTypeId? certificateType, Guid companyId);
 
+    /// <summary>
+    /// Get the company certificate document data
+    /// </summary>
+    /// <param name="documentId">id of the document</param>   
+    /// <returns>Returns the document data</returns>
+    Task<(byte[]? Content, string FileName, MediaTypeId MediaTypeId)> GetCompanyCertificateDocumentDataAsync(Guid documentId);
+
     Task<(Guid DocumentId, DocumentStatusId DocumentStatusId, IEnumerable<Guid> CompanyCertificateId, bool IsSameCompany)> GetCompanyCertificateDocumentDetailsForIdUntrackedAsync(Guid documentId, Guid companyId);
 
     void AttachAndModifyCompanyCertificateDetails(Guid id, Action<CompanyCertificate>? initialize, Action<CompanyCertificate> updateFields);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyCertificateRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyCertificateRepository.cs
@@ -19,9 +19,7 @@
 
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
@@ -70,7 +68,7 @@ public interface ICompanyCertificateRepository
     /// </summary>
     /// <param name="documentId">id of the document</param>   
     /// <returns>Returns the document data</returns>
-    Task<(byte[]? Content, string FileName, MediaTypeId MediaTypeId)> GetCompanyCertificateDocumentDataAsync(Guid documentId);
+    Task<(byte[] Content, string FileName, MediaTypeId MediaTypeId, bool IsExist)> GetCompanyCertificateDocumentDataAsync(Guid documentId, DocumentTypeId documentTypeId);
 
     Task<(Guid DocumentId, DocumentStatusId DocumentStatusId, IEnumerable<Guid> CompanyCertificateId, bool IsSameCompany)> GetCompanyCertificateDocumentDetailsForIdUntrackedAsync(Guid documentId, Guid companyId);
 

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -42,6 +42,7 @@ public class CompanyDataBusinessLogicTests
     private readonly IIdentityData _identity;
     private readonly Guid _traceabilityExternalTypeDetailId = Guid.NewGuid();
     private readonly Guid _validCredentialId = Guid.NewGuid();
+    private static readonly Guid ValidDocumentId = Guid.NewGuid();
     private readonly IFixture _fixture;
     private readonly IPortalRepositories _portalRepositories;
     private readonly IConsentRepository _consentRepository;
@@ -1670,6 +1671,26 @@ public class CompanyDataBusinessLogicTests
 
     #endregion
 
+    #region GetCompanyCertificateDocuments
+
+    [Fact]
+    public async Task GetCompanyCertificateDocumentAsync_WithValidData_ReturnsExpected()
+    {
+        // Arrange
+        SetupFakesForGetDocument();
+        var sut = _fixture.Create<CompanyDataBusinessLogic>();
+
+        // Act
+        var result = await sut.GetCompanyCertificateDocumentAsync(ValidDocumentId).ConfigureAwait(false);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.FileName.Should().Be("test.pdf");
+        result.MediaType.Should().Be("application/pdf");
+    }
+
+    #endregion
+
     #region DeleteCompanyCertificates
 
     [Fact]
@@ -1777,5 +1798,11 @@ public class CompanyDataBusinessLogicTests
         A.CallTo(() => _portalRepositories.GetInstance<ICompanyCertificateRepository>()).Returns(_companyCertificateRepository);
     }
 
+    private void SetupFakesForGetDocument()
+    {
+        var content = new byte[7];
+        A.CallTo(() => _companyCertificateRepository.GetCompanyCertificateDocumentDataAsync(ValidDocumentId))
+            .ReturnsLazily(() => new ValueTuple<byte[], string, MediaTypeId>(content, "test.pdf", MediaTypeId.PDF));
+    }
     #endregion
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -1702,6 +1702,21 @@ public class CompanyDataBusinessLogicTests
         ex.Message.Should().Be($"Company certificate document {documentId} does not exist");
     }
 
+    [Fact]
+    public async Task GetCompanyCertificateDocumentAsync_WithDocumentStatusIsNotLocked_ThrowsNotFoundException()
+    {
+        // Arrange
+        var documentId = new Guid("aaf53459-c36b-408e-a805-0b406ce9751d");
+        SetupFakesForGetDocument();
+
+        // Act
+        async Task Act() => await _sut.GetCompanyCertificateDocumentAsync(documentId).ConfigureAwait(false);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
+        ex.Message.Should().Be($"Document {documentId} status is not Locked");
+    }
+
     #endregion
 
     #region DeleteCompanyCertificates
@@ -1815,7 +1830,9 @@ public class CompanyDataBusinessLogicTests
     {
         var content = new byte[7];
         A.CallTo(() => _companyCertificateRepository.GetCompanyCertificateDocumentDataAsync(ValidDocumentId, DocumentTypeId.COMPANY_CERTIFICATE))
-            .ReturnsLazily(() => new ValueTuple<byte[], string, MediaTypeId, bool>(content, "test.pdf", MediaTypeId.PDF, true));
+            .ReturnsLazily(() => new ValueTuple<byte[], string, MediaTypeId, bool, bool>(content, "test.pdf", MediaTypeId.PDF, true, true));
+        A.CallTo(() => _companyCertificateRepository.GetCompanyCertificateDocumentDataAsync(new Guid("aaf53459-c36b-408e-a805-0b406ce9751d"), DocumentTypeId.COMPANY_CERTIFICATE))
+            .ReturnsLazily(() => new ValueTuple<byte[], string, MediaTypeId, bool, bool>(content, "test1.pdf", MediaTypeId.PDF, true, false));
     }
     #endregion
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -43,6 +43,7 @@ public class CompanyDataBusinessLogicTests
     private readonly Guid _traceabilityExternalTypeDetailId = Guid.NewGuid();
     private readonly Guid _validCredentialId = Guid.NewGuid();
     private static readonly Guid ValidDocumentId = Guid.NewGuid();
+    private static readonly Guid ValidDocumentId = Guid.NewGuid();
     private readonly IFixture _fixture;
     private readonly IPortalRepositories _portalRepositories;
     private readonly IConsentRepository _consentRepository;

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -42,8 +42,7 @@ public class CompanyDataBusinessLogicTests
     private readonly IIdentityData _identity;
     private readonly Guid _traceabilityExternalTypeDetailId = Guid.NewGuid();
     private readonly Guid _validCredentialId = Guid.NewGuid();
-    private static readonly Guid ValidDocumentId = Guid.NewGuid();
-    private static readonly Guid ValidDocumentId = Guid.NewGuid();
+    private static readonly Guid _validDocumentId = Guid.NewGuid();
     private readonly IFixture _fixture;
     private readonly IPortalRepositories _portalRepositories;
     private readonly IConsentRepository _consentRepository;
@@ -1680,7 +1679,7 @@ public class CompanyDataBusinessLogicTests
         SetupFakesForGetDocument();
 
         // Act
-        var result = await _sut.GetCompanyCertificateDocumentAsync(ValidDocumentId).ConfigureAwait(false);
+        var result = await _sut.GetCompanyCertificateDocumentAsync(_validDocumentId).ConfigureAwait(false);
 
         // Assert
         result.Should().NotBeNull();
@@ -1830,7 +1829,7 @@ public class CompanyDataBusinessLogicTests
     private void SetupFakesForGetDocument()
     {
         var content = new byte[7];
-        A.CallTo(() => _companyCertificateRepository.GetCompanyCertificateDocumentDataAsync(ValidDocumentId, DocumentTypeId.COMPANY_CERTIFICATE))
+        A.CallTo(() => _companyCertificateRepository.GetCompanyCertificateDocumentDataAsync(_validDocumentId, DocumentTypeId.COMPANY_CERTIFICATE))
             .ReturnsLazily(() => new ValueTuple<byte[], string, MediaTypeId, bool, bool>(content, "test.pdf", MediaTypeId.PDF, true, true));
         A.CallTo(() => _companyCertificateRepository.GetCompanyCertificateDocumentDataAsync(new Guid("aaf53459-c36b-408e-a805-0b406ce9751d"), DocumentTypeId.COMPANY_CERTIFICATE))
             .ReturnsLazily(() => new ValueTuple<byte[], string, MediaTypeId, bool, bool>(content, "test1.pdf", MediaTypeId.PDF, true, false));

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -1714,7 +1714,7 @@ public class CompanyDataBusinessLogicTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
-        ex.Message.Should().Be($"Document {documentId} status is not Locked");
+        ex.Message.Should().Be($"Document {documentId} status is not locked");
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyCertificateRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyCertificateRepositoryTests.cs
@@ -183,6 +183,38 @@ public class CompanyCertificateRepositoryTests
 
     #endregion
 
+    #region GetCompanyCertificateDocumentContentFile
+
+    [Fact]
+    public async Task GetCompanyCertificateDocumentContentFile_WithValidData_ReturnsExpectedDocument()
+    {
+        // Arrange
+        var sut = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetCompanyCertificateDocumentDataAsync(new Guid("aaf53459-c36b-408e-a805-0b406ce9751f")).ConfigureAwait(false);
+
+        // Assert
+        result.Should().NotBe(default);
+        result.FileName.Should().Be("AdditionalServiceDetails2.pdf");
+        result.MediaTypeId.Should().Be(MediaTypeId.PDF);
+    }
+
+    [Fact]
+    public async Task GetCompanyCertificateDocumentContentFile_WithNotExistingDocument_ReturnsDefault()
+    {
+        // Arrange
+        var sut = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetCompanyCertificateDocumentDataAsync(Guid.NewGuid()).ConfigureAwait(false);
+
+        // Assert
+        result.Should().Be(default);
+    }
+
+    #endregion
+
     #region DeleteCertificate
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyCertificateRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyCertificateRepositoryTests.cs
@@ -192,7 +192,7 @@ public class CompanyCertificateRepositoryTests
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetCompanyCertificateDocumentDataAsync(new Guid("aaf53459-c36b-408e-a805-0b406ce9751f")).ConfigureAwait(false);
+        var result = await sut.GetCompanyCertificateDocumentDataAsync(new Guid("aaf53459-c36b-408e-a805-0b406ce9751f"), DocumentTypeId.COMPANY_CERTIFICATE).ConfigureAwait(false);
 
         // Assert
         result.Should().NotBe(default);
@@ -207,7 +207,7 @@ public class CompanyCertificateRepositoryTests
         var sut = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetCompanyCertificateDocumentDataAsync(Guid.NewGuid()).ConfigureAwait(false);
+        var result = await sut.GetCompanyCertificateDocumentDataAsync(Guid.NewGuid(), DocumentTypeId.COMPANY_CERTIFICATE).ConfigureAwait(false);
 
         // Assert
         result.Should().Be(default);


### PR DESCRIPTION
## Description

Enable companies to fetch any company certificate(s) via the document ID
GET /api/administration/companydata/companyCertificates/documents/{documentId}

## Why

user can fetch documents of other companies as long as the document is "ACTIVE"
document type of the fetched document must be "Company_Certificate" (table documents.document_type)
Exception Cases / Error:
trying to fetch a document which does not exist
trying to fetch a document which is not in status "LOCKED"
trying to fetch a document of another document type

## Issue

#462 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
