### PR TITLE
fix: add clients to app_instances base seeding

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/app_instances.consortia.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/app_instances.consortia.json
@@ -45,21 +45,6 @@
     "iam_client_id": "f032a048-d035-11ec-9d64-0242ac120002"
   },
   {
-    "id": "47fa908a-99a4-4265-9936-2c890ad97a4c",
-    "app_id": "9b957704-3505-4445-822c-d7ef80f27fcd",
-    "iam_client_id": "0c9051d0-d032-11ec-9d64-0242ac120002"
-  },
-  {
-    "id": "e080bb4b-567b-477e-adcf-080efc457d38",
-    "app_id": "9ef01c20-6d9d-41ef-b336-fa64e1e2e4c2",
-    "iam_client_id": "f032a034-d035-11ec-9d64-0242ac120002"
-  },
-  {
-    "id": "1ef3a9b0-e8ef-48cc-9b88-65bacd6f05fb",
-    "app_id": "0ffcb416-1101-4ba6-8d4a-a9dfa31745a4",
-    "iam_client_id": "f032a049-d035-11ec-9d64-0242ac120002"
-  },
-  {
     "id": "476b0600-965b-4f10-8eb5-e4568859a886",
     "app_id": "5cf74ef8-e0b7-4984-a872-474828beb5d8",
     "iam_client_id": "f032a050-d035-11ec-9d64-0242ac120002"

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/app_instances.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/app_instances.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "47fa908a-99a4-4265-9936-2c890ad97a4c",
+    "app_id": "9b957704-3505-4445-822c-d7ef80f27fcd",
+    "iam_client_id": "0c9051d0-d032-11ec-9d64-0242ac120002"
+  },
+  {
+    "id": "e080bb4b-567b-477e-adcf-080efc457d38",
+    "app_id": "9ef01c20-6d9d-41ef-b336-fa64e1e2e4c2",
+    "iam_client_id": "f032a034-d035-11ec-9d64-0242ac120002"
+  },
+  {
+    "id": "1ef3a9b0-e8ef-48cc-9b88-65bacd6f05fb",
+    "app_id": "0ffcb416-1101-4ba6-8d4a-a9dfa31745a4",
+    "iam_client_id": "f032a049-d035-11ec-9d64-0242ac120002"
+  }
+]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRoleCollectionRolesViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRoleCollectionRolesViewTests.cs
@@ -46,7 +46,7 @@ public class CompanyRoleCollectionRolesViewTests : IAssemblyFixture<TestDbFixtur
 
         // Act
         var result = await sut.CompanyRoleCollectionRolesView.ToListAsync().ConfigureAwait(false);
-        result.Should().HaveCount(26);
+        result.Should().HaveCount(46);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/app_instances.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/app_instances.test.json
@@ -10,18 +10,8 @@
     "iam_client_id": "cf207afb-d213-4c33-becc-0cabeef174a7"
   },
   {
-    "id": "e080bb4b-567b-477e-adcf-080efc457d38",
-    "app_id": "9ef01c20-6d9d-41ef-b336-fa64e1e2e4c2",
-    "iam_client_id": "f032a034-d035-11ec-9d64-0242ac120002"
-  },
-  {
     "id": "b161d570-f6ff-45b4-a077-243f72487af6",
     "app_id": "ac1cf001-7fbc-1f2f-817f-bce0572c0007",
     "iam_client_id": "f032a042-d035-11ec-9d64-0242ac120002"
-  },
-  {
-    "id": "1ef3a9b0-e8ef-48cc-9b88-65bacd6f05fb",
-    "app_id": "0ffcb416-1101-4ba6-8d4a-a9dfa31745a4",
-    "iam_client_id": "f032a049-d035-11ec-9d64-0242ac120002"
   }
 ]


### PR DESCRIPTION
## Description

fix: add clients with composite roles to app_instances base seeding; Registration, Portal and technical_roles_management were accidentally maintained in consortia test data seeding

## Why

#718 

## Checklist


- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
