### PR TITLE
fix(mailing): add save calls after creating mail processes

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/MailBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/MailBusinessLogic.cs
@@ -53,6 +53,7 @@ public class MailBusinessLogic(IPortalRepositories portalRepositories, IMailingP
         if (data.RecipientMail is not null)
         {
             mailingProcessCreation.CreateMailProcess(data.RecipientMail, mailData.Template, mailData.MailParameters.ToImmutableDictionary(x => x.Key, x => x.Value));
+            await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
         }
     }
 }

--- a/src/administration/Administration.Service/BusinessLogic/UserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserBusinessLogic.cs
@@ -215,6 +215,7 @@ public class UserBusinessLogic : IUserBusinessLogic
             _mailingProcessCreation.CreateMailProcess(userCreationInfo.Email, template, mailParameters.ToImmutableDictionary());
         }
 
+        await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
         return result.CompanyUserId;
     }
 

--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -296,7 +296,8 @@
     "WelcomeNotificationTypeIds": [],
     "StartTime": "06:00:00",
     "EndTime": "21:00:00",
-    "LoginTheme": ""
+    "LoginTheme": "",
+    "UseDimWallet": false
   },
   "ApplicationChecklist": {
     "Custodian": {

--- a/src/registration/ApplicationActivation.Library/ApplicationActivationService.cs
+++ b/src/registration/ApplicationActivation.Library/ApplicationActivationService.cs
@@ -123,7 +123,12 @@ public class ApplicationActivationService : IApplicationActivationService
         var notifications = _settings.WelcomeNotificationTypeIds.Select(x => (default(string), x));
         await _notificationService.CreateNotifications(_settings.CompanyAdminRoles, null, notifications, companyId).AwaitAll(cancellationToken).ConfigureAwait(false);
 
-        var resultMessage = await _custodianService.SetMembership(businessPartnerNumber, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        string? resultMessage = null;
+        if (!_settings.UseDimWallet)
+        {
+            resultMessage = await _custodianService.SetMembership(businessPartnerNumber, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+
         await PostRegistrationWelcomeEmailAsync(applicationRepository, context.ApplicationId, companyName, businessPartnerNumber).ConfigureAwait(ConfigureAwaitOptions.None);
 
         if (assignedRoles != null)

--- a/src/registration/ApplicationActivation.Library/DependencyInjection/ApplicationActivationSettings.cs
+++ b/src/registration/ApplicationActivation.Library/DependencyInjection/ApplicationActivationSettings.cs
@@ -79,6 +79,9 @@ public class ApplicationActivationSettings
     [Required(AllowEmptyStrings = false)]
     public string DataspaceAddress { get; set; } = null!;
 
+    [Required]
+    public bool UseDimWallet { get; set; }
+
     public static bool Validate(ApplicationActivationSettings settings)
     {
         var startSet = settings.StartTime.HasValue;

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -591,8 +591,6 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
                     application.DateLastChanged = _dateTimeProvider.OffsetNow;
                 });
 
-        await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
-
         var mailParameters = ImmutableDictionary.CreateRange(new[]
         {
             KeyValuePair.Create("url", $"{_settings.BasePortalAddress}"),
@@ -606,6 +604,8 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
         {
             _logger.LogInformation("user {userId} has no email-address", _identityData.IdentityId);
         }
+
+        await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
 
         return true;
     }


### PR DESCRIPTION
## Description

Saving the mail processes after they are created

## Why

The mail processes are created, but not saved in the database, therefore no mail will be send out.

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
