### PR TITLE
fix(bpdm): adjust bpdm request urls

### DIFF
--- a/src/externalsystems/Bpdm.Library/BpdmService.cs
+++ b/src/externalsystems/Bpdm.Library/BpdmService.cs
@@ -112,7 +112,7 @@ public class BpdmService : IBpdmService
             )
         };
 
-        await httpClient.PutAsJsonAsync("/input/business-partners", requestData, Options, cancellationToken)
+        await httpClient.PutAsJsonAsync("input/business-partners", requestData, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("bpdm-put-legal-entities", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
         return true;
     }
@@ -122,7 +122,7 @@ public class BpdmService : IBpdmService
         using var httpClient = await _tokenService.GetAuthorizedClient<BpdmService>(_settings, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 
         var content = new { externalIds = Enumerable.Repeat(externalId, 1) };
-        await httpClient.PostAsJsonAsync("/sharing-state/ready", content, Options, cancellationToken)
+        await httpClient.PostAsJsonAsync("sharing-state/ready", content, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("bpdm-put-sharing-state-ready", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
         return true;
     }
@@ -132,7 +132,7 @@ public class BpdmService : IBpdmService
         using var httpClient = await _tokenService.GetAuthorizedClient<BpdmService>(_settings, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 
         var data = Enumerable.Repeat(externalId, 1);
-        var result = await httpClient.PostAsJsonAsync("/output/business-partners/search", data, Options, cancellationToken)
+        var result = await httpClient.PostAsJsonAsync("output/business-partners/search", data, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("bpdm-search-legal-entities", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
         try
         {
@@ -156,7 +156,7 @@ public class BpdmService : IBpdmService
     {
         using var httpClient = await _tokenService.GetAuthorizedClient<BpdmService>(_settings, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 
-        var url = $"/sharing-state?externalIds={applicationId}";
+        var url = $"sharing-state?externalIds={applicationId}";
         var result = await httpClient.GetAsync(url, cancellationToken)
             .CatchingIntoServiceExceptionFor("bpdm-sharing-state", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
         try

--- a/src/externalsystems/Bpdm.Library/DependencyInjection/BpdmServiceCollectionExtension.cs
+++ b/src/externalsystems/Bpdm.Library/DependencyInjection/BpdmServiceCollectionExtension.cs
@@ -38,7 +38,7 @@ public static class BpdmServiceCollectionExtension
         var sp = services.BuildServiceProvider();
         var settings = sp.GetRequiredService<IOptions<BpdmServiceSettings>>();
         services
-            .AddCustomHttpClientWithAuthentication<BpdmService>(settings.Value.BaseAddress)
+            .AddCustomHttpClientWithAuthentication<BpdmService>(settings.Value.BaseAddress.EndsWith('/') ? settings.Value.BaseAddress : $"{settings.Value.BaseAddress}/")
             .AddTransient<IBpdmService, BpdmService>()
             .AddTransient<IBpdmBusinessLogic, BpdmBusinessLogic>();
 

--- a/src/externalsystems/Bpdm.Library/DependencyInjection/BpnAccessCollectionExtension.cs
+++ b/src/externalsystems/Bpdm.Library/DependencyInjection/BpnAccessCollectionExtension.cs
@@ -30,7 +30,7 @@ public static class BpnAccessCollectionExtension
         services.AddTransient<LoggingHandler<BpnAccess>>();
         services.AddHttpClient(nameof(BpnAccess), c =>
             {
-                c.BaseAddress = new Uri(baseAddress);
+                c.BaseAddress = new Uri(baseAddress.EndsWith('/') ? baseAddress : $"{baseAddress}/");
             })
             .AddHttpMessageHandler<LoggingHandler<BpnAccess>>();
         services.AddTransient<IBpnAccess, BpnAccess>();

--- a/tests/shared/Tests.Shared/Extensions/IFixtureExtensions.cs
+++ b/tests/shared/Tests.Shared/Extensions/IFixtureExtensions.cs
@@ -20,6 +20,8 @@
 using AutoFixture;
 using AutoFixture.Dsl;
 using AutoFixture.Kernel;
+using FakeItEasy;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Token;
 using System.Linq.Expressions;
 using System.Text.Json;
 
@@ -53,5 +55,24 @@ public static class AutoFixtureExtensions
     public static IPostprocessComposer<T> WithOrgNamePattern<T>(this IPostprocessComposer<T> composer, Expression<Func<T, object?>> propertyPicker)
     {
         return composer.With(propertyPicker, new SpecimenContext(composer).Resolve(new RegularExpressionRequest(OrgNameRegex)));
+    }
+
+    public static void ConfigureTokenServiceFixture<T>(this IFixture fixture, HttpResponseMessage httpResponseMessage, Action<HttpRequestMessage?>? setMessage = null)
+    {
+        var messageHandler = A.Fake<HttpMessageHandler>();
+        A.CallTo(messageHandler) // mock protected method
+            .Where(x => x.Method.Name == "SendAsync")
+            .WithReturnType<Task<HttpResponseMessage>>()
+            .ReturnsLazily(call =>
+            {
+                var message = call.Arguments.Get<HttpRequestMessage>(0);
+                setMessage?.Invoke(message);
+                return Task.FromResult(httpResponseMessage);
+            });
+        var httpClient = new HttpClient(messageHandler) { BaseAddress = new Uri("https://example.com/path/test/") };
+        fixture.Inject(httpClient);
+
+        var tokenService = fixture.Freeze<Fake<ITokenService>>();
+        A.CallTo(() => tokenService.FakedObject.GetAuthorizedClient<T>(A<KeyVaultAuthSettings>._, A<CancellationToken>._)).Returns(httpClient);
     }
 }

--- a/tests/shared/Tests.Shared/Tests.Shared.csproj
+++ b/tests/shared/Tests.Shared/Tests.Shared.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\framework\Framework.Token\Framework.Token.csproj" />
     <ProjectReference Include="..\..\..\src\keycloak\Keycloak.Library\Keycloak.Library.csproj" />
     <ProjectReference Include="..\..\framework\Framework.Tests.Shared\Framework.Tests.Shared.csproj" />
     <ProjectReference Include="..\..\..\src\portalbackend\PortalBackend.Migrations\PortalBackend.Migrations.csproj" />


### PR DESCRIPTION
## Description

Fix the bpdm request urls

## Why

When registering the base url it must end with an /. This has been added to the registration of the bpdm http clients

## Issue

Refs: #632

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
