### PR TITLE
fix(applicationChecklist): set correct state for IDENTITY_WALLET step

### DIFF
--- a/src/externalsystems/BpnDidResolver.Library/BusinessLogic/BpnDidResolverBusinessLogic.cs
+++ b/src/externalsystems/BpnDidResolver.Library/BusinessLogic/BpnDidResolverBusinessLogic.cs
@@ -55,7 +55,7 @@ public class BpnDidResolverBusinessLogic : IBpnDidResolverBusinessLogic
             ProcessStepStatusId.DONE,
             checklist =>
             {
-                checklist.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.IN_PROGRESS;
+                checklist.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.DONE;
             },
             [ProcessStepTypeId.REQUEST_BPN_CREDENTIAL],
             null,

--- a/src/externalsystems/IssuerComponent.Library/BusinessLogic/IssuerComponentBusinessLogic.cs
+++ b/src/externalsystems/IssuerComponent.Library/BusinessLogic/IssuerComponentBusinessLogic.cs
@@ -94,7 +94,7 @@ public class IssuerComponentBusinessLogic(
 
         checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
-            null,
+            item => item.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.IN_PROGRESS,
             item =>
             {
                 item.ApplicationChecklistEntryStatusId = data.Status == IssuerResponseStatus.UNSUCCESSFUL
@@ -162,7 +162,7 @@ public class IssuerComponentBusinessLogic(
 
         checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
-            null,
+            item => item.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.IN_PROGRESS,
             item =>
             {
                 item.ApplicationChecklistEntryStatusId = data.Status == IssuerResponseStatus.UNSUCCESSFUL


### PR DESCRIPTION
## Description

Set the IDENTITY_WALLET step to done after the transmittion of the bpn / did to the resolver

## Why

The process stays in IN_PROGRESS, even after all steps are executed successfully

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
