### PR TITLE
fix(decline): adjust mail sending

### DIFF
--- a/src/provisioning/Provisioning.Library/ProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningManager.cs
@@ -72,13 +72,9 @@ public partial class ProvisioningManager : IProvisioningManager
 
     public async ValueTask DeleteSharedIdpRealmAsync(string alias)
     {
-        var sharedKeycloak = _Factory.CreateKeycloakClient("shared");
-        var sharedIdp = _Factory.CreateKeycloakClient("shared");
-        var clientId = GetServiceAccountClientId(alias);
-        var internalClientId = await GetInternalClientIdOfSharedIdpServiceAccount(sharedIdp, clientId).ConfigureAwait(false);
-        var credentials = await sharedIdp.GetClientSecretAsync("master", internalClientId).ConfigureAwait(false);
-        var deleteSharedKeycloak = _Factory.CreateKeycloakClient("shared", clientId, credentials.Value);
+        var deleteSharedKeycloak = await GetSharedKeycloakClient(alias).ConfigureAwait(false);
         await deleteSharedKeycloak.DeleteRealmAsync(alias).ConfigureAwait(false);
+        var sharedKeycloak = _Factory.CreateKeycloakClient("shared");
         await DeleteSharedIdpServiceAccountAsync(sharedKeycloak, alias);
     }
 


### PR DESCRIPTION
## Description

* get users to send mails to before deactivating them
* cleanup delete shared realm call

## Why

No mail is send when declining an application because all users got set to deleted before getting them for the mail sending

## Issue

Refs: #525

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
