### PR TITLE
fix: pass logging arguments to correct param

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IdentityProviderBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IdentityProviderBusinessLogic.cs
@@ -762,7 +762,7 @@ public class IdentityProviderBusinessLogic : IIdentityProviderBusinessLogic
         IEnumerable<(Guid IdentityProviderId, string Alias)> existingIdps,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var (companyUserId, profile, identityProviderLinks) in userProfileLinkDatas)
+        await foreach (var (companyUserId, profile, identityProviderLinks) in userProfileLinkDatas.WithCancellation(cancellationToken))
         {
             Exception? error = null;
             var success = false;
@@ -784,6 +784,7 @@ public class IdentityProviderBusinessLogic : IIdentityProviderBusinessLogic
                     await UpdateUserProfileAsync(userRepository, iamUserId, companyUserId, profile, existingLinks, sharedIdp).ConfigureAwait(false);
                     updated = true;
                 }
+
                 success = updated;
             }
             catch (Exception e)
@@ -792,8 +793,10 @@ public class IdentityProviderBusinessLogic : IIdentityProviderBusinessLogic
                 {
                     throw;
                 }
+
                 error = e;
             }
+
             yield return (success, error);
         }
     }

--- a/src/portalbackend/PortalBackend.Migrations/Program.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Program.cs
@@ -56,7 +56,7 @@ try
 }
 catch (Exception ex) when (!ex.GetType().Name.Equals("StopTheHostException", StringComparison.Ordinal))
 {
-    Log.Fatal("Unhandled exception {Exception}", ex);
+    Log.Fatal(ex, "Unhandled exception {Exception}", ex);
     throw;
 }
 finally

--- a/src/provisioning/Provisioning.Migrations/Program.cs
+++ b/src/provisioning/Provisioning.Migrations/Program.cs
@@ -49,7 +49,7 @@ try
 }
 catch (Exception ex) when (!ex.GetType().Name.Equals("StopTheHostException", StringComparison.Ordinal))
 {
-    Log.Fatal("Unhandled exception {Exception}", ex);
+    Log.Fatal(ex, "Unhandled exception {Exception}", ex);
     throw;
 }
 finally


### PR DESCRIPTION
## Description

Pass the logging argument to the correct parameter

## Why

To fix the sonar cloud finding

## Issue

Refs: #694

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
