### PR TITLE
fix(mailing): add subject for NewUserExternalIdpTemplate

### DIFF
--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -472,7 +472,7 @@
       {
         "Name": "NewUserExternalIdpTemplate",
         "Setting": {
-          "Subject": "",
+          "Subject": "Welcome as new user to the Catena-X Network",
           "EmailTemplateType": "NewUserAccountExternalIdp"
         }
       },


### PR DESCRIPTION

## Description

Add subject for mail template

## Why

The process worker fails when starting due to the missing subject

## Issue

Refs: #483

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
