### PR TITLE
fix(seeding): add missing service accounts and improve descriptions

### DIFF
--- a/src/notifications/Notifications.Service/Controllers/NotificationController.cs
+++ b/src/notifications/Notifications.Service/Controllers/NotificationController.cs
@@ -191,7 +191,7 @@ public class NotificationController : ControllerBase
     /// </summary>
     /// <param name="data">Data for the notification</param>
     /// <returns>Return NoContent</returns>
-    /// <remarks>Example: POST: /api/notification</remarks>
+    /// <remarks>Example: POST: /api/notification/ssi-credentials</remarks>
     /// <response code="204">Count of the notifications.</response>
     /// <response code="400">NotificationStatus does not exist.</response>
     /// <response code="403">IamUserId is not assigned.</response>

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
@@ -94,5 +94,21 @@
     "company_service_account_type_id": 2,
     "client_id": "8ac37496-cca9-41ba-9684-cf7348f880d5",
     "client_client_id": "sa-cl24-01"
+  },
+  {
+    "id": "f3498fe6-e0e5-413b-a725-39bf5c7c1959",
+    "name": "sa-cl2-04",
+    "description": "Technical User SSI Credential Issuer - Portal to SSI Credential Issuer (portal helm chart: backend.processesworker.issuerComponent.clientId)",
+    "company_service_account_type_id": 2,
+    "client_id": "beb01d13-04e2-4a2b-a909-8b4166b3dcf7",
+    "client_client_id": "sa-cl2-04"
+  },
+  {
+    "id": "ab7f01ea-cbb9-4d58-9efa-ea992395f997",
+    "name": "sa-cl2-05",
+    "description": "Technical User Dim Layer - Dim Layer to Portal (dim helm chart: processesworker.callback.clientId)",
+    "company_service_account_type_id": 2,
+    "client_id": "beb01d13-04e2-4a2b-a909-8b4166b3dcf7",
+    "client_client_id": "sa-cl2-05"
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
@@ -2,7 +2,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201007",
     "name": "sa-cl5-custodian-2",
-    "description": "Technical User for Portal to call Managed Identity Wallet",
+    "description": "Technical User for the Connection between the Portal and the Managed Identity Wallet\nAssigned Permissions: delete_wallet, add_wallets, delete_wallets, update_wallets, add_wallet, view_wallet, update_wallet, view_wallets\nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and Managed Identity Wallet. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "50fa6455-a775-4683-b407-57a33a9b9f3b",
     "client_client_id": "sa-cl5-custodian-2"
@@ -10,7 +10,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201023",
     "name": "sa-cl3-cx-1",
-    "description": "Semantic Hub",
+    "description": "Technical User for the Connection between the Portal and the Semantic Hub\nAssigned Permissions: Semantic Model Management, Identity Wallet Management, Dataspace Discovery\nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and Semantic Hub. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "7beaee76-d447-4531-9433-fd9ce19d1460",
     "client_client_id": "sa-cl3-cx-1"
@@ -18,7 +18,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201024",
     "name": "sa-cl7-cx-5",
-    "description": "User for Portal to access BPDM for Company Address publishing into the BPDM",
+    "description": "Technical User for the Connection between the Portal and the BPDM\nAssigned Permissions: BPDM Pool Admin, BPDM Sharing Admin\nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and BPDM. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "183aae87-c9cf-4d70-934b-629aa6974c54",
     "client_client_id": "sa-cl7-cx-5"
@@ -26,7 +26,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201026",
     "name": "sa-cl2-01",
-    "description": "Technical User GX-Clearinghouse to enable th CH to POST company application VC creation result",
+    "description": "Technical User for the Connection between the Portal and the Clearinghouse\nAssigned Permissions: update_application_checklist_value\nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and Clearinghouse. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "6bf6f4e5-562c-4382-945f-e5fef59423e2",
     "client_client_id": "sa-cl2-01"
@@ -34,7 +34,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201027",
     "name": "sa-cl2-02",
-    "description": "Technical User GX-Clearinghouse to enable th CH to POST Self-Description (SD) for LP and SO",
+    "description": "Technical User for the Connection between the Portal and the SD Factory\nAssigned Permissions: submit_connector_sd, update_application_checklist_value\nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and SD Factory. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "2d19b59b-4970-4cc0-a561-a9dac9d49045",
     "client_client_id": "sa-cl2-02"
@@ -42,7 +42,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201028",
     "name": "sa-cl8-cx-1",
-    "description": "Technical User created for the portal to call the self-description factory for SD creation LP and SO",
+    "description": "Technical User for the Connection between the Portal and the SD Factory\nAssigned Permissions: add_self_descriptions\nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and SD Factory. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "c2bdc736-ca35-43c4-8e18-27e7425df9f0",
     "client_client_id": "sa-cl8-cx-1"
@@ -58,7 +58,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201029",
     "name": "sa-cl1-reg-2",
-    "description": "Technical User for Portal-Backend to call Keycloak",
+    "description": "Technical User for the Connection between the Portal and Keycloak\nAssigned Permissions: manage-users, manage-identity-providers, manage-clients\nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and Keycloak. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "cdf11dff-530a-4fd4-97b9-84e4d60ac21e",
     "client_client_id": "sa-cl1-reg-2"
@@ -66,7 +66,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201030",
     "name": "sa-cl2-03",
-    "description": "Technical User AutoSetup trigger",
+    "description": "Technical User for the Connection between the Portal and the Vendor Autosetup\nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and the Vendor Autosetup. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "cad1382b-0dd4-4ac7-8183-1c08386c84e8",
     "client_client_id": "sa-cl2-03"
@@ -74,7 +74,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201031",
     "name": "sa-cl21-01",
-    "description": "Technical User Discovery Finder",
+    "description": "Technical User for the Connection between the Discovery Finder and the Portal\nAssigned Permissions: view_discovery_endpoint, delete_discovery_endpoint, add_discovery_endpoint\nNote: This user is a seeded user and is specifically designated for the technical integration between the Discovery Finder and the Portal. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "b09392dd-8b0f-4a32-bb0b-d00a4091b890",
     "client_client_id": "sa-cl21-01"
@@ -82,7 +82,7 @@
   {
     "id": "7e85a0b8-0001-ab67-10d1-0ef508201032",
     "name": "sa-cl22-01",
-    "description": "Technical User BPN Discovery",
+    "description": "Technical User for the Connection between the BPN Discovery and the Portal\nAssigned Permissions: add_bpn_discovery, delete_bpn_discovery, view_bpn_discovery\nNote: This user is a seeded user and is specifically designated for the technical integration between the BPN Discovery and the Portal. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "f1806543-d0ca-41cb-b029-883cdfb11a8e",
     "client_client_id": "sa-cl22-01"
@@ -90,7 +90,7 @@
   {
     "id": "33480038-9acf-40e2-9127-c9c7a9cbed99",
     "name": "sa-cl24-01",
-    "description": "Technical User for SSI Credential Issuer (credential issuer helm chart: processesworker.portal.clientId)",
+    "description": "Technical User for the Connection between the SSI Credential Issuer and the Portal\nAssigned Permissions: update_application_membership_credential, send_mail, update_application_bpn_credential, create_notifications\nNote: This user is a seeded user and is specifically designated for the technical integration between the SSI Credential Issuer and the Portal. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "8ac37496-cca9-41ba-9684-cf7348f880d5",
     "client_client_id": "sa-cl24-01"
@@ -98,7 +98,7 @@
   {
     "id": "f3498fe6-e0e5-413b-a725-39bf5c7c1959",
     "name": "sa-cl2-04",
-    "description": "Technical User SSI Credential Issuer - Portal to SSI Credential Issuer (portal helm chart: backend.processesworker.issuerComponent.clientId)",
+    "description": "Technical User for the Connection between the Portal and the SSI Credential Issuer\nAssigned Permissions: decision_ssicredential, view_use_case_participation, revoke_credential, revoke_credentials_issuer, request_ssicredential, view_certificates \nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and the SSI Credential Issuer. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "beb01d13-04e2-4a2b-a909-8b4166b3dcf7",
     "client_client_id": "sa-cl2-04"
@@ -106,7 +106,7 @@
   {
     "id": "ab7f01ea-cbb9-4d58-9efa-ea992395f997",
     "name": "sa-cl2-05",
-    "description": "Technical User Dim Layer - Dim Layer to Portal (dim helm chart: processesworker.callback.clientId)",
+    "description": "Technical User for the Connection between the Portal and the Dim Layer\nAssigned Permissions: store_didDocument, technical_roles_management\nNote: This user is a seeded user and is specifically designated for the technical integration between the Portal and the Dim Layer. As a result, dynamic user self-services such as password reset, role change, deletion, etc. are not applicable to this user. The user is exclusively available within the technical user management of the portal to ensure transparency and streamline the connection process.",
     "company_service_account_type_id": 2,
     "client_id": "beb01d13-04e2-4a2b-a909-8b4166b3dcf7",
     "client_client_id": "sa-cl2-05"

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/company_service_accounts.json
@@ -86,5 +86,13 @@
     "company_service_account_type_id": 2,
     "client_id": "f1806543-d0ca-41cb-b029-883cdfb11a8e",
     "client_client_id": "sa-cl22-01"
+  },
+  {
+    "id": "33480038-9acf-40e2-9127-c9c7a9cbed99",
+    "name": "sa-cl24-01",
+    "description": "Technical User for SSI Credential Issuer (credential issuer helm chart: processesworker.portal.clientId)",
+    "company_service_account_type_id": 2,
+    "client_id": "8ac37496-cca9-41ba-9684-cf7348f880d5",
+    "client_client_id": "sa-cl24-01"
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
@@ -104,5 +104,21 @@
     "user_status_id": 1,
     "user_entity_id": "e4a7204c-2fa8-4909-baa9-3fbc2fa6ec12",
     "identity_type_id": 2
+  },
+  {
+    "id": "f3498fe6-e0e5-413b-a725-39bf5c7c1959",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "date_created": "2022-06-01 18:01:33.439000 +00:00",
+    "user_status_id": 1,
+    "user_entity_id": "2f44169e-c974-4655-a5bf-eea00ba7e654",
+    "identity_type_id": 2
+  },
+  {
+    "id": "ab7f01ea-cbb9-4d58-9efa-ea992395f997",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "date_created": "2022-06-01 18:01:33.439000 +00:00",
+    "user_status_id": 1,
+    "user_entity_id": "e8bc6470-28ee-4c40-a2d9-27c6e78f303b",
+    "identity_type_id": 2
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
@@ -96,5 +96,13 @@
     "user_status_id": 1,
     "user_entity_id": "b52bd8e5-98ce-48b4-af43-0b43b45d0358",
     "identity_type_id": 2
+  },
+  {
+    "id": "33480038-9acf-40e2-9127-c9c7a9cbed99",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "date_created": "2022-06-01 18:01:33.439000 +00:00",
+    "user_status_id": 1,
+    "user_entity_id": "e4a7204c-2fa8-4909-baa9-3fbc2fa6ec12",
+    "identity_type_id": 2
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -266,7 +266,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, true, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
 
         // Assert
-        result!.Count.Should().Be(13);
+        result!.Count.Should().Be(15);
         result.Data.Should().HaveCount(10)
             .And.AllSatisfy(x => x.CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN))
             .And.BeInAscendingOrder(x => x.Name)
@@ -275,12 +275,12 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201026"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201027"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201030"),
+                x => x.ServiceAccountId == new Guid("f3498fe6-e0e5-413b-a725-39bf5c7c1959"),
+                x => x.ServiceAccountId == new Guid("ab7f01ea-cbb9-4d58-9efa-ea992395f997"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201031"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201032"),
                 x => x.ServiceAccountId == new Guid("33480038-9acf-40e2-9127-c9c7a9cbed99"),
-                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201023"),
-                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201024"),
-                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201007"));
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201023"));
     }
 
     [Fact]
@@ -339,7 +339,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null, UserStatusId.ACTIVE)(0, 10);
 
         // Assert
-        result!.Count.Should().Be(11);
+        result!.Count.Should().Be(13);
         result.Data.Should().HaveCount(10);
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -266,7 +266,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, true, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
 
         // Assert
-        result!.Count.Should().Be(12);
+        result!.Count.Should().Be(13);
         result.Data.Should().HaveCount(10)
             .And.AllSatisfy(x => x.CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN))
             .And.BeInAscendingOrder(x => x.Name)
@@ -277,9 +277,9 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201030"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201031"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201032"),
+                x => x.ServiceAccountId == new Guid("33480038-9acf-40e2-9127-c9c7a9cbed99"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201023"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201024"),
-                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201028"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201007"));
     }
 
@@ -339,7 +339,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null, UserStatusId.ACTIVE)(0, 10);
 
         // Assert
-        result!.Count.Should().Be(10);
+        result!.Count.Should().Be(11);
         result.Data.Should().HaveCount(10);
     }
 


### PR DESCRIPTION
## Description

Adding the sa-cl24-01 technical user to the database seeding

## Why

When calling the portal from the ssi credential issuer, the call fails with a 401 because the technical user isn't existing in the database

## Issue

[#66](https://github.com/eclipse-tractusx/portal-iam/issues/66)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
