### PR TITLE
fix(dim): move registration of dim to app and services service

### DIFF
--- a/src/externalsystems/Bpdm.Library/DependencyInjection/BpdmServiceCollectionExtension.cs
+++ b/src/externalsystems/Bpdm.Library/DependencyInjection/BpdmServiceCollectionExtension.cs
@@ -38,7 +38,7 @@ public static class BpdmServiceCollectionExtension
         var sp = services.BuildServiceProvider();
         var settings = sp.GetRequiredService<IOptions<BpdmServiceSettings>>();
         services
-            .AddCustomHttpClientWithAuthentication<BpdmService>(settings.Value.BaseAddress.EndsWith('/') ? settings.Value.BaseAddress : $"{settings.Value.BaseAddress}/")
+            .AddCustomHttpClientWithAuthentication<BpdmService>(settings.Value.BaseAddress)
             .AddTransient<IBpdmService, BpdmService>()
             .AddTransient<IBpdmBusinessLogic, BpdmBusinessLogic>();
 

--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/HttpClientExtensions.cs
+++ b/src/framework/Framework.HttpClientExtensions/HttpClientExtensions.cs
@@ -30,7 +30,7 @@ public static class HttpClientExtensions
         {
             if (baseAddress != null)
             {
-                c.BaseAddress = new Uri(baseAddress);
+                c.BaseAddress = new Uri(baseAddress.EndsWith('/') ? baseAddress : $"{baseAddress}/");
             }
         }).AddHttpMessageHandler<LoggingHandler<T>>();
 

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/marketplace/Apps.Service/Apps.Service.csproj
+++ b/src/marketplace/Apps.Service/Apps.Service.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\externalsystems\Dim.Library\Dim.Library.csproj" />
     <ProjectReference Include="..\..\keycloak\Keycloak.Authentication\Keycloak.Authentication.csproj" />
     <ProjectReference Include="..\..\portalbackend\PortalBackend.DBAccess\PortalBackend.DBAccess.csproj" />
     <ProjectReference Include="..\..\portalbackend\PortalBackend.PortalEntities\PortalBackend.PortalEntities.csproj" />

--- a/src/marketplace/Apps.Service/Program.cs
+++ b/src/marketplace/Apps.Service/Program.cs
@@ -18,6 +18,7 @@
  ********************************************************************************/
 
 using Org.Eclipse.TractusX.Portal.Backend.Apps.Service.BusinessLogic;
+using Org.Eclipse.TractusX.Portal.Backend.Dim.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Service;
@@ -52,7 +53,8 @@ WebAppHelper
             .AddOfferDocumentServices();
 
         builder.Services
-            .AddOfferServices(builder.Configuration)
+            .AddDimService(builder.Configuration.GetSection("Dim"))
+            .AddOfferServices()
             .AddProvisioningDBAccess(builder.Configuration);
 
         builder.Services.AddMailingProcessCreation(builder.Configuration.GetSection("MailingProcessCreation"));

--- a/src/marketplace/Offers.Library/DependencyInjection/OfferSetupServiceExtensions.cs
+++ b/src/marketplace/Offers.Library/DependencyInjection/OfferSetupServiceExtensions.cs
@@ -20,7 +20,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Org.Eclipse.TractusX.Portal.Backend.Dim.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Token;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Service;
@@ -31,13 +30,12 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Offers.Library.DependencyInjection
 
 public static class OfferSetupServiceCollectionExtension
 {
-    public static IServiceCollection AddOfferServices(this IServiceCollection services, IConfiguration config)
+    public static IServiceCollection AddOfferServices(this IServiceCollection services)
     {
         services
             .AddTransient<LoggingHandler<OfferSetupService>>()
             .AddHttpClient(nameof(OfferSetupService)).AddHttpMessageHandler<LoggingHandler<OfferSetupService>>();
         return services
-            .AddDimService(config.GetSection("Dim"))
             .AddTransient<IApplicationChecklistService, ApplicationChecklistService>()
             .AddTransient<ITokenService, TokenService>()
             .AddTransient<IOfferService, OfferService>()

--- a/src/marketplace/Services.Service/Program.cs
+++ b/src/marketplace/Services.Service/Program.cs
@@ -17,6 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Dim.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Web.DependencyInjection;
@@ -43,6 +44,7 @@ WebAppHelper
 
         builder.Services.AddTransient<INotificationService, NotificationService>();
         builder.Services
+            .AddDimService(builder.Configuration.GetSection("Dim"))
             .AddServiceBusinessLogic(builder.Configuration)
             .AddTransient<IServiceReleaseBusinessLogic, ServiceReleaseBusinessLogic>()
             .AddTransient<IServiceChangeBusinessLogic, ServiceChangeBusinessLogic>()
@@ -50,7 +52,7 @@ WebAppHelper
             .AddOfferDocumentServices();
 
         builder.Services
-            .AddOfferServices(builder.Configuration)
+            .AddOfferServices()
             .AddProvisioningDBAccess(builder.Configuration);
 
         builder.Services.AddMailingProcessCreation(builder.Configuration.GetSection("MailingProcessCreation"));

--- a/src/marketplace/Services.Service/Services.Service.csproj
+++ b/src/marketplace/Services.Service/Services.Service.csproj
@@ -33,6 +33,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\externalsystems\Dim.Library\Dim.Library.csproj" />
       <ProjectReference Include="..\..\keycloak\Keycloak.Authentication\Keycloak.Authentication.csproj" />
       <ProjectReference Include="..\..\portalbackend\PortalBackend.DBAccess\PortalBackend.DBAccess.csproj" />
       <ProjectReference Include="..\..\web\Web.Identity\Web.Identity.csproj" />

--- a/src/processes/OfferSubscription.Executor/DependencyInjection/OfferSubscriptionProcessCollectionExtensions.cs
+++ b/src/processes/OfferSubscription.Executor/DependencyInjection/OfferSubscriptionProcessCollectionExtensions.cs
@@ -38,7 +38,7 @@ public static class OfferSubscriptionProcessCollectionExtensions
 
         return services
             .AddOfferProviderService(config)
-            .AddOfferServices(config)
+            .AddOfferServices()
             .AddTransient<IProcessTypeExecutor, OfferSubscriptionProcessTypeExecutor>();
     }
 }


### PR DESCRIPTION
## Description

Move the configuration of the dim to the app and services service

## Why

The dim is registered multiple times for the processes worker.

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
