### PR TITLE
chore(iam-seeding): remove service-account and onboard CX-Test-Access(consortia)

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/application_checklist.consortia.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/application_checklist.consortia.json
@@ -286,5 +286,53 @@
     "date_last_changed": null,
     "application_checklist_entry_status_id": 3,
     "comment": null
+  },
+  {
+    "application_id": "6b2d1263-c073-4a48-bfaf-704dc154ca9f",
+    "application_checklist_entry_type_id": 1,
+    "date_created": "2023-01-18 12:46:57.583000 +00:00",
+    "date_last_changed": null,
+    "application_checklist_entry_status_id": 3,
+    "comment": null
+  },
+  {
+    "application_id": "6b2d1263-c073-4a48-bfaf-704dc154ca9f",
+    "application_checklist_entry_type_id": 2,
+    "date_created": "2023-01-18 12:46:57.583000 +00:00",
+    "date_last_changed": null,
+    "application_checklist_entry_status_id": 3,
+    "comment": null
+  },
+  {
+    "application_id": "6b2d1263-c073-4a48-bfaf-704dc154ca9f",
+    "application_checklist_entry_type_id": 3,
+    "date_created": "2023-01-18 12:46:57.583000 +00:00",
+    "date_last_changed": "2023-01-20 07:44:39.669032 +00:00",
+    "application_checklist_entry_status_id": 3,
+    "comment": null
+  },
+  {
+    "application_id": "6b2d1263-c073-4a48-bfaf-704dc154ca9f",
+    "application_checklist_entry_type_id": 4,
+    "date_created": "2023-01-18 12:46:57.583000 +00:00",
+    "date_last_changed": null,
+    "application_checklist_entry_status_id": 3,
+    "comment": null
+  },
+  {
+    "application_id": "6b2d1263-c073-4a48-bfaf-704dc154ca9f",
+    "application_checklist_entry_type_id": 5,
+    "date_created": "2023-01-18 12:46:57.583000 +00:00",
+    "date_last_changed": null,
+    "application_checklist_entry_status_id": 3,
+    "comment": null
+  },
+  {
+    "application_id": "6b2d1263-c073-4a48-bfaf-704dc154ca9f",
+    "application_checklist_entry_type_id": 6,
+    "date_created": "2023-01-18 12:46:57.583000 +00:00",
+    "date_last_changed": null,
+    "application_checklist_entry_status_id": 3,
+    "comment": null
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_applications.consortia.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_applications.consortia.json
@@ -65,7 +65,8 @@
     "application_status_id": 8,
     "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f88",
     "company_application_type_id": 1,
-    "last_editor_id": null
+    "last_editor_id": null,
+    "checklist_process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece"
   },
   {
     "id": "6b2d1263-c073-4a48-bfaf-704dc154ca9c",

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_applications.consortia.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_applications.consortia.json
@@ -62,7 +62,7 @@
     "id": "6b2d1263-c073-4a48-bfaf-704dc154ca9f",
     "date_created": "2022-03-24 18:01:33.439000 +00:00",
     "date_last_changed": "2022-03-24 18:01:33.439000 +00:00",
-    "application_status_id": 3,
+    "application_status_id": 8,
     "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f88",
     "company_application_type_id": 1,
     "last_editor_id": null

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
@@ -1,16 +1,8 @@
 [
   {
-    "id": "7e85a0b8-0001-ab67-10d1-0ef508201006",
-    "name": "Service Account 01",
-    "description": "Technical User for SD Hub Call to Custodian for SD signature",
-    "company_service_account_type_id": 2,
-    "client_id": "dab9dd17-0d31-46c7-b313-aca61225dcd1",
-    "client_client_id": "sa-cl5-custodian-1"
-  },
-  {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201007",
-    "name": "Service Account 02",
-    "description": "Technical User for Portal to call Custodian Wallet",
+    "name": "sa-cl5-custodian-2",
+    "description": "Technical User for Portal to call Managed Identity Wallet",
     "company_service_account_type_id": 2,
     "client_id": "50fa6455-a775-4683-b407-57a33a9b9f3b",
     "client_client_id": "sa-cl5-custodian-2"

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
@@ -10,14 +10,6 @@
     "identity_type_id": 1
   },
   {
-    "id": "7e85a0b8-0001-ab67-10d1-0ef508201006",
-    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
-    "date_created": "2022-06-01 18:01:33.439000 +00:00",
-    "user_status_id": 1,
-    "user_entity_id": "6e9d388a-1a21-4196-8210-80e9a696ae87",
-    "identity_type_id": 2
-  },
-  {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201007",
     "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
     "date_created": "2022-06-01 18:01:33.439000 +00:00",

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/process_steps.consortia.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/process_steps.consortia.json
@@ -350,5 +350,109 @@
     "process_id": "09d27ace-342d-47b2-8080-125f59fea6b0",
     "date_created": "2023-02-21 08:15:20.479000 +00:00",
     "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3940",
+    "process_step_type_id": 2,
+    "process_step_status_id": 2,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3941",
+    "process_step_type_id": 3,
+    "process_step_status_id": 4,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3942",
+    "process_step_type_id": 14,
+    "process_step_status_id": 3,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3943",
+    "process_step_type_id": 4,
+    "process_step_status_id": 2,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3944",
+    "process_step_type_id": 1,
+    "process_step_status_id": 2,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3945",
+    "process_step_type_id": 11,
+    "process_step_status_id": 1,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3946",
+    "process_step_type_id": 5,
+    "process_step_status_id": 1,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3947",
+    "process_step_type_id": 7,
+    "process_step_status_id": 2,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3948",
+    "process_step_type_id": 19,
+    "process_step_status_id": 1,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd3949",
+    "process_step_type_id": 10,
+    "process_step_status_id": 2,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd394a",
+    "process_step_type_id": 18,
+    "process_step_status_id": 2,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd394b",
+    "process_step_type_id": 12,
+    "process_step_status_id": 2,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "ad06aefd-6b37-455d-b26e-2a8feccd394c",
+    "process_step_type_id": 9,
+    "process_step_status_id": 2,
+    "process_id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "date_created": "2023-02-21 08:15:20.479000 +00:00",
+    "date_last_changed": null
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/processes.consortia.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/processes.consortia.json
@@ -34,5 +34,11 @@
     "process_type_id" : 1,
     "lock_expiry_date" : null,
     "version" : "deadbeef-dead-beef-dead-beefdeadbeef"
+  },
+  {
+    "id": "4d3676ae-c4fd-4a5c-a13e-5764ee1c4ece",
+    "process_type_id" : 1,
+    "lock_expiry_date" : null,
+    "version" : "deadbeef-dead-beef-dead-beefdeadbeef"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/AppInstanceRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/AppInstanceRepositoryTests.cs
@@ -126,7 +126,7 @@ public class AppInstanceRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetAssignedServiceAccounts(instanceId).ToListAsync();
 
         result.Should().HaveCount(1)
-            .And.ContainSingle().Which.Should().Be(new Guid("7e85a0b8-0001-ab67-10d1-0ef508201006"));
+            .And.ContainSingle().Which.Should().Be(new Guid("7e85a0b8-0001-ab67-10d1-0ef508201007"));
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/app_instance_assigned_company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/app_instance_assigned_company_service_accounts.test.json
@@ -1,6 +1,6 @@
 ﻿[
   {
     "app_instance_id": "ab25c218-9ab3-4f1a-b6f4-6394fbc33c5a",
-    "company_service_account_id": "7e85a0b8-0001-ab67-10d1-0ef508201006"
+    "company_service_account_id": "7e85a0b8-0001-ab67-10d1-0ef508201007"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -34,7 +34,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
     private readonly TestDbFixture _dbTestDbFixture;
     private readonly Guid _validCompanyId = new("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87");
     private readonly Guid _validSubscriptionId = new("eb98bdf5-14e1-4feb-a954-453eac0b93cd");
-    private readonly Guid _validServiceAccountId = new("7e85a0b8-0001-ab67-10d1-0ef508201006");
+    private readonly Guid _validServiceAccountId = new("7e85a0b8-0001-ab67-10d1-0ef508201007");
 
     public ServiceAccountRepositoryTests(TestDbFixture testDbFixture)
     {
@@ -124,7 +124,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBe(default);
-        result!.ClientClientId.Should().Be("sa-cl5-custodian-1");
+        result!.ClientClientId.Should().Be("sa-cl5-custodian-2");
     }
 
     [Fact]
@@ -247,7 +247,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-1", true, UserStatusId.ACTIVE)(0, 10);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-2", true, UserStatusId.ACTIVE)(0, 10);
 
         // Assert
         result!.Count.Should().Be(1);
@@ -277,7 +277,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-1", null, UserStatusId.ACTIVE)(0, 10);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-2", null, UserStatusId.ACTIVE)(0, 10);
 
         // Assert
         result!.Count.Should().Be(1);
@@ -295,7 +295,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null, UserStatusId.ACTIVE)(0, 10);
 
         // Assert
-        result!.Count.Should().Be(11);
+        result!.Count.Should().Be(10);
         result.Data.Should().HaveCount(10);
     }
 


### PR DESCRIPTION
## Description

- remove service account sa-cl5-custodian-1 and adjust tests
- rename service account sa-cl5-custodian-2
- onboard CX-Test-Access (consortia-test-data)

## Why

https://github.com/eclipse-tractusx/portal-iam/issues/66

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes