### PR TITLE
fix(registration): skip validation for bpn is empty

### DIFF
--- a/src/registration/Registration.Common/RegistrationValidation.cs
+++ b/src/registration/Registration.Common/RegistrationValidation.cs
@@ -30,7 +30,7 @@ public static class RegistrationValidation
 
     public static void ValidateData(this RegistrationData data)
     {
-        if (data.BusinessPartnerNumber != null && !BpnRegex.IsMatch(data.BusinessPartnerNumber))
+        if (!string.IsNullOrEmpty(data.BusinessPartnerNumber) && !BpnRegex.IsMatch(data.BusinessPartnerNumber))
         {
             throw new ControllerArgumentException("BPN must contain exactly 16 characters and must be prefixed with BPNL", nameof(data.BusinessPartnerNumber));
         }

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -358,7 +358,7 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
             },
             c =>
             {
-                c.BusinessPartnerNumber = modifyData.BusinessPartnerNumber?.ToUpper();
+                c.BusinessPartnerNumber = string.IsNullOrEmpty(modifyData.BusinessPartnerNumber) ? null : modifyData.BusinessPartnerNumber?.ToUpper();
                 c.Name = modifyData.Name;
                 c.Shortname = modifyData.ShortName;
                 c.CompanyStatusId = CompanyStatusId.PENDING;

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/NetworkBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/NetworkBusinessLogicTests.cs
@@ -114,7 +114,6 @@ public class NetworkBusinessLogicTests
     #region HandlePartnerRegistration
 
     [Theory]
-    [InlineData("")]
     [InlineData("TEST00000012")]
     [InlineData("BPNL1234567899")]
     public async Task HandlePartnerRegistration_WithInvalidBusinessPartnerNumber_ThrowsControllerArgumentException(string? bpn)


### PR DESCRIPTION
## Description

Skip validation for bpn is empty

## Why

The registration validation is always failing when no bpn is set because the regex validation jumps in place

## Issue

Refs: #639

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
