### PR TITLE
fix: Company Registration - Retrieve CompanyUniqueIdData

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -35,9 +35,9 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
+using Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
-using Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
 using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -123,7 +123,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
                     x.FirstName ?? "",
                     x.LastName ?? "",
                     x.Email ?? "")),
-            companyWithAddress.CompanyIdentifiers.Select(identifier => new UniqueIdentifierData((int)identifier.UniqueIdentifierId, identifier.UniqueIdentifierId))
+            companyWithAddress.CompanyIdentifiers.Select(identifier => new UniqueIdentifierData(identifier.UniqueIdentifierId, identifier.Value))
         );
     }
 

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -37,6 +37,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
 using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
@@ -123,7 +124,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
                     x.FirstName ?? "",
                     x.LastName ?? "",
                     x.Email ?? "")),
-            companyWithAddress.CompanyIdentifiers.Select(identifier => new UniqueIdentifierData(identifier.UniqueIdentifierId, identifier.Value))
+            companyWithAddress.CompanyIdentifiers.Select(identifier => new CompanyUniqueIdData(identifier.UniqueIdentifierId, identifier.Value))
         );
     }
 

--- a/src/administration/Administration.Service/Models/CompanyWithAddressData.cs
+++ b/src/administration/Administration.Service/Models/CompanyWithAddressData.cs
@@ -21,7 +21,6 @@
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
-
 using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;

--- a/src/administration/Administration.Service/Models/CompanyWithAddressData.cs
+++ b/src/administration/Administration.Service/Models/CompanyWithAddressData.cs
@@ -20,6 +20,8 @@
 
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
+
 using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
@@ -57,7 +59,7 @@ public record CompanyWithAddressData(
     string ZipCode,
     [property: JsonPropertyName("companyRoles")] IEnumerable<AgreementsRoleData> AgreementsRoleData,
     [property: JsonPropertyName("companyUser")] IEnumerable<InvitedUserData> InvitedUserData,
-    IEnumerable<UniqueIdentifierData> UniqueIds
+    IEnumerable<CompanyUniqueIdData> UniqueIds
 );
 
 /// <summary>

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -34,10 +34,10 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
+using Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
-using Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
 using System.Collections.Immutable;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.BusinessLogic;

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -169,13 +169,21 @@ public class RegistrationBusinessLogicTest
 
     #region GetCompanyWithAddressAsync
 
-    [Fact]
-    public async Task GetCompanyWithAddressAsync_WithDefaultRequest_GetsExpectedResult()
+    
+    [Theory]
+    [InlineData(UniqueIdentifierId.VAT_ID, "DE124356789")]
+    [InlineData(UniqueIdentifierId.VAT_ID, "DE233456789")]
+    [InlineData(UniqueIdentifierId.VAT_ID, "DE123124145")]
+    [InlineData(UniqueIdentifierId.LEI_CODE, "213800WSGIIZCXF1P572")]
+    [InlineData(UniqueIdentifierId.LEI_CODE, "54930084UKLVMY22DS16")]
+    [InlineData(UniqueIdentifierId.LEI_CODE, "5493000IBP32UQZ0KL24")]
+    public async Task GetCompanyWithAddressAsync_WithDefaultRequest_GetsExpectedResult(UniqueIdentifierId identifierIdType, string companyUniqueIds)
     {
         // Arrange
         var applicationId = _fixture.Create<Guid>();
         var data = _fixture.Build<CompanyUserRoleWithAddress>()
             .With(x => x.AgreementsData, _fixture.CreateMany<AgreementsData>(20))
+            .With(x => x.CompanyIdentifiers, Enumerable.Repeat(new ValueTuple<UniqueIdentifierId, string>(identifierIdType, companyUniqueIds), 1))
             .Create();
         A.CallTo(() => _applicationRepository.GetCompanyUserRoleWithAddressUntrackedAsync(applicationId))
             .Returns(data);
@@ -202,6 +210,7 @@ public class RegistrationBusinessLogicTest
         result.AgreementsRoleData.Should().HaveSameCount(data.AgreementsData.DistinctBy(ad => ad.CompanyRoleId));
         result.InvitedUserData.Should().HaveSameCount(data.InvitedCompanyUserData);
         result.UniqueIds.Should().HaveSameCount(data.CompanyIdentifiers);
+        result.UniqueIds.Should().AllSatisfy(u => u.Should().Match<CompanyUniqueIdData>(u => u.UniqueIdentifierId == identifierIdType && u.Value == companyUniqueIds));
     }
 
     [Fact]

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -37,6 +37,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
+using Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
 using System.Collections.Immutable;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.BusinessLogic;
@@ -169,14 +170,12 @@ public class RegistrationBusinessLogicTest
 
     #region GetCompanyWithAddressAsync
 
-    
     [Theory]
     [InlineData(UniqueIdentifierId.VAT_ID, "DE124356789")]
-    [InlineData(UniqueIdentifierId.VAT_ID, "DE233456789")]
-    [InlineData(UniqueIdentifierId.VAT_ID, "DE123124145")]
-    [InlineData(UniqueIdentifierId.LEI_CODE, "213800WSGIIZCXF1P572")]
     [InlineData(UniqueIdentifierId.LEI_CODE, "54930084UKLVMY22DS16")]
-    [InlineData(UniqueIdentifierId.LEI_CODE, "5493000IBP32UQZ0KL24")]
+    [InlineData(UniqueIdentifierId.EORI, "DE123456789012345")]
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "HRB123456")]
+    [InlineData(UniqueIdentifierId.VIES, "ATU99999999")]
     public async Task GetCompanyWithAddressAsync_WithDefaultRequest_GetsExpectedResult(UniqueIdentifierId identifierIdType, string companyUniqueIds)
     {
         // Arrange


### PR DESCRIPTION
## Description
Revert accidental change introduced from 1.6 -> 1.7. 
To GetCompanyWithAddressAsync: 
 * Use identifier.Value instead of repeating its type. 
 * Use CompanyUniqueIdData instead of UniqueIdentifierData 
Resolves issue with displaying identifier in /applicationrequests

Also extended tests. 

## Why
Frontend was not showing company identifier data in registration process due to this backend issue. See #606. 

## Issue
Closes #606 

## Checklist

Please delete options that are not relevant.
- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have not added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally and in Cofinity-X environments
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes

