### PR TITLE
fix(networkRegistration): adjust mail tempalte

### DIFF
--- a/src/processes/NetworkRegistration.Library/NetworkRegistrationHandler.cs
+++ b/src/processes/NetworkRegistration.Library/NetworkRegistrationHandler.cs
@@ -168,7 +168,7 @@ public class NetworkRegistrationHandler : INetworkRegistrationHandler
                 KeyValuePair.Create("url", _settings.BasePortalAddress),
                 KeyValuePair.Create("idpAlias", string.Join(",", displayNames))
             });
-            _mailingProcessCreation.CreateMailProcess(receiver, "CredentialRejected", mailParameters);
+            _mailingProcessCreation.CreateMailProcess(receiver, "OspWelcomeMail", mailParameters);
         }
     }
 

--- a/tests/processes/NetworkRegistration.Library.Tests/NetworkRegistrationHandlerTests.cs
+++ b/tests/processes/NetworkRegistration.Library.Tests/NetworkRegistrationHandlerTests.cs
@@ -234,11 +234,11 @@ public class NetworkRegistrationHandlerTests
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => _userRepository.AttachAndModifyIdentity(user2.CompanyUserId, A<Action<Identity>>._, A<Action<Identity>>._))
             .MustNotHaveHappened();
-        A.CallTo(() => _mailingProcessCreation.CreateMailProcess("tony@stark.com", "CredentialRejected", A<IReadOnlyDictionary<string, string>>.That.Matches(x => x["idpAlias"] == "DisplayName for Idp1")))
+        A.CallTo(() => _mailingProcessCreation.CreateMailProcess("tony@stark.com", "OspWelcomeMail", A<IReadOnlyDictionary<string, string>>.That.Matches(x => x["idpAlias"] == "DisplayName for Idp1")))
             .MustHaveHappenedOnceExactly();
-        A.CallTo(() => _mailingProcessCreation.CreateMailProcess("steven@strange.com", "CredentialRejected", A<IReadOnlyDictionary<string, string>>.That.Matches(x => x["idpAlias"] == "DisplayName for Idp1")))
+        A.CallTo(() => _mailingProcessCreation.CreateMailProcess("steven@strange.com", "OspWelcomeMail", A<IReadOnlyDictionary<string, string>>.That.Matches(x => x["idpAlias"] == "DisplayName for Idp1")))
             .MustHaveHappenedOnceExactly();
-        A.CallTo(() => _mailingProcessCreation.CreateMailProcess("foo@bar.com", "CredentialRejected", A<IReadOnlyDictionary<string, string>>.That.Matches(x => x["idpAlias"] == "DisplayName for Idp2")))
+        A.CallTo(() => _mailingProcessCreation.CreateMailProcess("foo@bar.com", "OspWelcomeMail", A<IReadOnlyDictionary<string, string>>.That.Matches(x => x["idpAlias"] == "DisplayName for Idp2")))
             .MustHaveHappenedOnceExactly();
 
         result.modified.Should().BeFalse();


### PR DESCRIPTION
## Description

Adjusting the mail template that's send out after the network registration from 'CredentialRejected' to 'OspWelcomeMail'

## Why

To send out the correct template

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
