### PR TITLE
feat(ssi): adjust framework creation endpoint

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
@@ -43,7 +43,7 @@ public interface ICompanyDataBusinessLogic
 
     Task<IEnumerable<SsiCertificateData>> GetSsiCertificatesAsync();
 
-    Task CreateUseCaseParticipation(UseCaseParticipationCreationData data, CancellationToken cancellationToken);
+    Task<Guid> CreateUseCaseParticipation(UseCaseParticipationCreationData data, CancellationToken cancellationToken);
     Task CreateSsiCertificate(SsiCertificateCreationData data, CancellationToken cancellationToken);
 
     Task<Pagination.Response<CredentialDetailData>> GetCredentials(int page, int size, CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId, string? companyName, CompanySsiDetailSorting? sorting);

--- a/src/administration/Administration.Service/Controllers/CompanyDataController.cs
+++ b/src/administration/Administration.Service/Controllers/CompanyDataController.cs
@@ -236,11 +236,8 @@ public class CompanyDataController : ControllerBase
     [Route("useCaseParticipation")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    public async Task<NoContentResult> CreateUseCaseParticipation([FromForm] UseCaseParticipationCreationData data, CancellationToken cancellationToken)
-    {
-        await _logic.CreateUseCaseParticipation(data, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
-        return NoContent();
-    }
+    public Task<Guid> CreateUseCaseParticipation([FromForm] UseCaseParticipationCreationData data, CancellationToken cancellationToken) =>
+        _logic.CreateUseCaseParticipation(data, cancellationToken);
 
     /// <summary>
     /// Creates the SSI Certificate request

--- a/src/externalsystems/IssuerComponent.Library/BusinessLogic/IIssuerComponentBusinessLogic.cs
+++ b/src/externalsystems/IssuerComponent.Library/BusinessLogic/IIssuerComponentBusinessLogic.cs
@@ -28,4 +28,5 @@ public interface IIssuerComponentBusinessLogic
     Task StoreBpnlCredentialResponse(Guid applicationId, IssuerResponseData data);
     Task<IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult> CreateMembershipCredential(IApplicationChecklistService.WorkerChecklistProcessStepData context, CancellationToken cancellationToken);
     Task StoreMembershipCredentialResponse(Guid applicationId, IssuerResponseData data);
+    Task<Guid> CreateFrameworkCredentialData(Guid useCaseFrameworkVersionId, UseCaseFrameworkId frameworkId, Guid identityId, CancellationToken cancellationToken);
 }

--- a/src/externalsystems/IssuerComponent.Library/BusinessLogic/IssuerComponentBusinessLogic.cs
+++ b/src/externalsystems/IssuerComponent.Library/BusinessLogic/IssuerComponentBusinessLogic.cs
@@ -174,4 +174,29 @@ public class IssuerComponentBusinessLogic(
                 ? [ProcessStepTypeId.START_CLEARING_HOUSE]
                 : null);
     }
+
+    public async Task<Guid> CreateFrameworkCredentialData(Guid useCaseFrameworkVersionId, UseCaseFrameworkId frameworkId, Guid identityId, CancellationToken cancellationToken)
+    {
+        var (holder, businessPartnerNumber, walletInformation) = await repositories.GetInstance<ICompanyRepository>().GetWalletData(identityId).ConfigureAwait(false);
+        if (holder is null)
+        {
+            throw new ConflictException("The holder must be set");
+        }
+
+        if (businessPartnerNumber is null)
+        {
+            throw new ConflictException("The bpn must be set");
+        }
+
+        if (walletInformation is null)
+        {
+            throw new ConflictException("The wallet information must be set");
+        }
+
+        var cryptoConfig = _settings.EncryptionConfigs.SingleOrDefault(x => x.Index == walletInformation.EncryptionMode) ?? throw new ConfigurationException($"EncryptionModeIndex {walletInformation.EncryptionMode} is not configured");
+        var secret = CryptoHelper.Decrypt(walletInformation.ClientSecret, walletInformation.InitializationVector, Convert.FromHexString(cryptoConfig.EncryptionKey), cryptoConfig.CipherMode, cryptoConfig.PaddingMode);
+
+        var data = new CreateFrameworkCredentialRequest(holder, businessPartnerNumber, frameworkId, useCaseFrameworkVersionId, new TechnicalUserDetails(walletInformation.WalletUrl, walletInformation.ClientId, secret), null);
+        return await service.CreateFrameworkCredential(data, cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/src/externalsystems/IssuerComponent.Library/Models/CreateFrameworkCredentialRequest.cs
+++ b/src/externalsystems/IssuerComponent.Library/Models/CreateFrameworkCredentialRequest.cs
@@ -1,6 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,20 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Models;
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using System.Text.Json.Serialization;
 
-namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+namespace Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Models;
 
-public record UseCaseParticipationCreationData
-(
-    Guid VerifiedCredentialExternalTypeDetailId,
-    UseCaseFrameworkId Framework,
-    IFormFile? Document
-);
-
-public record SsiCertificateCreationData
-(
-    VerifiedCredentialTypeId CredentialType,
-    IFormFile Document
+public record CreateFrameworkCredentialRequest(
+    [property: JsonPropertyName("holder")] string Holder,
+    [property: JsonPropertyName("businessPartnerNumber")] string HolderBpn,
+    [property: JsonPropertyName("useCaseFrameworkId")] UseCaseFrameworkId UseCaseFrameworkId,
+    [property: JsonPropertyName("useCaseFrameworkVersionId")] Guid UseCaseFrameworkVersionId,
+    [property: JsonPropertyName("technicalUserDetails")] TechnicalUserDetails? TechnicalUserDetails,
+    [property: JsonPropertyName("callbackUrl")] string? CallbackUrl
 );

--- a/src/externalsystems/IssuerComponent.Library/Models/UseCaseFrameworkId.cs
+++ b/src/externalsystems/IssuerComponent.Library/Models/UseCaseFrameworkId.cs
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using System.Runtime.Serialization;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Models;
+
+public enum UseCaseFrameworkId
+{
+    [EnumMember(Value = "TraceabilityCredential")]
+    TRACEABILITY_CREDENTIAL = 1,
+
+    [EnumMember(Value = "PcfCredential")]
+    PCF_CREDENTIAL = 2,
+
+    [EnumMember(Value = "BehaviorTwinCredential")]
+    BEHAVIOR_TWIN_CREDENTIAL = 3,
+
+    [EnumMember(Value = "vehicleDismantle")]
+    VEHICLE_DISMANTLE = 4,
+
+    [EnumMember(Value = "CircularEconomyCredential")]
+    CIRCULAR_ECONOMY = 5,
+
+    [EnumMember(Value = "QualityCredential")]
+    QUALITY_CREDENTIAL = 6,
+
+    [EnumMember(Value = "BusinessPartnerCredential")]
+    BUSINESS_PARTNER_NUMBER = 7,
+
+    [EnumMember(Value = "DemandCapacityCredential")]
+    DEMAND_AND_CAPACITY_MANAGEMENT = 8,
+
+    [EnumMember(Value = "DemandCapacityCredential")]
+    DEMAND_AND_CAPACITY_MANAGEMENT_PURIS = 9,
+
+    [EnumMember(Value = "BusinessPartnerCredential")]
+    BUSINESS_PARTNER_DATA_MANAGEMENT = 10
+}

--- a/src/externalsystems/IssuerComponent.Library/Service/IIssuerComponentService.cs
+++ b/src/externalsystems/IssuerComponent.Library/Service/IIssuerComponentService.cs
@@ -25,4 +25,5 @@ public interface IIssuerComponentService
 {
     Task<bool> CreateBpnlCredential(CreateBpnCredentialRequest data, CancellationToken cancellationToken);
     Task<bool> CreateMembershipCredential(CreateMembershipCredentialRequest data, CancellationToken cancellationToken);
+    Task<Guid> CreateFrameworkCredential(CreateFrameworkCredentialRequest data, CancellationToken cancellationToken);
 }

--- a/src/externalsystems/IssuerComponent.Library/Service/IssuerComponentService.cs
+++ b/src/externalsystems/IssuerComponent.Library/Service/IssuerComponentService.cs
@@ -48,4 +48,12 @@ public class IssuerComponentService(ITokenService tokenService, IOptions<IssuerC
             .CatchingIntoServiceExceptionFor("issuer-component-membership-post", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
         return true;
     }
+
+    public async Task<Guid> CreateFrameworkCredential(CreateFrameworkCredentialRequest data, CancellationToken cancellationToken)
+    {
+        var httpClient = await tokenService.GetAuthorizedClient<IssuerComponentService>(_settings, cancellationToken).ConfigureAwait(false);
+        var result = await httpClient.PostAsJsonAsync("/api/issuer/framework", data, Options, cancellationToken)
+            .CatchingIntoServiceExceptionFor("issuer-component-framework-post", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
+        return await result.Content.ReadFromJsonAsync<Guid>(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+    }
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -28,19 +28,9 @@ using System.Text.Json;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 
 /// <inheritdoc/>
-public class CompanyRepository : ICompanyRepository
+public class CompanyRepository(PortalDbContext context)
+    : ICompanyRepository
 {
-    private readonly PortalDbContext _context;
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    /// <param name="portalDbContext">Portal DB context.</param>
-    public CompanyRepository(PortalDbContext portalDbContext)
-    {
-        _context = portalDbContext;
-    }
-
     /// <inheritdoc/>
     Company ICompanyRepository.CreateCompany(string companyName, Action<Company>? setOptionalParameters)
     {
@@ -50,14 +40,14 @@ public class CompanyRepository : ICompanyRepository
             CompanyStatusId.PENDING,
             DateTimeOffset.UtcNow);
         setOptionalParameters?.Invoke(company);
-        return _context.Companies.Add(company).Entity;
+        return context.Companies.Add(company).Entity;
     }
 
     public void AttachAndModifyCompany(Guid companyId, Action<Company>? initialize, Action<Company> modify)
     {
         var company = new Company(companyId, null!, default, default);
         initialize?.Invoke(company);
-        _context.Attach(company);
+        context.Attach(company);
         modify(company);
     }
 
@@ -71,19 +61,19 @@ public class CompanyRepository : ICompanyRepository
             DateTimeOffset.UtcNow
         );
         setOptionalParameters?.Invoke(address);
-        return _context.Addresses.Add(address).Entity;
+        return context.Addresses.Add(address).Entity;
     }
 
     public void AttachAndModifyAddress(Guid addressId, Action<Address>? initialize, Action<Address> modify)
     {
         var address = new Address(addressId, null!, null!, null!, default);
         initialize?.Invoke(address);
-        _context.Attach(address);
+        context.Attach(address);
         modify(address);
     }
 
     public void CreateUpdateDeleteIdentifiers(Guid companyId, IEnumerable<(UniqueIdentifierId UniqueIdentifierId, string Value)> initialItems, IEnumerable<(UniqueIdentifierId UniqueIdentifierId, string Value)> modifiedItems) =>
-        _context.AddAttachRemoveRange(
+        context.AddAttachRemoveRange(
             initialItems,
             modifiedItems,
             initial => initial.UniqueIdentifierId,
@@ -94,13 +84,13 @@ public class CompanyRepository : ICompanyRepository
             (entity, modified) => entity.Value = modified.Value);
 
     public Task<(bool IsValidCompany, string CompanyName)> GetCompanyNameUntrackedAsync(Guid companyId) =>
-        _context.Companies
+        context.Companies
             .Where(x => x.Id == companyId)
             .Select(company => new ValueTuple<bool, string>(true, company.Name))
             .SingleOrDefaultAsync();
 
     public Task<(string? Bpn, IEnumerable<Guid> TechnicalUserRoleIds)> GetBpnAndTechnicalUserRoleIds(Guid companyId, string technicalUserClientId) =>
-        _context.Companies
+        context.Companies
             .AsNoTracking()
             .Where(company => company.Id == companyId)
             .Select(company => new ValueTuple<string?, IEnumerable<Guid>>(
@@ -109,7 +99,7 @@ public class CompanyRepository : ICompanyRepository
             .SingleOrDefaultAsync();
 
     public IAsyncEnumerable<string> GetAllMemberCompaniesBPNAsync(IEnumerable<string>? bpnIds) =>
-        _context.Companies
+        context.Companies
             .AsNoTracking()
             .Where(company => company.CompanyStatusId == CompanyStatusId.ACTIVE &&
                 (bpnIds == null || bpnIds.Contains(company.BusinessPartnerNumber) &&
@@ -118,7 +108,7 @@ public class CompanyRepository : ICompanyRepository
             .AsAsyncEnumerable();
 
     public Task<CompanyAddressDetailData?> GetCompanyDetailsAsync(Guid companyId) =>
-        _context.Companies
+        context.Companies
             .AsNoTracking()
             .Where(company => company.Id == companyId)
             .Select(company => new CompanyAddressDetailData(
@@ -139,7 +129,7 @@ public class CompanyRepository : ICompanyRepository
 
     /// <inheritdoc />
     public Task<(bool IsValidCompanyId, bool IsCompanyRoleOwner)> IsValidCompanyRoleOwner(Guid companyId, IEnumerable<CompanyRoleId> companyRoleIds) =>
-        _context.Companies.AsNoTracking()
+        context.Companies.AsNoTracking()
             .Where(company => company.Id == companyId)
             .Select(company => new ValueTuple<bool, bool>(
                 true,
@@ -149,7 +139,7 @@ public class CompanyRepository : ICompanyRepository
 
     /// <inheritdoc />
     public Task<(Guid ProviderCompanyDetailId, string Url)> GetProviderCompanyDetailsExistsForUser(Guid companyId) =>
-        _context.ProviderCompanyDetails.AsNoTracking()
+        context.ProviderCompanyDetails.AsNoTracking()
             .Where(details => details.CompanyId == companyId)
             .Select(details => new ValueTuple<Guid, string>(details.Id, details.AutoSetupUrl))
             .SingleOrDefaultAsync();
@@ -159,12 +149,12 @@ public class CompanyRepository : ICompanyRepository
     {
         var providerCompanyDetail = new ProviderCompanyDetail(Guid.NewGuid(), companyId, dataUrl, DateTimeOffset.UtcNow);
         setOptionalParameter?.Invoke(providerCompanyDetail);
-        return _context.ProviderCompanyDetails.Add(providerCompanyDetail).Entity;
+        return context.ProviderCompanyDetails.Add(providerCompanyDetail).Entity;
     }
 
     /// <inheritdoc />
     public Task<(ProviderDetailReturnData ProviderDetailReturnData, bool IsProviderCompany)> GetProviderCompanyDetailAsync(CompanyRoleId companyRoleId, Guid companyId) =>
-        _context.Companies
+        context.Companies
             .Where(company => company.Id == companyId)
             .Select(company => new ValueTuple<ProviderDetailReturnData, bool>(
                 new ProviderDetailReturnData(
@@ -179,20 +169,20 @@ public class CompanyRepository : ICompanyRepository
     {
         var details = new ProviderCompanyDetail(providerCompanyDetailId, Guid.Empty, null!, default);
         initialize(details);
-        _context.Attach(details);
+        context.Attach(details);
         modify(details);
     }
 
     /// <inheritdoc />
     public Task<(string? Bpn, Guid? SelfDescriptionDocumentId)> GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(Guid companyId) =>
-        _context.Companies.AsNoTracking()
+        context.Companies.AsNoTracking()
             .Where(x => x.Id == companyId)
             .Select(x => new ValueTuple<string?, Guid?>(x.BusinessPartnerNumber, x.SelfDescriptionDocumentId))
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
     public IAsyncEnumerable<CompanyAssignedUseCaseData> GetCompanyAssigendUseCaseDetailsAsync(Guid userCompanyId) =>
-        _context.Companies
+        context.Companies
         .Where(company => company.Id == userCompanyId)
         .SelectMany(company => company.CompanyAssignedUseCase)
         .Select(cauc => new CompanyAssignedUseCaseData(
@@ -202,7 +192,7 @@ public class CompanyRepository : ICompanyRepository
 
     /// <inheritdoc />
     public Task<(bool IsUseCaseIdExists, bool IsActiveCompanyStatus, bool IsValidCompany)> GetCompanyStatusAndUseCaseIdAsync(Guid companyId, Guid useCaseId) =>
-        _context.Companies
+        context.Companies
         .Where(company => company.Id == companyId)
         .Select(company => new ValueTuple<bool, bool, bool>(
             company.CompanyAssignedUseCase.Any(cauc => cauc.UseCaseId == useCaseId),
@@ -212,15 +202,15 @@ public class CompanyRepository : ICompanyRepository
 
     /// <inheritdoc />
     public CompanyAssignedUseCase CreateCompanyAssignedUseCase(Guid companyId, Guid useCaseId) =>
-        _context.CompanyAssignedUseCases.Add(new CompanyAssignedUseCase(companyId, useCaseId)).Entity;
+        context.CompanyAssignedUseCases.Add(new CompanyAssignedUseCase(companyId, useCaseId)).Entity;
 
     /// <inheritdoc /> 
     public void RemoveCompanyAssignedUseCase(Guid companyId, Guid useCaseId) =>
-        _context.CompanyAssignedUseCases.Remove(new CompanyAssignedUseCase(companyId, useCaseId));
+        context.CompanyAssignedUseCases.Remove(new CompanyAssignedUseCase(companyId, useCaseId));
 
     /// <inheritdoc />
     public IAsyncEnumerable<CompanyRoleConsentData> GetCompanyRoleAndConsentAgreementDataAsync(Guid companyId, string languageShortName) =>
-        _context.CompanyRoles
+        context.CompanyRoles
             .AsSplitQuery()
             .Where(companyRole => companyRole.CompanyRoleRegistrationData!.IsRegistrationRole)
             .Select(companyRole => new CompanyRoleConsentData(
@@ -241,7 +231,7 @@ public class CompanyRepository : ICompanyRepository
 
     /// <inheritdoc />
     public Task<(bool IsValidCompany, bool IsCompanyActive, IEnumerable<CompanyRoleId>? CompanyRoleIds, IEnumerable<ConsentStatusDetails>? ConsentStatusDetails)> GetCompanyRolesDataAsync(Guid companyId, IEnumerable<CompanyRoleId> companyRoleIds) =>
-        _context.Companies
+        context.Companies
             .AsNoTracking()
             .AsSplitQuery()
             .Where(company => company.Id == companyId)
@@ -268,7 +258,7 @@ public class CompanyRepository : ICompanyRepository
 
     /// <inheritdoc />
     public IAsyncEnumerable<(AgreementStatusData agreementStatusData, CompanyRoleId CompanyRoleId)> GetAgreementAssignedRolesDataAsync(IEnumerable<CompanyRoleId> companyRoleIds) =>
-        _context.AgreementAssignedCompanyRoles
+        context.AgreementAssignedCompanyRoles
             .Where(assigned => companyRoleIds.Contains(assigned.CompanyRoleId))
             .OrderBy(assigned => assigned.CompanyRoleId)
             .Select(assigned => new ValueTuple<AgreementStatusData, CompanyRoleId>(
@@ -278,7 +268,7 @@ public class CompanyRepository : ICompanyRepository
 
     /// <inheritdoc />
     public Task<(bool IsActive, bool IsValid)> GetCompanyStatusDataAsync(Guid companyId) =>
-        _context.Companies
+        context.Companies
         .Where(company => company.Id == companyId)
         .Select(company => new ValueTuple<bool, bool>(
             company.CompanyStatusId == CompanyStatusId.ACTIVE,
@@ -286,7 +276,7 @@ public class CompanyRepository : ICompanyRepository
         )).SingleOrDefaultAsync();
 
     public Task<CompanyInformationData?> GetOwnCompanyInformationAsync(Guid companyId, Guid companyUserId) =>
-        _context.Companies
+        context.Companies
             .AsNoTracking()
             .Where(c => c.Id == companyId)
             .Select(company => new CompanyInformationData(
@@ -300,14 +290,14 @@ public class CompanyRepository : ICompanyRepository
 
     /// <inheritdoc />
     public IAsyncEnumerable<CompanyRoleId> GetOwnCompanyRolesAsync(Guid companyId) =>
-        _context.CompanyAssignedRoles
+        context.CompanyAssignedRoles
             .Where(x => x.CompanyId == companyId)
             .Select(x => x.CompanyRoleId)
             .AsAsyncEnumerable();
 
     /// <inheritdoc />
     public IAsyncEnumerable<OperatorBpnData> GetOperatorBpns() =>
-        _context.Companies
+        context.Companies
             .Where(x =>
                 x.CompanyAssignedRoles.Any(car => car.CompanyRoleId == CompanyRoleId.OPERATOR) &&
                 !string.IsNullOrWhiteSpace(x.BusinessPartnerNumber))
@@ -317,7 +307,7 @@ public class CompanyRepository : ICompanyRepository
             .AsAsyncEnumerable();
 
     public Task<(bool IsValidCompany, string CompanyName, bool IsAllowed)> CheckCompanyAndCompanyRolesAsync(Guid companyId, IEnumerable<CompanyRoleId> companyRoles) =>
-        _context.Companies
+        context.Companies
             .Where(x => x.Id == companyId)
             .Select(x => new ValueTuple<bool, string, bool>(
                     true,
@@ -327,7 +317,7 @@ public class CompanyRepository : ICompanyRepository
             .SingleOrDefaultAsync();
 
     public Task<OnboardingServiceProviderCallbackResponseData> GetCallbackData(Guid companyId) =>
-        _context.Companies.Where(c => c.Id == companyId)
+        context.Companies.Where(c => c.Id == companyId)
             .Select(c => new OnboardingServiceProviderCallbackResponseData(
                     c.OnboardingServiceProviderDetail!.CallbackUrl,
                     c.OnboardingServiceProviderDetail.AuthUrl,
@@ -336,7 +326,7 @@ public class CompanyRepository : ICompanyRepository
             .SingleAsync();
 
     public Task<(bool HasCompanyRole, Guid? OnboardingServiceProviderDetailId, OspDetails? OspDetails)> GetCallbackEditData(Guid companyId, CompanyRoleId companyRoleId) =>
-        _context.Companies.Where(c => c.Id == companyId)
+        context.Companies.Where(c => c.Id == companyId)
             .Select(c => new ValueTuple<bool, Guid?, OspDetails?>(
                 c.CompanyAssignedRoles.Any(role => role.CompanyRoleId == companyRoleId),
                 c.OnboardingServiceProviderDetail!.Id,
@@ -356,29 +346,29 @@ public class CompanyRepository : ICompanyRepository
     {
         var ospDetails = new OnboardingServiceProviderDetail(onboardingServiceProviderDetailId, Guid.Empty, null!, null!, null!, null!, null, default);
         initialize?.Invoke(ospDetails);
-        _context.OnboardingServiceProviderDetails.Attach(ospDetails);
+        context.OnboardingServiceProviderDetails.Attach(ospDetails);
         setOptionalFields.Invoke(ospDetails);
     }
 
     public OnboardingServiceProviderDetail CreateOnboardingServiceProviderDetails(Guid companyId, string callbackUrl, string authUrl, string clientId, byte[] clientSecret, byte[]? initializationVector, int encryptionMode) =>
-        _context.OnboardingServiceProviderDetails.Add(new OnboardingServiceProviderDetail(Guid.NewGuid(), companyId, callbackUrl, authUrl, clientId, clientSecret, initializationVector, encryptionMode)).Entity;
+        context.OnboardingServiceProviderDetails.Add(new OnboardingServiceProviderDetail(Guid.NewGuid(), companyId, callbackUrl, authUrl, clientId, clientSecret, initializationVector, encryptionMode)).Entity;
 
     /// <inheritdoc />
     public Task<bool> CheckBpnExists(string bpn) =>
-        _context.Companies
+        context.Companies
             .AnyAsync(x => x.BusinessPartnerNumber == bpn);
 
     public void CreateWalletData(Guid companyId, string did, JsonDocument didDocument, string clientId, byte[] clientSecret, byte[]? initializationVector, int encryptionMode, string authenticationServiceUrl) =>
-        _context.CompanyWalletDatas.Add(new CompanyWalletData(Guid.NewGuid(), companyId, did, didDocument, clientId, clientSecret, initializationVector, encryptionMode, authenticationServiceUrl));
+        context.CompanyWalletDatas.Add(new CompanyWalletData(Guid.NewGuid(), companyId, did, didDocument, clientId, clientSecret, initializationVector, encryptionMode, authenticationServiceUrl));
 
     public Task<(bool Exists, JsonDocument DidDocument)> GetDidDocumentById(string bpn) =>
-        _context.CompanyWalletDatas
+        context.CompanyWalletDatas
             .Where(x => x.Company!.BusinessPartnerNumber == bpn)
             .Select(x => new ValueTuple<bool, JsonDocument>(true, x.DidDocument))
             .SingleOrDefaultAsync();
 
     public Task<(bool Exists, Guid CompanyId, IEnumerable<Guid> SubmittedCompanyApplicationId)> GetCompanyIdByBpn(string bpn) =>
-        _context.Companies
+        context.Companies
             .Where(x => x.BusinessPartnerNumber == bpn)
             .Select(x => new ValueTuple<bool, Guid, IEnumerable<Guid>>(
                 true,
@@ -389,7 +379,29 @@ public class CompanyRepository : ICompanyRepository
             .SingleOrDefaultAsync();
 
     public Task<string?> GetWalletServiceUrl(Guid companyId) =>
-        _context.Companies.Where(x => x.Id == companyId)
+        context.Companies.Where(x => x.Id == companyId)
             .Select(x => x.CompanyWalletData!.AuthenticationServiceUrl)
+            .SingleOrDefaultAsync();
+
+    public Task<(string? Holder, string? BusinessPartnerNumber, WalletInformation? WalletInformation)> GetWalletData(Guid identityId) =>
+        context.Identities
+            .Where(ca => ca.Id == identityId)
+            .Select(ca => new
+            {
+                Company = ca.Company!,
+                Wallet = ca.Company!.CompanyWalletData
+            })
+            .Select(c => new ValueTuple<string?, string?, WalletInformation?>(
+                c.Company.DidDocumentLocation,
+                c.Company.BusinessPartnerNumber,
+                c.Wallet == null ?
+                    null :
+                    new WalletInformation(
+                        c.Wallet.ClientId,
+                        c.Wallet.ClientSecret,
+                        c.Wallet.InitializationVector,
+                        c.Wallet.EncryptionMode,
+                        c.Wallet.AuthenticationServiceUrl
+                    )))
             .SingleOrDefaultAsync();
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -177,4 +177,5 @@ public interface ICompanyRepository
     Task<(bool Exists, JsonDocument DidDocument)> GetDidDocumentById(string bpn);
     Task<(bool Exists, Guid CompanyId, IEnumerable<Guid> SubmittedCompanyApplicationId)> GetCompanyIdByBpn(string bpn);
     Task<string?> GetWalletServiceUrl(Guid companyId);
+    Task<(string? Holder, string? BusinessPartnerNumber, WalletInformation? WalletInformation)> GetWalletData(Guid identityId);
 }

--- a/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
@@ -21,6 +21,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Controllers;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
+using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
@@ -201,7 +202,7 @@ public class CompanyDataControllerTests
     {
         // Arrange
         var file = FormFileHelper.GetFormFile("test content", "test.pdf", MediaTypeId.PDF.MapToMediaType());
-        var data = new UseCaseParticipationCreationData(Guid.NewGuid(), VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, file);
+        var data = new UseCaseParticipationCreationData(Guid.NewGuid(), UseCaseFrameworkId.TRACEABILITY_CREDENTIAL, file);
 
         // Act
         await _controller.CreateUseCaseParticipation(data, CancellationToken.None);


### PR DESCRIPTION
## Description

* adjust framework creation endpoint to call the ssi credential issuer

## Why

The user doesn't has all necessary data available to call the ssi-credential-issuer directly, therefore the portal backend provides an endpoint to than create a framework credential

## Issue

N/A

## Corresponding SSI-Credential-Issuer PR

[#70](https://github.com/eclipse-tractusx/ssi-credential-issuer/pull/70)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
