### PR TITLE
fix(didUrls): adjust response of companydata/decentralidentity/urls

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -604,9 +604,10 @@ public class CompanyDataBusinessLogic : ICompanyDataBusinessLogic
             _portalRepositories.GetInstance<ICompanyCertificateRepository>().GetActiveCompanyCertificatePaginationSource(sorting, certificateStatus, certificateType, _identityData.CompanyId));
 
     public async Task<DimUrlsResponse> GetDimServiceUrls() =>
-        new DimUrlsResponse(
-            _settings.DecentralIdentityManagementAuthUrl,
-            await _portalRepositories.GetInstance<ICompanyRepository>().GetWalletServiceUrl(_identityData.CompanyId).ConfigureAwait(ConfigureAwaitOptions.None));
+        new(
+            $"{await _portalRepositories.GetInstance<ICompanyRepository>().GetWalletServiceUrl(_identityData.CompanyId).ConfigureAwait(ConfigureAwaitOptions.None)}/oauth/token",
+            _settings.DecentralIdentityManagementAuthUrl
+        );
 
     /// <inheritdoc />
     public async Task<int> DeleteCompanyCertificateAsync(Guid documentId)

--- a/src/administration/Administration.Service/Models/DimUrlsResponse.cs
+++ b/src/administration/Administration.Service/Models/DimUrlsResponse.cs
@@ -20,6 +20,6 @@
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 
 public record DimUrlsResponse(
-    string DecentralIdentityManagementAuthUrl,
-    string? DecentralIdentityManagementServiceUrl
+    string? DecentralIdentityManagementAuthUrl,
+    string DecentralIdentityManagementServiceUrl
 );

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -97,7 +97,7 @@ public class CompanyDataBusinessLogicTests
         A.CallTo(() => _identity.CompanyId).Returns(Guid.NewGuid());
         A.CallTo(() => _identityService.IdentityData).Returns(_identity);
 
-        var options = Options.Create(new CompanyDataSettings { MaxPageSize = 20, UseCaseParticipationMediaTypes = new[] { MediaTypeId.PDF }, SsiCertificateMediaTypes = new[] { MediaTypeId.PDF }, CompanyCertificateMediaTypes = new[] { MediaTypeId.PDF }, DecentralIdentityManagementAuthUrl = "https://example.org/auth" });
+        var options = Options.Create(new CompanyDataSettings { MaxPageSize = 20, UseCaseParticipationMediaTypes = new[] { MediaTypeId.PDF }, SsiCertificateMediaTypes = new[] { MediaTypeId.PDF }, CompanyCertificateMediaTypes = new[] { MediaTypeId.PDF }, DecentralIdentityManagementAuthUrl = "https://example.org/test" });
         _sut = new CompanyDataBusinessLogic(_portalRepositories, _custodianService, _dateTimeProvider, _identityService, _mailingProcessCreation, options);
     }
 
@@ -1833,8 +1833,8 @@ public class CompanyDataBusinessLogicTests
         // Assert
         A.CallTo(() => _companyRepository.GetWalletServiceUrl(_identity.CompanyId))
             .MustHaveHappenedOnceExactly();
-        result.DecentralIdentityManagementAuthUrl.Should().Be("https://example.org/auth");
-        result.DecentralIdentityManagementServiceUrl.Should().Be("https://example.org/service");
+        result.DecentralIdentityManagementAuthUrl.Should().Be("https://example.org/service/oauth/token");
+        result.DecentralIdentityManagementServiceUrl.Should().Be("https://example.org/test");
     }
 
     #endregion


### PR DESCRIPTION
## Description

* adjust the response of the endpoint /api/administration/companydata/decentralidentity/urls
 
## Why

The urls were mixed up.

## Issue

#674 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
