### PR TITLE
fix(registration): adjust clearinghouse data post

### DIFF
--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -302,7 +302,8 @@
       "ClientSecret": "",
       "Scope": "",
       "TokenAddress": "",
-      "BaseAddress": ""
+      "BaseAddress": "",
+      "UseDimWallet": false
     },
     "SdFactory": {
       "Username": "",

--- a/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
+++ b/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -50,8 +50,8 @@ public class ClearinghouseBusinessLogic(
         string companyDid;
         if (_settings.UseDimWallet)
         {
-            var (exists, did, _) = await portalRepositories.GetInstance<IApplicationRepository>()
-                .GetDidAndBpnForApplicationId(context.ApplicationId).ConfigureAwait(ConfigureAwaitOptions.None);
+            var (exists, did) = await portalRepositories.GetInstance<IApplicationRepository>()
+                .GetDidForApplicationId(context.ApplicationId).ConfigureAwait(ConfigureAwaitOptions.None);
             if (!exists || string.IsNullOrWhiteSpace(did))
             {
                 throw new ConflictException($"Did must be set for Application {context.ApplicationId}");
@@ -75,7 +75,7 @@ public class ClearinghouseBusinessLogic(
         return new IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult(
             ProcessStepStatusId.DONE,
             entry => entry.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.IN_PROGRESS,
-            new[] { ProcessStepTypeId.END_CLEARING_HOUSE },
+            [ProcessStepTypeId.END_CLEARING_HOUSE],
             null,
             true,
             null);
@@ -115,9 +115,9 @@ public class ClearinghouseBusinessLogic(
             .VerifyChecklistEntryAndProcessSteps(
                 applicationId,
                 ApplicationChecklistEntryTypeId.CLEARING_HOUSE,
-                new[] { ApplicationChecklistEntryStatusId.IN_PROGRESS },
+                [ApplicationChecklistEntryStatusId.IN_PROGRESS],
                 ProcessStepTypeId.END_CLEARING_HOUSE,
-                processStepTypeIds: new[] { ProcessStepTypeId.START_SELF_DESCRIPTION_LP })
+                processStepTypeIds: [ProcessStepTypeId.START_SELF_DESCRIPTION_LP])
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
         var declined = data.Status == ClearinghouseResponseStatus.DECLINE;
@@ -133,7 +133,7 @@ public class ClearinghouseBusinessLogic(
                 item.Comment = data.Message;
             },
             declined
-                ? new[] { ProcessStepTypeId.TRIGGER_OVERRIDE_CLEARING_HOUSE }
-                : new[] { ProcessStepTypeId.START_SELF_DESCRIPTION_LP });
+                ? [ProcessStepTypeId.TRIGGER_OVERRIDE_CLEARING_HOUSE]
+                : [ProcessStepTypeId.START_SELF_DESCRIPTION_LP]);
     }
 }

--- a/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
+++ b/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -28,27 +28,15 @@ using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Clearinghouse.Library.BusinessLogic;
 
-public class ClearinghouseBusinessLogic : IClearinghouseBusinessLogic
+public class ClearinghouseBusinessLogic(
+    IPortalRepositories portalRepositories,
+    IClearinghouseService clearinghouseService,
+    ICustodianBusinessLogic custodianBusinessLogic,
+    IApplicationChecklistService checklistService,
+    IOptions<ClearinghouseSettings> options)
+    : IClearinghouseBusinessLogic
 {
-    private readonly IPortalRepositories _portalRepositories;
-    private readonly IClearinghouseService _clearinghouseService;
-    private readonly ICustodianBusinessLogic _custodianBusinessLogic;
-    private readonly IApplicationChecklistService _checklistService;
-    private readonly ClearinghouseSettings _settings;
-
-    public ClearinghouseBusinessLogic(
-        IPortalRepositories portalRepositories,
-        IClearinghouseService clearinghouseService,
-        ICustodianBusinessLogic custodianBusinessLogic,
-        IApplicationChecklistService checklistService,
-        IOptions<ClearinghouseSettings> options)
-    {
-        _portalRepositories = portalRepositories;
-        _clearinghouseService = clearinghouseService;
-        _custodianBusinessLogic = custodianBusinessLogic;
-        _checklistService = checklistService;
-        _settings = options.Value;
-    }
+    private readonly ClearinghouseSettings _settings = options.Value;
 
     public async Task<IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult> HandleClearinghouse(IApplicationChecklistService.WorkerChecklistProcessStepData context, CancellationToken cancellationToken)
     {
@@ -59,13 +47,30 @@ public class ClearinghouseBusinessLogic : IClearinghouseBusinessLogic
             _ => throw new UnexpectedConditionException($"HandleClearingHouse called for unexpected processStepTypeId {context.ProcessStepTypeId}. Expected {ProcessStepTypeId.START_CLEARING_HOUSE} or {ProcessStepTypeId.START_OVERRIDE_CLEARING_HOUSE}")
         };
 
-        var walletData = await _custodianBusinessLogic.GetWalletByBpnAsync(context.ApplicationId, cancellationToken);
-        if (walletData == null || string.IsNullOrEmpty(walletData.Did))
+        string companyDid;
+        if (_settings.UseDimWallet)
         {
-            throw new ConflictException($"Decentralized Identifier for application {context.ApplicationId} is not set");
+            var (exists, did, _) = await portalRepositories.GetInstance<IApplicationRepository>()
+                .GetDidAndBpnForApplicationId(context.ApplicationId).ConfigureAwait(ConfigureAwaitOptions.None);
+            if (!exists || string.IsNullOrWhiteSpace(did))
+            {
+                throw new ConflictException($"Did must be set for Application {context.ApplicationId}");
+            }
+
+            companyDid = did;
+        }
+        else
+        {
+            var walletData = await custodianBusinessLogic.GetWalletByBpnAsync(context.ApplicationId, cancellationToken);
+            if (walletData == null || string.IsNullOrEmpty(walletData.Did))
+            {
+                throw new ConflictException($"Decentralized Identifier for application {context.ApplicationId} is not set");
+            }
+
+            companyDid = walletData.Did;
         }
 
-        await TriggerCompanyDataPost(context.ApplicationId, walletData.Did, overwrite, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        await TriggerCompanyDataPost(context.ApplicationId, companyDid, overwrite, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 
         return new IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult(
             ProcessStepStatusId.DONE,
@@ -78,7 +83,7 @@ public class ClearinghouseBusinessLogic : IClearinghouseBusinessLogic
 
     private async Task TriggerCompanyDataPost(Guid applicationId, string decentralizedIdentifier, bool overwrite, CancellationToken cancellationToken)
     {
-        var data = await _portalRepositories.GetInstance<IApplicationRepository>()
+        var data = await portalRepositories.GetInstance<IApplicationRepository>()
             .GetClearinghouseDataForApplicationId(applicationId).ConfigureAwait(ConfigureAwaitOptions.None);
         if (data is null)
         {
@@ -101,12 +106,12 @@ public class ClearinghouseBusinessLogic : IClearinghouseBusinessLogic
             _settings.CallbackUrl,
             overwrite);
 
-        await _clearinghouseService.TriggerCompanyDataPost(transferData, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        await clearinghouseService.TriggerCompanyDataPost(transferData, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
     }
 
     public async Task ProcessEndClearinghouse(Guid applicationId, ClearinghouseResponseData data, CancellationToken cancellationToken)
     {
-        var context = await _checklistService
+        var context = await checklistService
             .VerifyChecklistEntryAndProcessSteps(
                 applicationId,
                 ApplicationChecklistEntryTypeId.CLEARING_HOUSE,
@@ -117,7 +122,7 @@ public class ClearinghouseBusinessLogic : IClearinghouseBusinessLogic
 
         var declined = data.Status == ClearinghouseResponseStatus.DECLINE;
 
-        _checklistService.FinalizeChecklistEntryAndProcessSteps(
+        checklistService.FinalizeChecklistEntryAndProcessSteps(
             context,
             null,
             item =>

--- a/src/externalsystems/Clearinghouse.Library/ClearinghouseSettings.cs
+++ b/src/externalsystems/Clearinghouse.Library/ClearinghouseSettings.cs
@@ -33,4 +33,6 @@ public class ClearinghouseSettings : KeyVaultAuthSettings
 
     [Required(AllowEmptyStrings = false)]
     public string CallbackUrl { get; set; } = null!;
+
+    public bool UseDimWallet { get; set; }
 }

--- a/src/externalsystems/Custodian.Library/BusinessLogic/CustodianBusinessLogic.cs
+++ b/src/externalsystems/Custodian.Library/BusinessLogic/CustodianBusinessLogic.cs
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -26,28 +26,21 @@ using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Custodian.Library.BusinessLogic;
 
-public class CustodianBusinessLogic : ICustodianBusinessLogic
+public class CustodianBusinessLogic(IPortalRepositories portalRepositories, ICustodianService custodianService)
+    : ICustodianBusinessLogic
 {
-    private readonly IPortalRepositories _portalRepositories;
-    private readonly ICustodianService _custodianService;
-
-    public CustodianBusinessLogic(IPortalRepositories portalRepositories, ICustodianService custodianService)
-    {
-        _portalRepositories = portalRepositories;
-        _custodianService = custodianService;
-    }
-
     /// <inheritdoc />
     public async Task<WalletData?> GetWalletByBpnAsync(Guid applicationId, CancellationToken cancellationToken)
     {
-        var bpn = await _portalRepositories.GetInstance<IApplicationRepository>()
+        var bpn = await portalRepositories.GetInstance<IApplicationRepository>()
             .GetBpnForApplicationIdAsync(applicationId).ConfigureAwait(ConfigureAwaitOptions.None);
+
         if (string.IsNullOrWhiteSpace(bpn))
         {
             throw new ConflictException("BusinessPartnerNumber is not set");
         }
 
-        var walletData = await _custodianService.GetWalletByBpnAsync(bpn, cancellationToken)
+        var walletData = await custodianService.GetWalletByBpnAsync(bpn, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
         return walletData;
@@ -88,7 +81,7 @@ public class CustodianBusinessLogic : ICustodianBusinessLogic
 
     private async Task<string> CreateWalletInternal(Guid applicationId, CancellationToken cancellationToken)
     {
-        var result = await _portalRepositories.GetInstance<IApplicationRepository>().GetCompanyAndApplicationDetailsForCreateWalletAsync(applicationId).ConfigureAwait(ConfigureAwaitOptions.None);
+        var result = await portalRepositories.GetInstance<IApplicationRepository>().GetCompanyAndApplicationDetailsForCreateWalletAsync(applicationId).ConfigureAwait(ConfigureAwaitOptions.None);
         if (result == default)
         {
             throw new ConflictException($"CompanyApplication {applicationId} is not in status SUBMITTED");
@@ -100,6 +93,6 @@ public class CustodianBusinessLogic : ICustodianBusinessLogic
             throw new ConflictException($"BusinessPartnerNumber (bpn) for CompanyApplications {applicationId} company {companyId} is empty");
         }
 
-        return await _custodianService.CreateWalletAsync(businessPartnerNumber, companyName, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        return await custodianService.CreateWalletAsync(businessPartnerNumber, companyName, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
     }
 }

--- a/src/externalsystems/Custodian.Library/CustodianSettings.cs
+++ b/src/externalsystems/Custodian.Library/CustodianSettings.cs
@@ -1,6 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,16 +24,10 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Custodian.Library
 {
     public class CustodianSettings : KeyVaultAuthSettings
     {
-        public CustodianSettings()
-        {
-            BaseAddress = null!;
-            MembershipErrorMessage = null!;
-        }
+        [Required(AllowEmptyStrings = false)]
+        public string MembershipErrorMessage { get; set; } = null!;
 
         [Required(AllowEmptyStrings = false)]
-        public string MembershipErrorMessage { get; set; }
-
-        [Required(AllowEmptyStrings = false)]
-        public string BaseAddress { get; set; }
+        public string BaseAddress { get; set; } = null!;
     }
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -520,7 +520,14 @@ public class ApplicationRepository(PortalDbContext portalDbContext)
             .Select(ca => new ValueTuple<bool, string?, string?>(
                 true,
                 ca.Company!.CompanyWalletData!.Did,
-                ca.Company.BusinessPartnerNumber
-            ))
+                ca.Company.BusinessPartnerNumber))
+            .SingleOrDefaultAsync();
+
+    public Task<(bool Exists, string? Did)> GetDidForApplicationId(Guid applicationId) =>
+        portalDbContext.CompanyApplications
+            .Where(ca => ca.Id == applicationId)
+            .Select(ca => new ValueTuple<bool, string?>(
+                true,
+                ca.Company!.CompanyWalletData!.Did))
             .SingleOrDefaultAsync();
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -103,4 +103,5 @@ public interface IApplicationRepository
     Task<(bool Exists, string? Did, IEnumerable<DateTimeOffset> ProcessStepsDateCreated)> GetDidApplicationId(Guid applicationId);
     Task<(bool Exists, string? Holder, string? BusinessPartnerNumber, WalletInformation? WalletInformation)> GetBpnlCredentialIformationByApplicationId(Guid applicationId);
     Task<(bool Exists, string? Did, string? Bpn)> GetDidAndBpnForApplicationId(Guid applicationId);
+    Task<(bool Exists, string? Did)> GetDidForApplicationId(Guid applicationId);
 }

--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -341,7 +341,8 @@
       "ClientSecret": "",
       "Scope": "",
       "TokenAddress": "",
-      "BaseAddress": ""
+      "BaseAddress": "",
+      "UseDimWallet": false
     },
     "Dim": {
       "Username": "",

--- a/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
+++ b/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
@@ -224,8 +224,8 @@ public class ClearinghouseBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetDidAndBpnForApplicationId(context.ApplicationId))
-            .Returns(new ValueTuple<bool, string?, string?>(false, null, null));
+        A.CallTo(() => _applicationRepository.GetDidForApplicationId(A<Guid>._))
+            .Returns<(bool, string?)>(default);
         var logic = new ClearinghouseBusinessLogic(_portalRepositories, _clearinghouseService, _custodianBusinessLogic, _checklistService, Options.Create(new ClearinghouseSettings
         {
             CallbackUrl = "https://api.com",
@@ -238,6 +238,8 @@ public class ClearinghouseBusinessLogicTests
 
         // Assert
         ex.Message.Should().Be($"Did must be set for Application {context.ApplicationId}");
+        A.CallTo(() => _applicationRepository.GetDidForApplicationId(context.ApplicationId))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -253,8 +255,8 @@ public class ClearinghouseBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetDidAndBpnForApplicationId(context.ApplicationId))
-            .Returns(new ValueTuple<bool, string?, string?>(true, null, null));
+        A.CallTo(() => _applicationRepository.GetDidForApplicationId(A<Guid>._))
+            .Returns((true, null));
         var logic = new ClearinghouseBusinessLogic(_portalRepositories, _clearinghouseService, _custodianBusinessLogic, _checklistService, Options.Create(new ClearinghouseSettings
         {
             CallbackUrl = "https://api.com",
@@ -267,6 +269,8 @@ public class ClearinghouseBusinessLogicTests
 
         // Assert
         ex.Message.Should().Be($"Did must be set for Application {context.ApplicationId}");
+        A.CallTo(() => _applicationRepository.GetDidForApplicationId(context.ApplicationId))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -283,8 +287,8 @@ public class ClearinghouseBusinessLogicTests
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
-        A.CallTo(() => _applicationRepository.GetDidAndBpnForApplicationId(context.ApplicationId))
-            .Returns(new ValueTuple<bool, string?, string?>(true, "did:web:test123456", null));
+        A.CallTo(() => _applicationRepository.GetDidForApplicationId(A<Guid>._))
+            .Returns((true, "did:web:test123456"));
         SetupForHandleStartClearingHouse();
         var logic = new ClearinghouseBusinessLogic(_portalRepositories, _clearinghouseService, _custodianBusinessLogic, _checklistService, Options.Create(new ClearinghouseSettings
         {
@@ -296,6 +300,8 @@ public class ClearinghouseBusinessLogicTests
         var result = await logic.HandleClearinghouse(context, CancellationToken.None);
 
         // Assert
+        A.CallTo(() => _applicationRepository.GetDidForApplicationId(context.ApplicationId))
+            .MustHaveHappenedOnceExactly();
         result.ModifyChecklistEntry.Should().NotBeNull();
         result.ModifyChecklistEntry!.Invoke(entry);
         entry.ApplicationChecklistEntryStatusId.Should().Be(ApplicationChecklistEntryStatusId.IN_PROGRESS);

--- a/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
+++ b/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
@@ -70,7 +70,8 @@ public class ClearinghouseBusinessLogicTests
 
         _logic = new ClearinghouseBusinessLogic(_portalRepositories, _clearinghouseService, _custodianBusinessLogic, _checklistService, Options.Create(new ClearinghouseSettings
         {
-            CallbackUrl = "https://api.com"
+            CallbackUrl = "https://api.com",
+            UseDimWallet = false
         }));
     }
 
@@ -93,7 +94,6 @@ public class ClearinghouseBusinessLogicTests
     [InlineData(ProcessStepTypeId.OVERRIDE_BUSINESS_PARTNER_NUMBER)]
     [InlineData(ProcessStepTypeId.TRIGGER_OVERRIDE_CLEARING_HOUSE)]
     [InlineData(ProcessStepTypeId.FINISH_SELF_DESCRIPTION_LP)]
-
     public async Task HandleStartClearingHouse_ForInvalidProcessStepTypeId_ThrowsUnexpectedCondition(ProcessStepTypeId stepTypeId)
     {
         // Arrange
@@ -118,7 +118,7 @@ public class ClearinghouseBusinessLogicTests
                 { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
                 { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE },
                 { ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE },
-                { ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO },
+                { ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(applicationId, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -141,7 +141,7 @@ public class ClearinghouseBusinessLogicTests
                 {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
                 {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE},
                 {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO},
+                {ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO}
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithApplicationCreated, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -164,7 +164,7 @@ public class ClearinghouseBusinessLogicTests
                 {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
                 {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE},
                 {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO},
+                {ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO}
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithoutBpn, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -190,7 +190,7 @@ public class ClearinghouseBusinessLogicTests
                 {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
                 {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE},
                 {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO},
+                {ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO}
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, stepTypeId, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -207,6 +207,102 @@ public class ClearinghouseBusinessLogicTests
             .MustHaveHappenedOnceExactly();
         result.ScheduleStepTypeIds.Should().HaveCount(1);
         result.ScheduleStepTypeIds.Should().Contain(expectedProcessTypeId);
+        result.SkipStepTypeIds.Should().BeNull();
+        result.Modified.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleStartClearingHouse_WithDimActiveAndNonExistingApplication_ThrowsConflictException()
+    {
+        // Arrange
+        var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
+            {
+                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
+                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE},
+                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                {ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO}
+            }
+            .ToImmutableDictionary();
+        var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
+        A.CallTo(() => _applicationRepository.GetDidAndBpnForApplicationId(context.ApplicationId))
+            .Returns(new ValueTuple<bool, string?, string?>(false, null, null));
+        var logic = new ClearinghouseBusinessLogic(_portalRepositories, _clearinghouseService, _custodianBusinessLogic, _checklistService, Options.Create(new ClearinghouseSettings
+        {
+            CallbackUrl = "https://api.com",
+            UseDimWallet = true
+        }));
+        async Task Act() => await logic.HandleClearinghouse(context, CancellationToken.None);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+
+        // Assert
+        ex.Message.Should().Be($"Did must be set for Application {context.ApplicationId}");
+    }
+
+    [Fact]
+    public async Task HandleStartClearingHouse_WithDimActiveAndDidNotSet_ThrowsConflictException()
+    {
+        // Arrange
+        var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
+            {
+                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
+                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE},
+                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                {ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO}
+            }
+            .ToImmutableDictionary();
+        var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
+        A.CallTo(() => _applicationRepository.GetDidAndBpnForApplicationId(context.ApplicationId))
+            .Returns(new ValueTuple<bool, string?, string?>(true, null, null));
+        var logic = new ClearinghouseBusinessLogic(_portalRepositories, _clearinghouseService, _custodianBusinessLogic, _checklistService, Options.Create(new ClearinghouseSettings
+        {
+            CallbackUrl = "https://api.com",
+            UseDimWallet = true
+        }));
+        async Task Act() => await logic.HandleClearinghouse(context, CancellationToken.None);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+
+        // Assert
+        ex.Message.Should().Be($"Did must be set for Application {context.ApplicationId}");
+    }
+
+    [Fact]
+    public async Task HandleStartClearingHouse_WithDimActive_CallsExpected()
+    {
+        // Arrange
+        var entry = new ApplicationChecklistEntry(Guid.NewGuid(), ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO, DateTimeOffset.UtcNow);
+        var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
+            {
+                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
+                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE},
+                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                {ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO},
+            }
+            .ToImmutableDictionary();
+        var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
+        A.CallTo(() => _applicationRepository.GetDidAndBpnForApplicationId(context.ApplicationId))
+            .Returns(new ValueTuple<bool, string?, string?>(true, "did:web:test123456", null));
+        SetupForHandleStartClearingHouse();
+        var logic = new ClearinghouseBusinessLogic(_portalRepositories, _clearinghouseService, _custodianBusinessLogic, _checklistService, Options.Create(new ClearinghouseSettings
+        {
+            CallbackUrl = "https://api.com",
+            UseDimWallet = true
+        }));
+
+        // Act
+        var result = await logic.HandleClearinghouse(context, CancellationToken.None);
+
+        // Assert
+        result.ModifyChecklistEntry.Should().NotBeNull();
+        result.ModifyChecklistEntry!.Invoke(entry);
+        entry.ApplicationChecklistEntryStatusId.Should().Be(ApplicationChecklistEntryStatusId.IN_PROGRESS);
+        A.CallTo(() => _clearinghouseService.TriggerCompanyDataPost(A<ClearinghouseTransferData>._, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+        result.ScheduleStepTypeIds.Should().HaveCount(1);
+        result.ScheduleStepTypeIds.Should().Contain(ProcessStepTypeId.END_CLEARING_HOUSE);
         result.SkipStepTypeIds.Should().BeNull();
         result.Modified.Should().BeTrue();
     }


### PR DESCRIPTION
## Description

* get the did of the company from the database if the dim wallet is enabled instead of requesting it from the miw

## Why

Since the portal enabled the configuration to use the dim wallet instead of the miw wallet, the did is saved in the database for a company after the wallet is created. Therefore the call to the miw to receive the did for the bpn of the company can be skipped.

## Issue

Refs: #695

## Corresponding CD Pr

[#297](https://github.com/eclipse-tractusx/portal/pull/297)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
