### PR TITLE
fix(administration): fix routing for retrigger-validate-did

### DIFF
--- a/src/administration/Administration.Service/Controllers/RegistrationController.cs
+++ b/src/administration/Administration.Service/Controllers/RegistrationController.cs
@@ -422,7 +422,7 @@ public class RegistrationController : ControllerBase
     [HttpPost]
     [Authorize(Roles = "approve_new_partner")]
     [Authorize(Policy = PolicyTypes.CompanyUser)]
-    [Route("application/{applicationId}/retrigger-clearinghouse")]
+    [Route("application/{applicationId}/retrigger-validate-did")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]


### PR DESCRIPTION
## Description

Fixed the routing for the /retrigger-validate-did endpoint

## Why

Swagger isn't loading because of a duplicate route.

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
