### PR TITLE
fix: fixed isOwner filter

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
@@ -29,6 +29,7 @@ public record CompanyServiceAccountData(
     [property: JsonPropertyName("name")] string Name,
     [property: JsonPropertyName("serviceAccountType")] CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
     [property: JsonPropertyName("isOwner")] bool IsOwner,
+    [property: JsonPropertyName("isProvider")] bool IsProvider,
     [property: JsonPropertyName("offerSubscriptionId")] Guid? OfferSubscriptionId,
     [property: JsonPropertyName("connector")] ConnectorResponseData? ConnectorData,
     [property: JsonPropertyName("offer")] OfferResponseData? OfferSubscriptionsData

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -162,9 +162,8 @@ public class ServiceAccountRepository : IServiceAccountRepository
                 .AsNoTracking()
                 .Where(serviceAccount =>
                     (!isOwner.HasValue && (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) ||
-                    isOwner.HasValue &&
-                        (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN ||
-                        !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED)) &&
+                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId ||
+                        !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId)) &&
                     serviceAccount.Identity!.UserStatusId == userStatusId &&
                     (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
                 .GroupBy(serviceAccount => serviceAccount.Identity!.UserStatusId),
@@ -174,7 +173,8 @@ public class ServiceAccountRepository : IServiceAccountRepository
                 serviceAccount.ClientClientId,
                 serviceAccount.Name,
                 serviceAccount.CompanyServiceAccountTypeId,
-                serviceAccount.CompaniesLinkedServiceAccount!.Provider == null,
+                serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId,
+                serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId,
                 serviceAccount.OfferSubscriptionId,
                 serviceAccount.Connector == null
                     ? null

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -162,7 +162,8 @@ public class ServiceAccountRepository : IServiceAccountRepository
                 .AsNoTracking()
                 .Where(serviceAccount =>
                     (!isOwner.HasValue && (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) ||
-                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId)) &&
+                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN ||
+                    !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED)) &&
                     serviceAccount.Identity!.UserStatusId == userStatusId &&
                     (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
                 .GroupBy(serviceAccount => serviceAccount.Identity!.UserStatusId),

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -162,8 +162,9 @@ public class ServiceAccountRepository : IServiceAccountRepository
                 .AsNoTracking()
                 .Where(serviceAccount =>
                     (!isOwner.HasValue && (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) ||
-                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN ||
-                    !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED)) &&
+                    isOwner.HasValue &&
+                        (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN ||
+                        !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId && serviceAccount.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED)) &&
                     serviceAccount.Identity!.UserStatusId == userStatusId &&
                     (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
                 .GroupBy(serviceAccount => serviceAccount.Identity!.UserStatusId),

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -160,34 +160,40 @@ public class ServiceAccountRepository : IServiceAccountRepository
             take,
             _dbContext.CompanyServiceAccounts
                 .AsNoTracking()
-                .Where(serviceAccount =>
-                    (!isOwner.HasValue && (serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId) ||
-                    isOwner.HasValue && (isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId ||
-                        !isOwner.Value && serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId)) &&
-                    serviceAccount.Identity!.UserStatusId == userStatusId &&
-                    (clientId == null || EF.Functions.ILike(serviceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
-                .GroupBy(serviceAccount => serviceAccount.Identity!.UserStatusId),
-            serviceAccounts => serviceAccounts.OrderBy(serviceAccount => serviceAccount.Name),
-            serviceAccount => new CompanyServiceAccountData(
-                serviceAccount.Id,
-                serviceAccount.ClientClientId,
-                serviceAccount.Name,
-                serviceAccount.CompanyServiceAccountTypeId,
-                serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId,
-                serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId,
-                serviceAccount.OfferSubscriptionId,
-                serviceAccount.Connector == null
+                .Select(serviceAccount => new
+                {
+                    ServiceAccount = serviceAccount,
+                    IsOwner = serviceAccount.CompaniesLinkedServiceAccount!.Owners == userCompanyId,
+                    IsProvider = serviceAccount.CompaniesLinkedServiceAccount!.Provider == userCompanyId
+                })
+                .Where(x =>
+                    (isOwner.HasValue
+                        ? isOwner.Value && x.IsOwner || !isOwner.Value && x.IsProvider
+                        : x.IsOwner || x.IsProvider) &&
+                    x.ServiceAccount.Identity!.UserStatusId == userStatusId &&
+                    (clientId == null || EF.Functions.ILike(x.ServiceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
+                .GroupBy(x => x.ServiceAccount.Identity!.UserStatusId),
+            x => x.OrderBy(x => x.ServiceAccount.Name),
+            x => new CompanyServiceAccountData(
+                x.ServiceAccount.Id,
+                x.ServiceAccount.ClientClientId,
+                x.ServiceAccount.Name,
+                x.ServiceAccount.CompanyServiceAccountTypeId,
+                x.IsOwner,
+                x.IsProvider,
+                x.ServiceAccount.OfferSubscriptionId,
+                x.ServiceAccount.Connector == null
                     ? null
                     : new ConnectorResponseData(
-                        serviceAccount.Connector.Id,
-                        serviceAccount.Connector.Name),
-                serviceAccount!.OfferSubscription == null
+                        x.ServiceAccount.Connector.Id,
+                        x.ServiceAccount.Connector.Name),
+                x!.ServiceAccount.OfferSubscription == null
                     ? null
                     : new OfferResponseData(
-                        serviceAccount.OfferSubscription.OfferId,
-                        serviceAccount.OfferSubscription.Offer!.OfferTypeId,
-                        serviceAccount.OfferSubscription.Offer.Name,
-                        serviceAccount.OfferSubscription.Id)))
+                        x.ServiceAccount.OfferSubscription.OfferId,
+                        x.ServiceAccount.OfferSubscription.Offer!.OfferTypeId,
+                        x.ServiceAccount.OfferSubscription.Offer.Name,
+                        x.ServiceAccount.OfferSubscription.Id)))
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -5,7 +5,6 @@
     "description": "SA for offer subscription",
     "company_service_account_type_id": 2,
     "offer_subscription_id": "3DE6A31F-A5D1-4F60-AA3A-4B1A769BECBF",
-    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
     "client_client_id":"sa-x-4"
   },
   {
@@ -13,8 +12,7 @@
     "name": "sa-test",
     "description": "SA with offer subscription",
     "company_service_account_type_id": 1,
-    "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5552",
-    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542"
+    "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5552"
   },
   {
     "id": "d0c8ae19-d4f3-49cc-9cb4-6c766d4680f4",
@@ -22,7 +20,6 @@
     "description": "SA with connector",
     "company_service_account_type_id": 1,
     "offer_subscription_id": null,
-    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
     "client_client_id": "sa-x-1"
   },
   {
@@ -30,8 +27,7 @@
     "name": "test-user-service-account",
     "description": "test-user-service-account-desc",
     "company_service_account_type_id": 1,
-    "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5552",
-    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542"
+    "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5552"
   },
   {
     "id": "93eecd4e-ca47-4dd2-85bf-775ea72eb009",
@@ -39,7 +35,6 @@
     "description": "test-user-service-account-descs",
     "company_service_account_type_id": 1,
     "offer_subscription_id": "0b2ca541-206d-48ad-bc02-fb61fbcb5562",
-    "company_id": "41fd2ab8-71cd-4546-9bef-a388d91b2543",
     "client_client_id": "sa-x-2"
   },
   {
@@ -48,7 +43,6 @@
     "description": "test-user-service-account-descs",
     "company_service_account_type_id": 1,
     "offer_subscription_id": null,
-    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f8",
     "client_client_id": "sa-x-3"
   },
   {
@@ -57,7 +51,6 @@
     "description": "inactive service account",
     "company_service_account_type_id": 1,
     "offer_subscription_id": null,
-    "company_id": "729e0af2-6723-4a7f-85a1-833d84b39bdf",
     "client_client_id": "sa-x-inactive"
   },
   {
@@ -66,7 +59,6 @@
     "description": "test-user-service-account-desc-0",
     "company_service_account_type_id": 1,
     "offer_subscription_id": null,
-    "company_id": "729e0af2-6723-4a7f-85a1-833d84b39bdf",
     "client_client_id": "sa-x-0"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -256,6 +256,36 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
     }
 
     [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithOwnerTrue_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, true, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
+
+        // Assert
+        result!.Count.Should().Be(13);
+        result.Data.Should().HaveCount(10)
+            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN);
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithOwnerFalse_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, false, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
+
+        // Assert
+        result!.Count.Should().Be(1);
+        result.Data.Should().HaveCount(1)
+            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED);
+    }
+
+    [Fact]
     public async Task GetOwnCompanyServiceAccountsUntracked_WithClientIdAndProvider_ReturnsExpectedResult()
     {
         // Arrange

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -266,19 +266,21 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, true, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
 
         // Assert
-        result!.Count.Should().Be(13);
+        result!.Count.Should().Be(12);
         result.Data.Should().HaveCount(10)
+            .And.AllSatisfy(x => x.CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN))
+            .And.BeInAscendingOrder(x => x.Name)
             .And.Satisfy(
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201029"),
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201026"),
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201027"),
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201030"),
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201031"),
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201032"),
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201023"),
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201024"),
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201028"),
-                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("d0c8ae19-d4f3-49cc-9cb4-6c766d4680f2"));
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201029"),
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201026"),
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201027"),
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201030"),
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201031"),
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201032"),
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201023"),
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201024"),
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201028"),
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201007"));
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -294,7 +294,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         result!.Count.Should().Be(1);
         result.Data.Should().HaveCount(1)
             .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED
-                && x.IsOwner == false && x.IsProvider == true);
+                && !x.IsOwner && x.IsProvider);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -236,7 +236,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         if (expected > 0)
         {
             result.Data.First().CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.MANAGED);
-            result.Data.First().IsOwner.Should().BeFalse();
+            result.Data.First().IsOwner.Should().BeTrue();
+            result.Data.First().IsProvider.Should().BeFalse();
         }
     }
 
@@ -292,7 +293,8 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result!.Count.Should().Be(1);
         result.Data.Should().HaveCount(1)
-            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED);
+            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED
+                && x.IsOwner == false && x.IsProvider == true);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -267,7 +267,17 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result!.Count.Should().Be(13);
         result.Data.Should().HaveCount(10)
-            .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN);
+            .And.Satisfy(
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201029"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201026"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201027"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201030"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201031"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201032"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201023"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201024"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201028"),
+                x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN && x.ServiceAccountId == new Guid("d0c8ae19-d4f3-49cc-9cb4-6c766d4680f2"));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

fixed isOwner filter

## Why

when hitting GET: api/administration/serviceaccount/owncompany/serviceaccounts with isOwner flag as true it results
companyServiceAccountTypeIds as Managed Type records instead of showing only Own Type records, now it is fixed by adding additional check condition

## Issue

Ref : #563

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
