### PR TITLE
fix(identityprovider): allow null values in get- or create identityprovider response

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IdentityProviderBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IdentityProviderBusinessLogic.cs
@@ -523,19 +523,17 @@ public class IdentityProviderBusinessLogic : IIdentityProviderBusinessLogic
             identityProviderDataOidc?.Enabled,
             identityProviderMapper)
         {
-            Oidc = identityProviderDataOidc == null ?
-                null :
-                new IdentityProviderDetailsOidc(
+            Oidc = identityProviderDataOidc == null
+                ? null
+                : new IdentityProviderDetailsOidc(
                     metadataUrl,
                     identityProviderDataOidc.AuthorizationUrl,
                     identityProviderDataOidc.TokenUrl,
                     identityProviderDataOidc.LogoutUrl,
                     identityProviderDataOidc.ClientId,
                     !string.IsNullOrEmpty(identityProviderDataOidc.ClientSecret),
-                    identityProviderDataOidc.ClientAuthMethod)
-                {
-                    SignatureAlgorithm = identityProviderDataOidc.SignatureAlgorithm
-                }
+                    identityProviderDataOidc.ClientAuthMethod,
+                    identityProviderDataOidc.SignatureAlgorithm)
         };
     }
 
@@ -575,9 +573,9 @@ public class IdentityProviderBusinessLogic : IIdentityProviderBusinessLogic
             identityProviderDataSaml?.Enabled,
             identityProviderMapper)
         {
-            Saml = identityProviderDataSaml == null ?
-                null :
-                new IdentityProviderDetailsSaml(
+            Saml = identityProviderDataSaml == null
+                ? null
+                : new IdentityProviderDetailsSaml(
                     identityProviderDataSaml.EntityId,
                     identityProviderDataSaml.SingleSignOnServiceUrl)
         };

--- a/src/administration/Administration.Service/BusinessLogic/UserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserBusinessLogic.cs
@@ -122,7 +122,7 @@ public class UserBusinessLogic : IUserBusinessLogic
             user => user.userName ?? user.eMail,
             user => user.eMail);
 
-        var companyDisplayName = await _userProvisioningService.GetIdentityProviderDisplayName(companyNameIdpAliasData.IdpAlias).ConfigureAwait(ConfigureAwaitOptions.None);
+        var companyDisplayName = await _userProvisioningService.GetIdentityProviderDisplayName(companyNameIdpAliasData.IdpAlias).ConfigureAwait(ConfigureAwaitOptions.None) ?? companyNameIdpAliasData.IdpAlias;
 
         await foreach (var (companyUserId, userName, password, error) in _userProvisioningService.CreateOwnCompanyIdpUsersAsync(companyNameIdpAliasData, userCreationInfoIdps).ConfigureAwait(false))
         {
@@ -163,7 +163,7 @@ public class UserBusinessLogic : IUserBusinessLogic
     public async Task<Guid> CreateOwnCompanyIdpUserAsync(Guid identityProviderId, UserCreationInfoIdp userCreationInfo)
     {
         var (companyNameIdpAliasData, nameCreatedBy) = await _userProvisioningService.GetCompanyNameIdpAliasData(identityProviderId, _identityData.IdentityId).ConfigureAwait(ConfigureAwaitOptions.None);
-        var displayName = await _userProvisioningService.GetIdentityProviderDisplayName(companyNameIdpAliasData.IdpAlias).ConfigureAwait(ConfigureAwaitOptions.None);
+        var displayName = await _userProvisioningService.GetIdentityProviderDisplayName(companyNameIdpAliasData.IdpAlias).ConfigureAwait(ConfigureAwaitOptions.None) ?? companyNameIdpAliasData.IdpAlias;
 
         if (!userCreationInfo.Roles.Any())
         {

--- a/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
@@ -129,7 +129,7 @@ public class UserUploadBusinessLogic : IUserUploadBusinessLogic
 
         UserCreationRoleDataIdpInfo? userCreationInfo = null;
 
-        var displayName = await _userProvisioningService.GetIdentityProviderDisplayName(companyNameIdpAliasData.IdpAlias).ConfigureAwait(ConfigureAwaitOptions.None);
+        var displayName = await _userProvisioningService.GetIdentityProviderDisplayName(companyNameIdpAliasData.IdpAlias).ConfigureAwait(ConfigureAwaitOptions.None) ?? companyNameIdpAliasData.IdpAlias;
 
         await foreach (var result in
             _userProvisioningService

--- a/src/administration/Administration.Service/Models/IdentityProviderDetails.cs
+++ b/src/administration/Administration.Service/Models/IdentityProviderDetails.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -25,7 +24,15 @@ using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 
-public record IdentityProviderDetails(Guid IdentityProviderId, string? Alias, IdentityProviderCategoryId IdentityProviderCategoryId, IdentityProviderTypeId IdentityProviderTypeId, string? DisplayName, string? RedirectUrl, bool? Enabled, IEnumerable<IdentityProviderMapperModel>? Mappers)
+public record IdentityProviderDetails(
+    Guid IdentityProviderId,
+    string? Alias,
+    IdentityProviderCategoryId IdentityProviderCategoryId,
+    IdentityProviderTypeId IdentityProviderTypeId,
+    string? DisplayName,
+    string? RedirectUrl,
+    bool? Enabled,
+    IEnumerable<IdentityProviderMapperModel>? Mappers)
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IdentityProviderDetailsOidc? Oidc { get; init; } = null;
@@ -34,10 +41,18 @@ public record IdentityProviderDetails(Guid IdentityProviderId, string? Alias, Id
     public IdentityProviderDetailsSaml? Saml { get; init; } = null;
 }
 
-public record IdentityProviderDetailsOidc(string? MetadataUrl, string AuthorizationUrl, string TokenUrl, string? LogoutUrl, string ClientId, bool HasClientSecret, IamIdentityProviderClientAuthMethod ClientAuthMethod)
-{
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public IamIdentityProviderSignatureAlgorithm? SignatureAlgorithm { get; init; } = null;
-}
+public record IdentityProviderDetailsOidc(
+    string? MetadataUrl,
+    string? AuthorizationUrl,
+    string? TokenUrl,
+    string? LogoutUrl,
+    string? ClientId,
+    bool HasClientSecret,
+    IamIdentityProviderClientAuthMethod? ClientAuthMethod,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] IamIdentityProviderSignatureAlgorithm? SignatureAlgorithm
+);
 
-public record IdentityProviderDetailsSaml(string ServiceProviderEntityId, string SingleSignOnServiceUrl);
+public record IdentityProviderDetailsSaml(
+    string? ServiceProviderEntityId,
+    string? SingleSignOnServiceUrl
+);

--- a/src/administration/Administration.Service/Models/PartnerRegistrationData.cs
+++ b/src/administration/Administration.Service/Models/PartnerRegistrationData.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -38,7 +37,7 @@ public record PartnerRegistrationData
     IEnumerable<CompanyUniqueIdData> UniqueIds,
     IEnumerable<UserDetailData> UserDetails,
     IEnumerable<CompanyRoleId> CompanyRoles
-) : Registration.Common.RegistrationData(Name, City, StreetName, CountryAlpha2Code, BusinessPartnerNumber, null, Region, null, StreetNumber, ZipCode, UniqueIds);
+) : RegistrationData(Name, City, StreetName, CountryAlpha2Code, BusinessPartnerNumber, null, Region, null, StreetNumber, ZipCode, UniqueIds);
 
 public record UserDetailData(
     Guid? IdentityProviderId,

--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -245,7 +245,10 @@
     }
   },
   "ServiceAccount": {
-    "ClientId": ""
+    "ClientId": "",
+    "DimCreationRoles": [],
+    "EncryptionConfigIndex": 0,
+    "EncryptionConfigs": []
   },
   "Connectors": {
     "MaxPageSize": 20,

--- a/src/provisioning/Provisioning.Library/Extensions/RealmManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/RealmManager.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -19,14 +18,12 @@
  ********************************************************************************/
 
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library;
-using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.RealmsAdmin;
-using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
 
 public partial class ProvisioningManager
 {
-    private static async ValueTask UpdateSharedRealmAsync(KeycloakClient keycloak, string alias, string displayName, string? loginTheme)
+    private static async ValueTask UpdateSharedRealmAsync(KeycloakClient keycloak, string alias, string? displayName, string? loginTheme)
     {
         var realm = await keycloak.GetRealmAsync(alias).ConfigureAwait(ConfigureAwaitOptions.None);
         realm.DisplayName = displayName;

--- a/src/provisioning/Provisioning.Library/Extensions/RoleManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/RoleManager.cs
@@ -35,8 +35,8 @@ public partial class ProvisioningManager
             return count switch
             {
                 0 => (idOfClient, Enumerable.Empty<Role>()),
-                1 => (idOfClient, Enumerable.Repeat(await _CentralIdp.GetRoleByNameAsync(_Settings.CentralRealm, idOfClient, roleNames.Single()).ConfigureAwait(ConfigureAwaitOptions.None), 1)),
-                _ => (idOfClient, (await _CentralIdp.GetRolesAsync(_Settings.CentralRealm, idOfClient).ConfigureAwait(ConfigureAwaitOptions.None)).Where(x => roleNames.Contains(x.Name))),
+                1 => (idOfClient, Enumerable.Repeat(await _centralIdp.GetRoleByNameAsync(_settings.CentralRealm, idOfClient, roleNames.Single()).ConfigureAwait(ConfigureAwaitOptions.None), 1)),
+                _ => (idOfClient, (await _centralIdp.GetRolesAsync(_settings.CentralRealm, idOfClient).ConfigureAwait(ConfigureAwaitOptions.None)).Where(x => roleNames.Contains(x.Name))),
             };
         }
         catch (KeycloakEntityNotFoundException)
@@ -53,7 +53,7 @@ public partial class ProvisioningManager
                 if (clientId == null || !roles.Any())
                     return;
 
-                await _CentralIdp.DeleteClientRoleMappingsFromUserAsync(_Settings.CentralRealm, centralUserId, clientId, roles).ConfigureAwait(ConfigureAwaitOptions.None);
+                await _centralIdp.DeleteClientRoleMappingsFromUserAsync(_settings.CentralRealm, centralUserId, clientId, roles).ConfigureAwait(ConfigureAwaitOptions.None);
             }
         )).ConfigureAwait(ConfigureAwaitOptions.None);
 
@@ -72,7 +72,7 @@ public partial class ProvisioningManager
             Exception? error;
             try
             {
-                await _CentralIdp.AddClientRoleMappingsToUserAsync(_Settings.CentralRealm, centralUserId, clientId, roles).ConfigureAwait(ConfigureAwaitOptions.None);
+                await _centralIdp.AddClientRoleMappingsToUserAsync(_settings.CentralRealm, centralUserId, clientId, roles).ConfigureAwait(ConfigureAwaitOptions.None);
                 assigned = roles.Select(role => role.Name ?? throw new KeycloakInvalidResponseException("name of role is null"));
                 error = null;
             }
@@ -101,7 +101,7 @@ public partial class ProvisioningManager
                     ClientRole = true
                 }))
         {
-            await _CentralIdp.CreateRoleAsync(_Settings.CentralRealm, result.ClientId, role).ConfigureAwait(ConfigureAwaitOptions.None);
+            await _centralIdp.CreateRoleAsync(_settings.CentralRealm, result.ClientId, role).ConfigureAwait(ConfigureAwaitOptions.None);
         }
     }
 
@@ -112,7 +112,7 @@ public partial class ProvisioningManager
             ClientRole = true
         }).Select(async role =>
             {
-                await _CentralIdp.CreateRoleAsync(_Settings.CentralRealm, clientId, role).ConfigureAwait(ConfigureAwaitOptions.None);
+                await _centralIdp.CreateRoleAsync(_settings.CentralRealm, clientId, role).ConfigureAwait(ConfigureAwaitOptions.None);
             }
         ));
 }

--- a/src/provisioning/Provisioning.Library/IProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/IProvisioningManager.cs
@@ -54,7 +54,7 @@ public interface IProvisioningManager
     Task ResetSharedUserPasswordAsync(string realm, string userId);
     Task<IEnumerable<string>> GetClientRoleMappingsForUserAsync(string userId, string clientId);
     ValueTask<bool> IsCentralIdentityProviderEnabled(string alias);
-    Task<string> GetCentralIdentityProviderDisplayName(string alias);
+    Task<string?> GetCentralIdentityProviderDisplayName(string alias);
     ValueTask<IdentityProviderConfigOidc> GetCentralIdentityProviderDataOIDCAsync(string alias);
     ValueTask SetSharedIdentityProviderStatusAsync(string alias, bool enabled);
     ValueTask SetCentralIdentityProviderStatusAsync(string alias, bool enabled);

--- a/src/provisioning/Provisioning.Library/Models/IdentityProviderConfigOidc.cs
+++ b/src/provisioning/Provisioning.Library/Models/IdentityProviderConfigOidc.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -22,5 +21,25 @@ using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 
-public record IdentityProviderConfigOidc(string DisplayName, string RedirectUrl, string TokenUrl, string? LogoutUrl, string ClientId, string? ClientSecret, bool Enabled, string AuthorizationUrl, IamIdentityProviderClientAuthMethod ClientAuthMethod, IamIdentityProviderSignatureAlgorithm? SignatureAlgorithm);
-public record IdentityProviderEditableConfigOidc(string Alias, string DisplayName, string MetadataUrl, IamIdentityProviderClientAuthMethod ClientAuthMethod, string ClientId, string? Secret = null, IamIdentityProviderSignatureAlgorithm? SignatureAlgorithm = null);
+public record IdentityProviderConfigOidc(
+    string? DisplayName,
+    string? RedirectUrl,
+    string? TokenUrl,
+    string? LogoutUrl,
+    string? ClientId,
+    string? ClientSecret,
+    bool? Enabled,
+    string? AuthorizationUrl,
+    IamIdentityProviderClientAuthMethod? ClientAuthMethod,
+    IamIdentityProviderSignatureAlgorithm? SignatureAlgorithm
+);
+
+public record IdentityProviderEditableConfigOidc(
+    string Alias,
+    string DisplayName,
+    string MetadataUrl,
+    IamIdentityProviderClientAuthMethod ClientAuthMethod,
+    string ClientId,
+    string? Secret = null,
+    IamIdentityProviderSignatureAlgorithm? SignatureAlgorithm = null
+);

--- a/src/provisioning/Provisioning.Library/Models/IdentityProviderConfigSaml.cs
+++ b/src/provisioning/Provisioning.Library/Models/IdentityProviderConfigSaml.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
  * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -20,5 +19,18 @@
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 
-public record IdentityProviderConfigSaml(string DisplayName, string RedirectUrl, string ClientId, bool Enabled, string EntityId, string SingleSignOnServiceUrl);
-public record IdentityProviderEditableConfigSaml(string alias, string displayName, string entityId, string singleSignOnServiceUrl);
+public record IdentityProviderConfigSaml(
+    string? DisplayName,
+    string? RedirectUrl,
+    string? ClientId,
+    bool? Enabled,
+    string? EntityId,
+    string? SingleSignOnServiceUrl
+);
+
+public record IdentityProviderEditableConfigSaml(
+    string Alias,
+    string DisplayName,
+    string EntityId,
+    string SingleSignOnServiceUrl
+);

--- a/src/provisioning/Provisioning.Library/Service/IUserProvisioningService.cs
+++ b/src/provisioning/Provisioning.Library/Service/IUserProvisioningService.cs
@@ -31,7 +31,7 @@ public interface IUserProvisioningService
     Task HandleCentralKeycloakCreation(UserCreationRoleDataIdpInfo user, Guid companyUserId, string companyName, string? businessPartnerNumber, Identity? identity, IEnumerable<IdentityProviderLink> identityProviderLinks, IUserRepository userRepository, IUserRolesRepository userRolesRepository);
     Task<(CompanyNameIdpAliasData IdpAliasData, string NameCreatedBy)> GetCompanyNameIdpAliasData(Guid identityProviderId, Guid companyUserId);
     Task<(CompanyNameIdpAliasData IdpAliasData, string NameCreatedBy)> GetCompanyNameSharedIdpAliasData(Guid companyUserId, Guid? applicationId = null);
-    Task<string> GetIdentityProviderDisplayName(string idpAlias);
+    Task<string?> GetIdentityProviderDisplayName(string idpAlias);
     IAsyncEnumerable<UserRoleData> GetRoleDatas(IEnumerable<UserRoleConfig> clientRoles);
     Task<IEnumerable<UserRoleData>> GetOwnCompanyPortalRoleDatas(string clientId, IEnumerable<string> roles, Guid companyId);
     Task<(Identity? Identity, Guid CompanyUserId)> GetOrCreateCompanyUser(IUserRepository userRepository, string alias, UserCreationRoleDataIdpInfo user, Guid companyId, Guid identityProviderId, string? businessPartnerNumber);

--- a/src/provisioning/Provisioning.Library/Service/UserProvisioningService.cs
+++ b/src/provisioning/Provisioning.Library/Service/UserProvisioningService.cs
@@ -246,7 +246,7 @@ public class UserProvisioningService : IUserProvisioningService
         return (new CompanyNameIdpAliasData(company.CompanyId, company.CompanyName, company.BusinessPartnerNumber, idpAlias.Alias, idpAlias.IdentityProviderId, true), createdByName);
     }
 
-    public Task<string> GetIdentityProviderDisplayName(string idpAlias) =>
+    public Task<string?> GetIdentityProviderDisplayName(string idpAlias) =>
         _provisioningManager.GetCentralIdentityProviderDisplayName(idpAlias);
 
     private async Task<Guid> ValidateDuplicateIdpUsersAsync(IUserRepository userRepository, string alias, UserCreationRoleDataIdpInfo user, Guid companyId)

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -423,7 +423,7 @@ public class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
         var modified = await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
 
-        var companyDisplayName = await _userProvisioningService.GetIdentityProviderDisplayName(companyNameIdpAliasData.IdpAlias).ConfigureAwait(ConfigureAwaitOptions.None);
+        var companyDisplayName = await _userProvisioningService.GetIdentityProviderDisplayName(companyNameIdpAliasData.IdpAlias).ConfigureAwait(ConfigureAwaitOptions.None) ?? companyNameIdpAliasData.IdpAlias;
         var mailParameters = ImmutableDictionary.CreateRange(new[]
         {
             KeyValuePair.Create("password", password),

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/IdentityProviderBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/IdentityProviderBusinessLogicTests.cs
@@ -1706,7 +1706,7 @@ public class IdentityProviderBusinessLogicTests
         var result = await sut.UpdateOwnCompanyIdentityProviderAsync(identityProviderId, data, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _provisioningManager.UpdateCentralIdentityProviderDataSAMLAsync(A<IdentityProviderEditableConfigSaml>.That.Matches(x => x.singleSignOnServiceUrl == "https://sso.com" && x.alias == "cl1")))
+        A.CallTo(() => _provisioningManager.UpdateCentralIdentityProviderDataSAMLAsync(A<IdentityProviderEditableConfigSaml>.That.Matches(x => x.SingleSignOnServiceUrl == "https://sso.com" && x.Alias == "cl1")))
             .MustHaveHappenedOnceExactly();
         result.Mappers.Should().HaveCount(2);
         result.DisplayName.Should().Be("dis-saml");


### PR DESCRIPTION
## Description

change response-type-definition of endpoint GET / POST /api/administration/identityprovider/owncompany/identityproviders to allow null-values

## Why

as clientId is not a mandatory parameter when creating a new identityprovider right after its creation the identityproviders config-property clientId is not set when querying the keycloak api. ClientId being null results in an InvalidKeycloakResponse-exception being thrown. As a result the response when creating a new identityProvider despite the actual creation is successful an internal error is being returned.

## Issue

#682 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
