### PR TITLE
fix(universalResolver): set base address for universal resolver

### DIFF
--- a/src/externalsystems/Dim.Library/DependencyInjection/DimServiceCollectionExtension.cs
+++ b/src/externalsystems/Dim.Library/DependencyInjection/DimServiceCollectionExtension.cs
@@ -40,10 +40,23 @@ public static class DimServiceCollectionExtension
         var sp = services.BuildServiceProvider();
         var settings = sp.GetRequiredService<IOptions<DimSettings>>();
         services.AddCustomHttpClientWithAuthentication<DimService>(settings.Value.BaseAddress);
+
+        RegisterUniversalResolver(settings.Value, services);
         services
             .AddTransient<IDimService, DimService>()
             .AddTransient<IDimBusinessLogic, DimBusinessLogic>();
 
         return services;
+    }
+
+    private static void RegisterUniversalResolver(DimSettings settings, IServiceCollection services)
+    {
+        var baseAddress = settings.UniversalResolverAddress.EndsWith("/")
+            ? settings.UniversalResolverAddress
+            : $"{settings.UniversalResolverAddress}/";
+        services.AddHttpClient("universalResolver", c =>
+        {
+            c.BaseAddress = new Uri(baseAddress);
+        });
     }
 }

--- a/src/externalsystems/Dim.Library/DimService.cs
+++ b/src/externalsystems/Dim.Library/DimService.cs
@@ -53,7 +53,7 @@ public class DimService : IDimService
     public async Task<bool> ValidateDid(string did, CancellationToken cancellationToken)
     {
         using var httpClient = _httpClientFactory.CreateClient("universalResolver");
-        var result = await httpClient.GetAsync($"{Uri.EscapeDataString(_settings.UniversalResolverAddress)}1.0/identifiers/{Uri.EscapeDataString(did)}", cancellationToken)
+        var result = await httpClient.GetAsync($"1.0/identifiers/{Uri.EscapeDataString(did)}", cancellationToken)
             .CatchingIntoServiceExceptionFor("validate-did", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
 
         if (!result.IsSuccessStatusCode)

--- a/tests/externalsystems/Bpdm.Library/BPNAccessTest.cs
+++ b/tests/externalsystems/Bpdm.Library/BPNAccessTest.cs
@@ -18,6 +18,7 @@
  ********************************************************************************/
 
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
 using System.Net;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Tests;
@@ -25,25 +26,6 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Tests;
 public class BPNAccessTest
 {
     private readonly IFixture _fixture = new Fixture().Customize(new AutoFakeItEasyCustomization { ConfigureMembers = true });
-
-    private void ConfigureHttpClientFactoryFixture(HttpResponseMessage httpResponseMessage, Action<HttpRequestMessage?>? setMessage = null)
-    {
-        var messageHandler = A.Fake<HttpMessageHandler>();
-        A.CallTo(messageHandler) // mock protected method
-            .Where(x => x.Method.Name == "SendAsync")
-            .WithReturnType<Task<HttpResponseMessage>>()
-            .ReturnsLazily(call =>
-            {
-                var message = call.Arguments.Get<HttpRequestMessage>(0);
-                setMessage?.Invoke(message);
-                return Task.FromResult(httpResponseMessage);
-            });
-        var httpClient = new HttpClient(messageHandler) { BaseAddress = new Uri("http://localhost") };
-        _fixture.Inject(httpClient);
-
-        var httpClientFactory = _fixture.Freeze<Fake<IHttpClientFactory>>();
-        A.CallTo(() => httpClientFactory.FakedObject.CreateClient("bpn")).Returns(httpClient);
-    }
 
     #region FetchLegalEntityByBpns
 
@@ -189,7 +171,7 @@ public class BPNAccessTest
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(json)
         };
-        ConfigureHttpClientFactoryFixture(responseMessage, requestMessage => request = requestMessage);
+        _fixture.ConfigureHttpClientFactoryFixture("bpn", responseMessage, requestMessage => request = requestMessage);
 
         var businessPartnerNumber = _fixture.Create<string>();
         var sut = _fixture.Create<BpnAccess>();
@@ -219,7 +201,7 @@ public class BPNAccessTest
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(json)
         };
-        ConfigureHttpClientFactoryFixture(responseMessage);
+        _fixture.ConfigureHttpClientFactoryFixture("bpn", responseMessage);
 
         var sut = _fixture.Create<BpnAccess>();
 
@@ -243,7 +225,7 @@ public class BPNAccessTest
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(json)
         };
-        ConfigureHttpClientFactoryFixture(responseMessage);
+        _fixture.ConfigureHttpClientFactoryFixture("bpn", responseMessage);
 
         var sut = _fixture.Create<BpnAccess>();
 
@@ -265,7 +247,7 @@ public class BPNAccessTest
         {
             StatusCode = HttpStatusCode.OK,
         };
-        ConfigureHttpClientFactoryFixture(responseMessage);
+        _fixture.ConfigureHttpClientFactoryFixture("bpn", responseMessage);
 
         var sut = _fixture.Create<BpnAccess>();
 
@@ -289,7 +271,7 @@ public class BPNAccessTest
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(json)
         };
-        ConfigureHttpClientFactoryFixture(responseMessage);
+        _fixture.ConfigureHttpClientFactoryFixture("bpn", responseMessage);
 
         var sut = _fixture.Create<BpnAccess>();
 
@@ -313,7 +295,7 @@ public class BPNAccessTest
             StatusCode = HttpStatusCode.BadRequest,
             Content = new StringContent(json)
         };
-        ConfigureHttpClientFactoryFixture(responseMessage);
+        _fixture.ConfigureHttpClientFactoryFixture("bpn", responseMessage);
 
         var sut = _fixture.Create<BpnAccess>();
 


### PR DESCRIPTION
## Description

Setting the base address for the universal revolver correctly

## Why

The request of the universal resolver is failing because the base address isn't set correctly

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
