### PR TITLE
fix(app): fix app short description getting error

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
@@ -86,8 +86,7 @@ public class OfferRepository : IOfferRepository
                 a.LicenseTypeId,
                 _context.Languages.Any(l => l.ShortName == languageShortName)
                         ? a.OfferDescriptions.SingleOrDefault(d => d.LanguageShortName == languageShortName)!.DescriptionShort
-                            ?? a.OfferDescriptions.SingleOrDefault(d => d.LanguageShortName == defaultLanguageShortName)!.DescriptionShort
-                        : null,
+                            : a.OfferDescriptions.SingleOrDefault(d => d.LanguageShortName == defaultLanguageShortName)!.DescriptionShort,
                 a.OfferLicenses
                     .Select(license => license.Licensetext)
                     .FirstOrDefault()))


### PR DESCRIPTION
## Description

The shortDescription is not fetched from the backend. Instead we always receive "ERROR".
Per app the short description is expected to get fetched from offer_descriptions.description_short

## Why

Based on the submitted language parameter. If no language parameter is provided fetch the "en" description_short.

## Issue

#590 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
