### PR TITLE
fix: adjust error tolerance for GET companyData/decentralidentity/urls

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -579,28 +579,12 @@ public class CompanyDataBusinessLogic(
     public async Task<DimUrlsResponse> GetDimServiceUrls()
     {
         var (bpnl, did, walletServiceUrl) = await portalRepositories.GetInstance<ICompanyRepository>().GetDimServiceUrls(_identityData.CompanyId).ConfigureAwait(ConfigureAwaitOptions.None);
-
-        if (bpnl is null)
-        {
-            throw new ConflictException("Bpn must be set");
-        }
-
-        if (did is null)
-        {
-            throw new ConflictException("Did must be set");
-        }
-
-        if (walletServiceUrl is null)
-        {
-            throw new ConflictException("Wallet Url must be set");
-        }
-
         return new(
             _settings.IssuerDid,
             bpnl,
             did,
             _settings.BpnDidResolverUrl,
-            $"{walletServiceUrl}/oauth/token",
+            walletServiceUrl is null ? null : $"{walletServiceUrl}/oauth/token",
             _settings.DecentralIdentityManagementAuthUrl
         );
     }

--- a/src/administration/Administration.Service/Models/DimUrlsResponse.cs
+++ b/src/administration/Administration.Service/Models/DimUrlsResponse.cs
@@ -23,9 +23,9 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 
 public record DimUrlsResponse(
     [property: JsonPropertyName("trusted_issuer")] string IssuerDid,
-    [property: JsonPropertyName("participant_id")] string Bpnl,
-    [property: JsonPropertyName("iatp_id")] string HolderDid,
+    [property: JsonPropertyName("participant_id")] string? Bpnl,
+    [property: JsonPropertyName("iatp_id")] string? HolderDid,
     [property: JsonPropertyName("did_resolver")] string BpnDidResolverUrl,
-    [property: JsonPropertyName("decentralIdentityManagementAuthUrl")] string DecentralIdentityManagementAuthUrl,
+    [property: JsonPropertyName("decentralIdentityManagementAuthUrl")] string? DecentralIdentityManagementAuthUrl,
     [property: JsonPropertyName("decentralIdentityManagementServiceUrl")] string DecentralIdentityManagementServiceUrl
 );

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -1760,13 +1760,12 @@ public class CompanyDataBusinessLogicTests
         // Arrange
         A.CallTo(() => _companyRepository.GetDimServiceUrls(A<Guid>._))
             .Returns(new ValueTuple<string?, string?, string?>(null, null, null));
-        Task Act() => _sut.GetDimServiceUrls();
 
         // Act
-        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+        var result = await _sut.GetDimServiceUrls();
 
         // Assert
-        ex.Message.Should().Be("Bpn must be set");
+        result.Bpnl.Should().BeNull();
     }
 
     [Fact]
@@ -1775,13 +1774,12 @@ public class CompanyDataBusinessLogicTests
         // Arrange
         A.CallTo(() => _companyRepository.GetDimServiceUrls(A<Guid>._))
             .Returns(new ValueTuple<string?, string?, string?>("BPNL00012345677", null, null));
-        Task Act() => _sut.GetDimServiceUrls();
 
         // Act
-        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+        var result = await _sut.GetDimServiceUrls();
 
         // Assert
-        ex.Message.Should().Be("Did must be set");
+        result.HolderDid.Should().BeNull();
     }
 
     [Fact]
@@ -1790,13 +1788,12 @@ public class CompanyDataBusinessLogicTests
         // Arrange
         A.CallTo(() => _companyRepository.GetDimServiceUrls(A<Guid>._))
             .Returns(new ValueTuple<string?, string?, string?>("BPNL00012345677", "did:web:test.org:123234345", null));
-        Task Act() => _sut.GetDimServiceUrls();
 
         // Act
-        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+        var result = await _sut.GetDimServiceUrls();
 
         // Assert
-        ex.Message.Should().Be("Wallet Url must be set");
+        result.DecentralIdentityManagementAuthUrl.Should().BeNull();
     }
 
     #endregion


### PR DESCRIPTION
## Description

Instead of throwing an error when a specific value isn't set, return null for those values.

## Why

To always return data for the customer, even if some values are not set.

## Issue

Refs: #710

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
