### PR TITLE
fix(decline): add decline url for invite process

### DIFF
--- a/src/processes/Invitation.Executor/DependencyInjection/InvitationSettings.cs
+++ b/src/processes/Invitation.Executor/DependencyInjection/InvitationSettings.cs
@@ -46,6 +46,9 @@ public class InvitationSettings
     [Required]
     [DistinctValues("x => x.Index")]
     public IEnumerable<EncryptionModeConfig> EncryptionConfigs { get; set; } = null!;
+
+    [Required(AllowEmptyStrings = false)]
+    public string CloseApplicationAddress { get; set; } = null!;
 }
 
 public static class InvitationSettingsExtension

--- a/src/processes/Invitation.Executor/InvitationProcessService.cs
+++ b/src/processes/Invitation.Executor/InvitationProcessService.cs
@@ -360,6 +360,7 @@ public class InvitationProcessService : IInvitationProcessService
                 KeyValuePair.Create("companyName", companyName),
                 KeyValuePair.Create("url", _settings.RegistrationAppAddress),
                 KeyValuePair.Create("passwordResendUrl", _settings.PasswordResendAddress),
+                KeyValuePair.Create("closeApplicationUrl", _settings.CloseApplicationAddress)
             });
             _mailingProcessCreation.CreateMailProcess(userInformation.Email, template, mailParameters);
         }


### PR DESCRIPTION
## Description

Add decline url to invite mail template

## Why

The decline url is empty in the mail template

## Issue

Refs: #701

## Corresponding CD PR

https://github.com/eclipse-tractusx/portal/pull/311

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
