### PR TITLE
fix(mail): remove disposal of mimeMessage

### DIFF
--- a/src/mailing/Mailing.SendMail/SendMail.cs
+++ b/src/mailing/Mailing.SendMail/SendMail.cs
@@ -35,7 +35,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail
 
         Task ISendMail.Send(string sender, string recipient, string subject, string body, bool useHtml)
         {
-            using var message = new MimeMessage();
+            var message = new MimeMessage();
             message.From.Add(MailboxAddress.Parse(sender));
             message.To.Add(MailboxAddress.Parse(recipient));
             message.Subject = subject;
@@ -53,6 +53,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail
                 {
                     client.ProxyClient = new HttpProxyClient(_MailSettings.HttpProxy, _MailSettings.HttpProxyPort);
                 }
+
                 await client.ConnectAsync(_MailSettings.SmtpHost, _MailSettings.SmtpPort);
                 await client.AuthenticateAsync(_MailSettings.SmtpUser, _MailSettings.SmtpPassword);
                 await client.SendAsync(message);


### PR DESCRIPTION
## Description

remove disposal of mimeMessage

## Why

Mail isn't send correctly because the mime message is disposed before the mail gets send

## Issue

Refs: #579

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
