### PR TITLE
chore(update): rename migration for rc8

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20240514145358_2.0.0-rc8.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20240514145358_2.0.0-rc8.Designer.cs
@@ -29,8 +29,8 @@ using System.Text.Json;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    [Migration("20240514145358_593-AdjustDimTechnicalUsers")]
-    partial class _593AdjustDimTechnicalUsers
+    [Migration("20240514145358_2.0.0-rc8")]
+    partial class _200rc8
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20240514145358_2.0.0-rc8.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20240514145358_2.0.0-rc8.cs
@@ -26,7 +26,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations.Migrations
 {
     /// <inheritdoc />
-    public partial class _593AdjustDimTechnicalUsers : Migration
+    public partial class _200rc8 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
## Description

existing migration 593-AdjustDimTechnicalusers  has been renamed to 2.0.0-rc8

## Why

release- and release-candidate migrations shall aggregate all intermediate migrations and be named according to the respective release

## Issue

https://github.com/eclipse-tractusx/portal/issues/318

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
