### PR TITLE
fix(credential): call ssi with current user for framework credentials

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -287,8 +287,8 @@ public class CompanyDataBusinessLogic(
             .ConfigureAwait(false);
 
     /// <inheritdoc />
-    public Task<Guid> CreateUseCaseParticipation(UseCaseParticipationCreationData data, CancellationToken cancellationToken) =>
-        _issuerComponentBusinessLogic.CreateFrameworkCredentialData(data.VerifiedCredentialExternalTypeDetailId, data.CredentialType, _identityData.IdentityId, cancellationToken);
+    public Task<Guid> CreateUseCaseParticipation(UseCaseParticipationCreationData data, string token, CancellationToken cancellationToken) =>
+        _issuerComponentBusinessLogic.CreateFrameworkCredentialData(data.VerifiedCredentialExternalTypeDetailId, data.CredentialType, _identityData.IdentityId, token, cancellationToken);
 
     /// <inheritdoc />
     public async Task CreateSsiCertificate(SsiCertificateCreationData data, CancellationToken cancellationToken)

--- a/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
@@ -43,7 +43,7 @@ public interface ICompanyDataBusinessLogic
 
     Task<IEnumerable<SsiCertificateData>> GetSsiCertificatesAsync();
 
-    Task<Guid> CreateUseCaseParticipation(UseCaseParticipationCreationData data, CancellationToken cancellationToken);
+    Task<Guid> CreateUseCaseParticipation(UseCaseParticipationCreationData data, string token, CancellationToken cancellationToken);
     Task CreateSsiCertificate(SsiCertificateCreationData data, CancellationToken cancellationToken);
 
     Task<Pagination.Response<CredentialDetailData>> GetCredentials(int page, int size, CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId, string? companyName, CompanySsiDetailSorting? sorting);

--- a/src/administration/Administration.Service/Controllers/CompanyDataController.cs
+++ b/src/administration/Administration.Service/Controllers/CompanyDataController.cs
@@ -24,6 +24,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
+using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Authentication;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Web.Identity;
@@ -237,7 +238,7 @@ public class CompanyDataController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     public Task<Guid> CreateUseCaseParticipation([FromForm] UseCaseParticipationCreationData data, CancellationToken cancellationToken) =>
-        _logic.CreateUseCaseParticipation(data, cancellationToken);
+        this.WithBearerToken(token => _logic.CreateUseCaseParticipation(data, token, cancellationToken));
 
     /// <summary>
     /// Creates the SSI Certificate request

--- a/src/externalsystems/IssuerComponent.Library/BusinessLogic/IIssuerComponentBusinessLogic.cs
+++ b/src/externalsystems/IssuerComponent.Library/BusinessLogic/IIssuerComponentBusinessLogic.cs
@@ -28,5 +28,5 @@ public interface IIssuerComponentBusinessLogic
     Task StoreBpnlCredentialResponse(Guid applicationId, IssuerResponseData data);
     Task<IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult> CreateMembershipCredential(IApplicationChecklistService.WorkerChecklistProcessStepData context, CancellationToken cancellationToken);
     Task StoreMembershipCredentialResponse(Guid applicationId, IssuerResponseData data);
-    Task<Guid> CreateFrameworkCredentialData(Guid useCaseFrameworkVersionId, UseCaseFrameworkId frameworkId, Guid identityId, CancellationToken cancellationToken);
+    Task<Guid> CreateFrameworkCredentialData(Guid useCaseFrameworkVersionId, UseCaseFrameworkId frameworkId, Guid identityId, string token, CancellationToken cancellationToken);
 }

--- a/src/externalsystems/IssuerComponent.Library/BusinessLogic/IssuerComponentBusinessLogic.cs
+++ b/src/externalsystems/IssuerComponent.Library/BusinessLogic/IssuerComponentBusinessLogic.cs
@@ -24,6 +24,7 @@ using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.DependencyInje
 using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Service;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library;
@@ -175,7 +176,7 @@ public class IssuerComponentBusinessLogic(
                 : null);
     }
 
-    public async Task<Guid> CreateFrameworkCredentialData(Guid useCaseFrameworkVersionId, UseCaseFrameworkId frameworkId, Guid identityId, CancellationToken cancellationToken)
+    public async Task<Guid> CreateFrameworkCredentialData(Guid useCaseFrameworkVersionId, UseCaseFrameworkId frameworkId, Guid identityId, string token, CancellationToken cancellationToken)
     {
         var (holder, businessPartnerNumber, walletInformation) = await repositories.GetInstance<ICompanyRepository>().GetWalletData(identityId).ConfigureAwait(false);
         if (holder is null)
@@ -197,6 +198,6 @@ public class IssuerComponentBusinessLogic(
         var secret = CryptoHelper.Decrypt(walletInformation.ClientSecret, walletInformation.InitializationVector, Convert.FromHexString(cryptoConfig.EncryptionKey), cryptoConfig.CipherMode, cryptoConfig.PaddingMode);
 
         var data = new CreateFrameworkCredentialRequest(holder, businessPartnerNumber, frameworkId, useCaseFrameworkVersionId, new TechnicalUserDetails(walletInformation.WalletUrl, walletInformation.ClientId, secret), null);
-        return await service.CreateFrameworkCredential(data, cancellationToken).ConfigureAwait(false);
+        return await service.CreateFrameworkCredential(data, token, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/externalsystems/IssuerComponent.Library/Service/IIssuerComponentService.cs
+++ b/src/externalsystems/IssuerComponent.Library/Service/IIssuerComponentService.cs
@@ -25,5 +25,5 @@ public interface IIssuerComponentService
 {
     Task<bool> CreateBpnlCredential(CreateBpnCredentialRequest data, CancellationToken cancellationToken);
     Task<bool> CreateMembershipCredential(CreateMembershipCredentialRequest data, CancellationToken cancellationToken);
-    Task<Guid> CreateFrameworkCredential(CreateFrameworkCredentialRequest data, CancellationToken cancellationToken);
+    Task<Guid> CreateFrameworkCredential(CreateFrameworkCredentialRequest data, string token, CancellationToken cancellationToken);
 }

--- a/src/externalsystems/IssuerComponent.Library/Service/IssuerComponentService.cs
+++ b/src/externalsystems/IssuerComponent.Library/Service/IssuerComponentService.cs
@@ -36,7 +36,7 @@ public class IssuerComponentService(ITokenService tokenService, IHttpClientFacto
 
     public async Task<bool> CreateBpnlCredential(CreateBpnCredentialRequest data, CancellationToken cancellationToken)
     {
-        var httpClient = await tokenService.GetAuthorizedClient<IssuerComponentService>(_settings, cancellationToken).ConfigureAwait(false);
+        using var httpClient = await tokenService.GetAuthorizedClient<IssuerComponentService>(_settings, cancellationToken).ConfigureAwait(false);
         await httpClient.PostAsJsonAsync("/api/issuer/bpn", data, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("issuer-component-bpn-post", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
         return true;
@@ -44,7 +44,7 @@ public class IssuerComponentService(ITokenService tokenService, IHttpClientFacto
 
     public async Task<bool> CreateMembershipCredential(CreateMembershipCredentialRequest data, CancellationToken cancellationToken)
     {
-        var httpClient = await tokenService.GetAuthorizedClient<IssuerComponentService>(_settings, cancellationToken).ConfigureAwait(false);
+        using var httpClient = await tokenService.GetAuthorizedClient<IssuerComponentService>(_settings, cancellationToken).ConfigureAwait(false);
         await httpClient.PostAsJsonAsync("/api/issuer/membership", data, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("issuer-component-membership-post", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
         return true;
@@ -52,7 +52,7 @@ public class IssuerComponentService(ITokenService tokenService, IHttpClientFacto
 
     public async Task<Guid> CreateFrameworkCredential(CreateFrameworkCredentialRequest data, string token, CancellationToken cancellationToken)
     {
-        var httpClient = httpClientFactory.CreateClient(nameof(IssuerComponentService));
+        using var httpClient = httpClientFactory.CreateClient(nameof(IssuerComponentService));
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         var result = await httpClient.PostAsJsonAsync("/api/issuer/framework", data, Options, cancellationToken)

--- a/src/externalsystems/IssuerComponent.Library/Service/IssuerComponentService.cs
+++ b/src/externalsystems/IssuerComponent.Library/Service/IssuerComponentService.cs
@@ -22,12 +22,13 @@ using Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Token;
 using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Models;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Service;
 
-public class IssuerComponentService(ITokenService tokenService, IOptions<IssuerComponentSettings> options)
+public class IssuerComponentService(ITokenService tokenService, IHttpClientFactory httpClientFactory, IOptions<IssuerComponentSettings> options)
     : IIssuerComponentService
 {
     private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
@@ -49,9 +50,11 @@ public class IssuerComponentService(ITokenService tokenService, IOptions<IssuerC
         return true;
     }
 
-    public async Task<Guid> CreateFrameworkCredential(CreateFrameworkCredentialRequest data, CancellationToken cancellationToken)
+    public async Task<Guid> CreateFrameworkCredential(CreateFrameworkCredentialRequest data, string token, CancellationToken cancellationToken)
     {
-        var httpClient = await tokenService.GetAuthorizedClient<IssuerComponentService>(_settings, cancellationToken).ConfigureAwait(false);
+        var httpClient = httpClientFactory.CreateClient(nameof(IssuerComponentService));
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
         var result = await httpClient.PostAsJsonAsync("/api/issuer/framework", data, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("issuer-component-framework-post", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
         return await result.Content.ReadFromJsonAsync<Guid>(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -43,10 +43,12 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Busin
 
 public class CompanyDataBusinessLogicTests
 {
+    private const string Token = "test123";
+    private static readonly Guid _validDocumentId = Guid.NewGuid();
+
     private readonly IIdentityData _identity;
     private readonly Guid _traceabilityExternalTypeDetailId = Guid.NewGuid();
     private readonly Guid _validCredentialId = Guid.NewGuid();
-    private static readonly Guid _validDocumentId = Guid.NewGuid();
     private readonly IFixture _fixture;
     private readonly IPortalRepositories _portalRepositories;
     private readonly IConsentRepository _consentRepository;
@@ -786,10 +788,10 @@ public class CompanyDataBusinessLogicTests
         var data = new UseCaseParticipationCreationData(_traceabilityExternalTypeDetailId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, file);
 
         // Act
-        await _sut.CreateUseCaseParticipation(data, CancellationToken.None);
+        await _sut.CreateUseCaseParticipation(data, Token, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _issuerComponentBusinessLogic.CreateFrameworkCredentialData(_traceabilityExternalTypeDetailId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, _identity.IdentityId, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentBusinessLogic.CreateFrameworkCredentialData(_traceabilityExternalTypeDetailId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, _identity.IdentityId, A<string>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -37,13 +37,11 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identitie
 using Org.Eclipse.TractusX.Portal.Backend.Processes.Mailing.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
-using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.BusinessLogic;
 
 public class CompanyDataBusinessLogicTests
 {
-    private const string Token = "test123";
     private static readonly Guid _validDocumentId = Guid.NewGuid();
 
     private readonly IIdentityData _identity;
@@ -784,14 +782,15 @@ public class CompanyDataBusinessLogicTests
     public async Task CreateUseCaseParticipation_WithValidCall_CreatesExpected()
     {
         // Arrange
+        var token = _fixture.Create<string>();
         var file = FormFileHelper.GetFormFile("test content", "test.pdf", MediaTypeId.PDF.MapToMediaType());
         var data = new UseCaseParticipationCreationData(_traceabilityExternalTypeDetailId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, file);
 
         // Act
-        await _sut.CreateUseCaseParticipation(data, Token, CancellationToken.None);
+        await _sut.CreateUseCaseParticipation(data, token, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _issuerComponentBusinessLogic.CreateFrameworkCredentialData(_traceabilityExternalTypeDetailId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, _identity.IdentityId, A<string>._, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentBusinessLogic.CreateFrameworkCredentialData(_traceabilityExternalTypeDetailId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, _identity.IdentityId, token, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
@@ -25,7 +25,10 @@ using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
+using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
+using Org.Eclipse.TractusX.Portal.Backend.Web.Identity;
 using System.Net;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Controllers;
@@ -41,6 +44,9 @@ public class CompanyDataControllerTests
         _fixture = new Fixture();
         _logic = A.Fake<ICompanyDataBusinessLogic>();
         _controller = new CompanyDataController(_logic);
+        var identity = A.Fake<IIdentityData>();
+        A.CallTo(() => identity.IdentityId).Returns(Guid.NewGuid());
+        _controller.AddControllerContextWithClaimAndBearer("ac-token", identity);
     }
 
     [Fact]
@@ -208,7 +214,7 @@ public class CompanyDataControllerTests
         await _controller.CreateUseCaseParticipation(data, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _logic.CreateUseCaseParticipation(data, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.CreateUseCaseParticipation(data, "ac-token", A<CancellationToken>._)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]

--- a/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/CompanyDataControllerTests.cs
@@ -28,7 +28,6 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
-using Org.Eclipse.TractusX.Portal.Backend.Web.Identity;
 using System.Net;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Controllers;

--- a/tests/externalsystems/IssuerComponent.Library.Tests/IssuerComponentBusinessLogicTests.cs
+++ b/tests/externalsystems/IssuerComponent.Library.Tests/IssuerComponentBusinessLogicTests.cs
@@ -40,6 +40,7 @@ public class IssuerComponentBusinessLogicTests
 {
     private static readonly Guid IdWithBpn = new("c244f79a-7faf-4c59-bb85-fbfdf72ce46f");
     private const string ValidBpn = "BPNL123698762345";
+    private const string Token = "test123";
 
     private readonly IApplicationRepository _applicationRepository;
     private readonly ICompanyRepository _companyRepository;
@@ -503,14 +504,14 @@ public class IssuerComponentBusinessLogicTests
         A.CallTo(() => _companyRepository.GetWalletData(identityId))
             .Returns(new ValueTuple<string?, string?, WalletInformation?>("did:123:testabc", ValidBpn, new WalletInformation("cl1", secret, vector, 0, "https://example.com/wallet"))
             );
-        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, Token, A<CancellationToken>._))
             .Returns(credentialId);
 
         // Act
-        var result = await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, CancellationToken.None);
+        var result = await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<string>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
         result.Should().Be(credentialId);
     }
@@ -523,13 +524,13 @@ public class IssuerComponentBusinessLogicTests
         var identityId = Guid.NewGuid();
         A.CallTo(() => _companyRepository.GetWalletData(identityId))
             .Returns(new ValueTuple<string?, string?, WalletInformation?>(null, null, null));
-        async Task Act() => await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, CancellationToken.None);
+        async Task Act() => await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
 
         // Assert
-        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<string>._, A<CancellationToken>._))
             .MustNotHaveHappened();
         ex.Message.Should().Be($"The holder must be set");
     }
@@ -542,13 +543,13 @@ public class IssuerComponentBusinessLogicTests
         var identityId = Guid.NewGuid();
         A.CallTo(() => _companyRepository.GetWalletData(identityId))
             .Returns(new ValueTuple<string?, string?, WalletInformation?>("test", null, null));
-        async Task Act() => await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, CancellationToken.None);
+        async Task Act() => await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
 
         // Assert
-        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<string>._, A<CancellationToken>._))
             .MustNotHaveHappened();
         ex.Message.Should().Be("The bpn must be set");
     }
@@ -561,13 +562,13 @@ public class IssuerComponentBusinessLogicTests
         var identityId = Guid.NewGuid();
         A.CallTo(() => _companyRepository.GetWalletData(identityId))
             .Returns(new ValueTuple<string?, string?, WalletInformation?>("test", "BPNL0000001Test", null));
-        async Task Act() => await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, CancellationToken.None);
+        async Task Act() => await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
 
         // Assert
-        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<string>._, A<CancellationToken>._))
             .MustNotHaveHappened();
         ex.Message.Should().Be("The wallet information must be set");
     }

--- a/tests/externalsystems/IssuerComponent.Library.Tests/IssuerComponentBusinessLogicTests.cs
+++ b/tests/externalsystems/IssuerComponent.Library.Tests/IssuerComponentBusinessLogicTests.cs
@@ -112,14 +112,26 @@ public class IssuerComponentBusinessLogicTests
             .ToImmutableDictionary();
         var entry = new ApplicationChecklistEntry(IdWithBpn, ApplicationChecklistEntryTypeId.BPNL_CREDENTIAL, ApplicationChecklistEntryStatusId.TO_DO, DateTimeOffset.UtcNow);
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
-            .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(true, "did:123:testabc", ValidBpn, new WalletInformation("cl1", secret, vector, 0, "https://example.com/wallet")));
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
+            .Returns((true, "did:123:testabc", ValidBpn, new WalletInformation("cl1", secret, vector, 0, "https://example.com/wallet")));
 
         // Act
         var result = await _sut.CreateBpnlCredential(context, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _issuerComponentService.CreateBpnlCredential(A<CreateBpnCredentialRequest>._, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentService
+            .CreateBpnlCredential(
+                A<CreateBpnCredentialRequest>.That.Matches(x =>
+                    x.Holder == "did:123:testabc" &&
+                    x.BusinessPartnerNumber == ValidBpn &&
+                    x.TechnicalUserDetails != null &&
+                    x.TechnicalUserDetails.WalletUrl == "https://example.com/wallet" &&
+                    x.TechnicalUserDetails.ClientId == "cl1" &&
+                    x.TechnicalUserDetails.ClientSecret == "test123" &&
+                    x.CallbackUrl == "https://example.org/callback/api/administration/registration/issuer/bpncredential"),
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
             .MustHaveHappenedOnceExactly();
         result.StepStatusId.Should().Be(ProcessStepStatusId.DONE);
         result.ScheduleStepTypeIds.Should().ContainSingle().Which.Should().Be(ProcessStepTypeId.STORED_BPN_CREDENTIAL);
@@ -143,9 +155,9 @@ public class IssuerComponentBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
-            .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(false, null, null, null));
-        async Task Act() => await _sut.CreateBpnlCredential(context, CancellationToken.None);
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
+            .Returns<(bool, string?, string?, WalletInformation?)>(default);
+        Task Act() => _sut.CreateBpnlCredential(context, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
@@ -153,6 +165,8 @@ public class IssuerComponentBusinessLogicTests
         // Assert
         A.CallTo(() => _issuerComponentService.CreateBpnlCredential(A<CreateBpnCredentialRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+            .MustHaveHappenedOnceExactly();
         ex.Message.Should().Be($"CompanyApplication {IdWithBpn} does not exist");
     }
 
@@ -169,9 +183,9 @@ public class IssuerComponentBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
-            .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(true, null, null, null));
-        async Task Act() => await _sut.CreateBpnlCredential(context, CancellationToken.None);
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
+            .Returns((true, null, null, null));
+        Task Act() => _sut.CreateBpnlCredential(context, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
@@ -179,6 +193,8 @@ public class IssuerComponentBusinessLogicTests
         // Assert
         A.CallTo(() => _issuerComponentService.CreateBpnlCredential(A<CreateBpnCredentialRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+            .MustHaveHappenedOnceExactly();
         ex.Message.Should().Be("The holder must be set");
     }
 
@@ -195,9 +211,9 @@ public class IssuerComponentBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
             .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(true, "test123", null, null));
-        async Task Act() => await _sut.CreateBpnlCredential(context, CancellationToken.None);
+        Task Act() => _sut.CreateBpnlCredential(context, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
@@ -205,6 +221,8 @@ public class IssuerComponentBusinessLogicTests
         // Assert
         A.CallTo(() => _issuerComponentService.CreateBpnlCredential(A<CreateBpnCredentialRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+            .MustHaveHappenedOnceExactly();
         ex.Message.Should().Be("The bpn must be set");
     }
 
@@ -221,9 +239,9 @@ public class IssuerComponentBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
             .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(true, "test123", ValidBpn, null));
-        async Task Act() => await _sut.CreateBpnlCredential(context, CancellationToken.None);
+        Task Act() => _sut.CreateBpnlCredential(context, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
@@ -231,6 +249,8 @@ public class IssuerComponentBusinessLogicTests
         // Assert
         A.CallTo(() => _issuerComponentService.CreateBpnlCredential(A<CreateBpnCredentialRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+            .MustHaveHappenedOnceExactly();
         ex.Message.Should().Be("The wallet information must be set");
     }
 
@@ -251,7 +271,7 @@ public class IssuerComponentBusinessLogicTests
                 ProcessStepTypeId.STORED_BPN_CREDENTIAL,
                 A<IEnumerable<ApplicationChecklistEntryTypeId>?>._,
                 A<IEnumerable<ProcessStepTypeId>?>._))
-            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.BPNL_CREDENTIAL, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty, new List<ProcessStep>()));
+            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.BPNL_CREDENTIAL, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty, Enumerable.Empty<ProcessStep>()));
         SetupForProcessIssuerComponentResponse(entry);
 
         // Act
@@ -277,7 +297,7 @@ public class IssuerComponentBusinessLogicTests
                 ProcessStepTypeId.STORED_MEMBERSHIP_CREDENTIAL,
                 A<IEnumerable<ApplicationChecklistEntryTypeId>?>._,
                 A<IEnumerable<ProcessStepTypeId>?>._))
-            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.MEMBERSHIP_CREDENTIAL, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty, new List<ProcessStep>()));
+            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.MEMBERSHIP_CREDENTIAL, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty, Enumerable.Empty<ProcessStep>()));
         SetupForProcessIssuerComponentResponse(entry);
 
         // Act
@@ -310,14 +330,27 @@ public class IssuerComponentBusinessLogicTests
             .ToImmutableDictionary();
         var entry = new ApplicationChecklistEntry(IdWithBpn, ApplicationChecklistEntryTypeId.BPNL_CREDENTIAL, ApplicationChecklistEntryStatusId.TO_DO, DateTimeOffset.UtcNow);
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
-            .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(true, "did:123:testabc", ValidBpn, new WalletInformation("cl1", secret, vector, 0, "https://example.com/wallet")));
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
+            .Returns((true, "did:123:testabc", ValidBpn, new WalletInformation("cl1", secret, vector, 0, "https://example.com/wallet")));
 
         // Act
         var result = await _sut.CreateMembershipCredential(context, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _issuerComponentService.CreateMembershipCredential(A<CreateMembershipCredentialRequest>._, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentService
+            .CreateMembershipCredential(
+                A<CreateMembershipCredentialRequest>.That.Matches(x =>
+                    x.Holder == "did:123:testabc" &&
+                    x.HolderBpn == ValidBpn &&
+                    x.TechnicalUserDetails != null &&
+                    x.TechnicalUserDetails.ClientId == "cl1" &&
+                    x.TechnicalUserDetails.ClientSecret == "test123" &&
+                    x.TechnicalUserDetails.WalletUrl == "https://example.com/wallet" &&
+                    x.CallbackUrl == "https://example.org/callback/api/administration/registration/issuer/membershipcredential"
+                ),
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
             .MustHaveHappenedOnceExactly();
         result.StepStatusId.Should().Be(ProcessStepStatusId.DONE);
         result.ScheduleStepTypeIds.Should().ContainSingle().Which.Should().Be(ProcessStepTypeId.STORED_MEMBERSHIP_CREDENTIAL);
@@ -341,9 +374,9 @@ public class IssuerComponentBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
-            .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(false, null, null, null));
-        async Task Act() => await _sut.CreateBpnlCredential(context, CancellationToken.None);
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
+            .Returns<(bool, string?, string?, WalletInformation?)>(default);
+        Task Act() => _sut.CreateBpnlCredential(context, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
@@ -351,6 +384,8 @@ public class IssuerComponentBusinessLogicTests
         // Assert
         A.CallTo(() => _issuerComponentService.CreateMembershipCredential(A<CreateMembershipCredentialRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+            .MustHaveHappenedOnceExactly();
         ex.Message.Should().Be($"CompanyApplication {IdWithBpn} does not exist");
     }
 
@@ -367,9 +402,9 @@ public class IssuerComponentBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
-            .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(true, null, null, null));
-        async Task Act() => await _sut.CreateBpnlCredential(context, CancellationToken.None);
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
+            .Returns((true, null, null, null));
+        Task Act() => _sut.CreateBpnlCredential(context, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
@@ -377,6 +412,8 @@ public class IssuerComponentBusinessLogicTests
         // Assert
         A.CallTo(() => _issuerComponentService.CreateMembershipCredential(A<CreateMembershipCredentialRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+            .MustHaveHappenedOnceExactly();
         ex.Message.Should().Be("The holder must be set");
     }
 
@@ -393,9 +430,9 @@ public class IssuerComponentBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
-            .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(true, "test123", null, null));
-        async Task Act() => await _sut.CreateMembershipCredential(context, CancellationToken.None);
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
+            .Returns((true, "test123", null, null));
+        Task Act() => _sut.CreateMembershipCredential(context, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
@@ -403,6 +440,8 @@ public class IssuerComponentBusinessLogicTests
         // Assert
         A.CallTo(() => _issuerComponentService.CreateMembershipCredential(A<CreateMembershipCredentialRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+            .MustHaveHappenedOnceExactly();
         ex.Message.Should().Be("The bpn must be set");
     }
 
@@ -419,9 +458,9 @@ public class IssuerComponentBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.REQUEST_BPN_CREDENTIAL, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
-            .Returns(new ValueTuple<bool, string?, string?, WalletInformation?>(true, "test123", ValidBpn, null));
-        async Task Act() => await _sut.CreateMembershipCredential(context, CancellationToken.None);
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(A<Guid>._))
+            .Returns((true, "test123", ValidBpn, null));
+        Task Act() => _sut.CreateMembershipCredential(context, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
@@ -429,6 +468,8 @@ public class IssuerComponentBusinessLogicTests
         // Assert
         A.CallTo(() => _issuerComponentService.CreateMembershipCredential(A<CreateMembershipCredentialRequest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+        A.CallTo(() => _applicationRepository.GetBpnlCredentialIformationByApplicationId(IdWithBpn))
+            .MustHaveHappenedOnceExactly();
         ex.Message.Should().Be("The wallet information must be set");
     }
 
@@ -449,7 +490,7 @@ public class IssuerComponentBusinessLogicTests
                 ProcessStepTypeId.STORED_MEMBERSHIP_CREDENTIAL,
                 A<IEnumerable<ApplicationChecklistEntryTypeId>?>._,
                 A<IEnumerable<ProcessStepTypeId>?>._))
-            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.MEMBERSHIP_CREDENTIAL, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty, new List<ProcessStep>()));
+            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.MEMBERSHIP_CREDENTIAL, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty, Enumerable.Empty<ProcessStep>()));
         SetupForProcessIssuerComponentResponse(entry);
 
         // Act
@@ -475,7 +516,7 @@ public class IssuerComponentBusinessLogicTests
                 ProcessStepTypeId.STORED_MEMBERSHIP_CREDENTIAL,
                 A<IEnumerable<ApplicationChecklistEntryTypeId>?>._,
                 A<IEnumerable<ProcessStepTypeId>?>._))
-            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.MEMBERSHIP_CREDENTIAL, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty, new List<ProcessStep>()));
+            .Returns(new IApplicationChecklistService.ManualChecklistProcessStepData(Guid.Empty, new Process(Guid.NewGuid(), ProcessTypeId.APPLICATION_CHECKLIST, Guid.NewGuid()), Guid.Empty, ApplicationChecklistEntryTypeId.MEMBERSHIP_CREDENTIAL, ImmutableDictionary<ApplicationChecklistEntryTypeId, (ApplicationChecklistEntryStatusId, string?)>.Empty, Enumerable.Empty<ProcessStep>()));
         SetupForProcessIssuerComponentResponse(entry);
 
         // Act
@@ -501,17 +542,30 @@ public class IssuerComponentBusinessLogicTests
         var useCaseFrameworkVersionId = Guid.NewGuid();
         var cryptoConfig = _options.Value.EncryptionConfigs.First();
         var (secret, vector) = CryptoHelper.Encrypt("test123", Convert.FromHexString(cryptoConfig.EncryptionKey), cryptoConfig.CipherMode, cryptoConfig.PaddingMode);
-        A.CallTo(() => _companyRepository.GetWalletData(identityId))
-            .Returns(new ValueTuple<string?, string?, WalletInformation?>("did:123:testabc", ValidBpn, new WalletInformation("cl1", secret, vector, 0, "https://example.com/wallet"))
-            );
-        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, Token, A<CancellationToken>._))
+        A.CallTo(() => _companyRepository.GetWalletData(A<Guid>._))
+            .Returns(("did:123:testabc", ValidBpn, new WalletInformation("cl1", secret, vector, 0, "https://example.com/wallet")));
+        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<string>._, A<CancellationToken>._))
             .Returns(credentialId);
 
         // Act
         var result = await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _issuerComponentService.CreateFrameworkCredential(A<CreateFrameworkCredentialRequest>._, A<string>._, A<CancellationToken>._))
+        A.CallTo(() => _issuerComponentService
+            .CreateFrameworkCredential(
+                A<CreateFrameworkCredentialRequest>.That.Matches(x =>
+                    x.Holder == "did:123:testabc" &&
+                    x.HolderBpn == ValidBpn &&
+                    x.TechnicalUserDetails != null &&
+                    x.TechnicalUserDetails.WalletUrl == "https://example.com/wallet" &&
+                    x.TechnicalUserDetails.ClientId == "cl1" &&
+                    x.TechnicalUserDetails.ClientSecret == "test123" &&
+                    x.CallbackUrl == null
+                ),
+                Token,
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _companyRepository.GetWalletData(identityId))
             .MustHaveHappenedOnceExactly();
         result.Should().Be(credentialId);
     }
@@ -523,8 +577,8 @@ public class IssuerComponentBusinessLogicTests
         var useCaseFrameworkVersionId = Guid.NewGuid();
         var identityId = Guid.NewGuid();
         A.CallTo(() => _companyRepository.GetWalletData(identityId))
-            .Returns(new ValueTuple<string?, string?, WalletInformation?>(null, null, null));
-        async Task Act() => await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
+            .Returns<(string?, string?, WalletInformation?)>(default);
+        Task Act() => _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
@@ -542,8 +596,8 @@ public class IssuerComponentBusinessLogicTests
         var useCaseFrameworkVersionId = Guid.NewGuid();
         var identityId = Guid.NewGuid();
         A.CallTo(() => _companyRepository.GetWalletData(identityId))
-            .Returns(new ValueTuple<string?, string?, WalletInformation?>("test", null, null));
-        async Task Act() => await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
+            .Returns(("test", null, null));
+        Task Act() => _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
@@ -561,8 +615,8 @@ public class IssuerComponentBusinessLogicTests
         var useCaseFrameworkVersionId = Guid.NewGuid();
         var identityId = Guid.NewGuid();
         A.CallTo(() => _companyRepository.GetWalletData(identityId))
-            .Returns(new ValueTuple<string?, string?, WalletInformation?>("test", "BPNL0000001Test", null));
-        async Task Act() => await _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
+            .Returns(("test", "BPNL0000001Test", null));
+        Task Act() => _sut.CreateFrameworkCredentialData(useCaseFrameworkVersionId, UseCaseFrameworkId.TRACEABILITY_FRAMEWORK, identityId, Token, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);

--- a/tests/shared/Tests.Shared/Extensions/ControllerExtensions.cs
+++ b/tests/shared/Tests.Shared/Extensions/ControllerExtensions.cs
@@ -41,7 +41,7 @@ public static class ControllerExtensions
         var claimsIdentity = new ClaimsIdentity();
         if (identity != null)
         {
-            claimsIdentity.AddClaims(new[] { new Claim(PortalClaimTypes.PreferredUserName, identity.IdentityId.ToString()) });
+            claimsIdentity.AddClaims([new Claim(PortalClaimTypes.PreferredUserName, identity.IdentityId.ToString())]);
         }
 
         var httpContext = new DefaultHttpContext
@@ -66,7 +66,7 @@ public static class ControllerExtensions
     public static void AddControllerContextWithClaimAndBearer(this ControllerBase controller, string accessToken, IIdentityData identity)
     {
         var claimsIdentity = new ClaimsIdentity();
-        claimsIdentity.AddClaims(new[] { new Claim(PortalClaimTypes.PreferredUserName, identity.IdentityId.ToString()) });
+        claimsIdentity.AddClaims([new Claim(PortalClaimTypes.PreferredUserName, identity.IdentityId.ToString())]);
 
         var httpContext = new DefaultHttpContext
         {


### PR DESCRIPTION
## Description

* adjust framework credential creation to call the ssi issuer with the current user instead of the technical user

## Why

The calling user of the framework credential creation is stored in the database as requester on the ssi issuer site. Therefore it needs to be the calling user of the endpoint on portal side instead of a generic technical user. 

## Issue

Refs: #712

## Corresponding Ssi Credential Issuer PR

[101](https://github.com/eclipse-tractusx/ssi-credential-issuer/pull/101)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
