### PR TITLE
fix: fixed isOwner filter

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
@@ -29,6 +29,7 @@ public record CompanyServiceAccountData(
     [property: JsonPropertyName("name")] string Name,
     [property: JsonPropertyName("serviceAccountType")] CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
     [property: JsonPropertyName("isOwner")] bool IsOwner,
+    [property: JsonPropertyName("isProvider")] bool IsProvider,
     [property: JsonPropertyName("offerSubscriptionId")] Guid? OfferSubscriptionId,
     [property: JsonPropertyName("connector")] ConnectorResponseData? ConnectorData,
     [property: JsonPropertyName("offer")] OfferResponseData? OfferSubscriptionsData

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -155,9 +155,8 @@ public class ServiceAccountRepository : IServiceAccountRepository
                 .AsNoTracking()
                 .Where(serviceAccount =>
                     (!isOwner.HasValue && (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) ||
-                    isOwner.HasValue &&
-                        (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN ||
-                        !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED)) &&
+                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId ||
+                        !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId)) &&
                     serviceAccount.Identity!.UserStatusId == userStatusId &&
                     (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
                 .GroupBy(serviceAccount => serviceAccount.Identity!.UserStatusId),
@@ -167,7 +166,8 @@ public class ServiceAccountRepository : IServiceAccountRepository
                 serviceAccount.ClientClientId,
                 serviceAccount.Name,
                 serviceAccount.CompanyServiceAccountTypeId,
-                serviceAccount.CompaniesLinkedServiceAccount!.Provider == null,
+                serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId,
+                serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId,
                 serviceAccount.OfferSubscriptionId,
                 serviceAccount.Connector == null
                     ? null

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -155,8 +155,9 @@ public class ServiceAccountRepository : IServiceAccountRepository
                 .AsNoTracking()
                 .Where(serviceAccount =>
                     (!isOwner.HasValue && (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) ||
-                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN ||
-                    !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED)) &&
+                    isOwner.HasValue &&
+                        (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN ||
+                        !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED)) &&
                     serviceAccount.Identity!.UserStatusId == userStatusId &&
                     (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
                 .GroupBy(serviceAccount => serviceAccount.Identity!.UserStatusId),

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -155,7 +155,8 @@ public class ServiceAccountRepository : IServiceAccountRepository
                 .AsNoTracking()
                 .Where(serviceAccount =>
                     (!isOwner.HasValue && (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) ||
-                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId)) &&
+                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN ||
+                    !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED)) &&
                     serviceAccount.Identity!.UserStatusId == userStatusId &&
                     (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
                 .GroupBy(serviceAccount => serviceAccount.Identity!.UserStatusId),

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -256,6 +256,36 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
     }
 
     [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithOwnerTrue_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, true, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
+
+        // Assert
+        result!.Count.Should().Be(13);
+        result.Data.Should().HaveCount(10)
+            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN);
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithOwnerFalse_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, false, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
+
+        // Assert
+        result!.Count.Should().Be(1);
+        result.Data.Should().HaveCount(1)
+            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED);
+    }
+
+    [Fact]
     public async Task GetOwnCompanyServiceAccountsUntracked_WithClientIdAndProvider_ReturnsExpectedResult()
     {
         // Arrange

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -294,7 +294,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         result!.Count.Should().Be(1);
         result.Data.Should().HaveCount(1)
             .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED
-                && x.IsOwner == false && x.IsProvider == true);
+                && !x.IsOwner && x.IsProvider);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -236,7 +236,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         if (expected > 0)
         {
             result.Data.First().CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.MANAGED);
-            result.Data.First().IsOwner.Should().BeFalse();
+            result.Data.First().IsOwner.Should().BeTrue();
+            result.Data.First().IsProvider.Should().BeFalse();
         }
     }
 
@@ -292,7 +293,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result!.Count.Should().Be(1);
         result.Data.Should().HaveCount(1)
-            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED);
+            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED
+                && x.IsOwner == false && x.IsProvider == true);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -267,7 +267,17 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result!.Count.Should().Be(13);
         result.Data.Should().HaveCount(10)
-            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN);
+            .And.Satisfy(
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201029"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201026"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201027"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201030"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201031"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201032"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201023"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201024"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201028"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("d0c8ae19-d4f3-49cc-9cb4-6c766d4680f2"));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

fixed isOwner filter

## Why

when hitting GET: api/administration/serviceaccount/owncompany/serviceaccounts with isOwner flag as true it results
companyServiceAccountTypeIds as Managed Type records instead of showing only Own Type records, now it is fixed by adding additional check condition

## Issue

Ref : #563

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
