### PR TITLE
feat: changed policyType to trigger by technicalUsers

### DIFF
--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -99,7 +99,7 @@ public class ServiceAccountController : ControllerBase
     /// <response code="409">Undefined client for service account.</response>
     [HttpGet]
     [Authorize(Roles = "view_tech_user_management")]
-    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [Authorize(Policy = PolicyTypes.ServiceAccount)]
     [Route("owncompany/serviceaccounts/{serviceAccountId}", Name = "GetServiceAccountDetails")]
     [ProducesResponseType(typeof(ServiceAccountConnectorOfferData), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -233,7 +233,7 @@ public class AppsController : ControllerBase
     [Route("/subscription/{subscriptionId}/activate")]
     [Authorize(Roles = "activate_subscription")]
     [Authorize(Policy = PolicyTypes.ValidIdentity)]
-    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [Authorize(Policy = PolicyTypes.ServiceAccount)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
@@ -375,7 +375,7 @@ public class AppsController : ControllerBase
     /// <response code="404">No app or subscription found.</response>
     [HttpGet]
     [Authorize(Roles = "app_management")]
-    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [Authorize(Policy = PolicyTypes.ServiceAccount)]
     [Route("{appId}/subscription/{subscriptionId}/provider")]
     [ProducesResponseType(typeof(AppProviderSubscriptionDetailData), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]


### PR DESCRIPTION
## Description

changed policyType to trigger by technicalUsers

## Why

Changed policyType for endpoints to trigger by technicalUsers

## Issue

Ref : #500

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
