### PR TITLE
fix(seeding): add companyApplication to update seeder

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
@@ -151,6 +151,14 @@ public class BatchUpdateSeeder : ICustomSeeder
                 dbEntry.SelfDescriptionDocumentId = entry.SelfDescriptionDocumentId;
             }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 
+        await SeedTable<CompanyApplication>("company_applications",
+            x => x.Id,
+            x => x.dbEntity.ChecklistProcessId == null,
+            (dbEntry, entry) =>
+            {
+                dbEntry.ChecklistProcessId = entry.ChecklistProcessId;
+            }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+
         await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
         _logger.LogInformation("Finished BaseEntityBatch Seeder");
     }


### PR DESCRIPTION
## Description

Add CompanyApplications to the batchUpdateSeeder

## Why

To set the checklistProcessId for seeded companyApplications

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
