### PR TITLE
chore(iam): add user.session.note from client protocol mapper to seeding

### DIFF
--- a/src/keycloak/Keycloak.Library/Models/Clients/ClientConfig.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/ClientConfig.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021, 2023 BMW Group AG
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 BMW Group AG
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,4 +46,7 @@ public class ClientConfig
     public string? FriendlyName { get; set; }
     [JsonProperty("attribute.name")]
     public string? AttributeName { get; set; }
+
+    [JsonProperty("user.session.note")]
+    public string? UserSessionNote { get; set; }
 }

--- a/src/keycloak/Keycloak.Library/Models/ProtocolMappers/Config.cs
+++ b/src/keycloak/Keycloak.Library/Models/ProtocolMappers/Config.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021, 2023 BMW Group AG
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 BMW Group AG
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -64,4 +64,7 @@ public class Config
     public string? IncludedClientAudience { get; set; }
     [JsonProperty("multivalued")]
     public string? Multivalued { get; set; }
+
+    [JsonProperty("user.session.note")]
+    public string? UserSessionNote { get; set; }
 }

--- a/src/keycloak/Keycloak.Seeding/BusinessLogic/ClientsUpdater.cs
+++ b/src/keycloak/Keycloak.Seeding/BusinessLogic/ClientsUpdater.cs
@@ -232,5 +232,6 @@ public class ClientsUpdater : IClientsUpdater
         config.ClaimName == update.GetValueOrDefault("claim.name") &&
         config.JsonTypelabel == update.GetValueOrDefault("jsonType.label") &&
         config.FriendlyName == update.GetValueOrDefault("friendly.name") &&
-        config.AttributeName == update.GetValueOrDefault("attribute.name");
+        config.AttributeName == update.GetValueOrDefault("attribute.name") &&
+        config.UserSessionNote == update.GetValueOrDefault("user.session.note");
 }

--- a/src/keycloak/Keycloak.Seeding/BusinessLogic/ProtocolMappersUpdater.cs
+++ b/src/keycloak/Keycloak.Seeding/BusinessLogic/ProtocolMappersUpdater.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 BMW Group AG
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -63,7 +63,8 @@ public static class ProtocolMappersUpdater
             UserAttributeRegion = update.GetValueOrDefault("user.attribute.region"),
             UserAttributeLocality = update.GetValueOrDefault("user.attribute.locality"),
             IncludedClientAudience = update.GetValueOrDefault("included.client.audience"),
-            Multivalued = update.GetValueOrDefault("multivalued")
+            Multivalued = update.GetValueOrDefault("multivalued"),
+            UserSessionNote = update.GetValueOrDefault("user.session.note"),
         };
 
     private static bool CompareProtocolMapperConfig(Config config, IReadOnlyDictionary<string, string> update) =>
@@ -83,5 +84,6 @@ public static class ProtocolMappersUpdater
             config.UserAttributeRegion == update.GetValueOrDefault("user.attribute.region") &&
             config.UserAttributeLocality == update.GetValueOrDefault("user.attribute.locality") &&
             config.IncludedClientAudience == update.GetValueOrDefault("included.client.audience") &&
-            config.Multivalued == update.GetValueOrDefault("multivalued");
+            config.Multivalued == update.GetValueOrDefault("multivalued") &&
+            config.UserSessionNote == update.GetValueOrDefault("user.session.note");
 }


### PR DESCRIPTION
## Description

add user.session.note from client protocol mapper to iam seeding

## Why

needed for realm config upgrade

## Issue

https://github.com/eclipse-tractusx/portal-iam/issues/47

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally