### PR TITLE
feat(bpdm): fix /api/registration/legalEntityAddress/{bpn} endpoint

### DIFF
--- a/src/externalsystems/Bpdm.Library/BpnAccess.cs
+++ b/src/externalsystems/Bpdm.Library/BpnAccess.cs
@@ -41,10 +41,10 @@ public class BpnAccess : IBpnAccess
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var uri = new UriBuilder
         {
-            Path = $"/legal-entities/{Uri.EscapeDataString(businessPartnerNumber)}",
+            Path = $"legal-entities/{Uri.EscapeDataString(businessPartnerNumber)}",
             Query = "idType=BPN"
         }.Uri;
-        var result = await _httpClient.GetAsync(uri.PathAndQuery, cancellationToken)
+        var result = await _httpClient.GetAsync(uri.PathAndQuery.TrimStart('/'), cancellationToken)
             .CatchingIntoServiceExceptionFor("bpn-fetch-legal-entity")
             .ConfigureAwait(false);
         try


### PR DESCRIPTION
## Description

Remove the leading slash from the api of the bpn access

## Why

when setting a leading slash in the url for the http client the url path is overwritten

## Issue

#632

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
