### PR TITLE
chore: add dependabot.yml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+###############################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+---
+version: 2
+updates:
+  # NuGet
+  -
+    package-ecosystem: "nuget"
+    target-branch: dev
+    directory: /
+    labels:
+      - "dependabot"
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # Github Actions
+  -
+    package-ecosystem: "github-actions"
+    target-branch: dev
+    directory: /
+    labels:
+      - "dependabot"
+      - "github-actions"
+    schedule:
+      interval: "weekly"
+
+  # Docker
+  -
+    package-ecosystem: "docker"
+    target-branch: dev
+    directory: ./docker/
+    labels:
+      - "dependabot"
+      - "docker"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Description

chore: add dependabot.yml file

## Why

https://github.com/eclipse-tractusx/portal/issues/219

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes