### PR TITLE
feat(app): add roleId for exitisting activeRoleDetails

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferRoleInfos.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferRoleInfos.cs
@@ -30,6 +30,7 @@ public record OfferRoleInfos(
     [property: JsonPropertyName("roles")] IEnumerable<OfferRoleInfo> RoleInfos);
 
 public record ActiveAppRoleDetails(
+    [property: JsonPropertyName("roleId")] Guid RoleId,
     [property: JsonPropertyName("role")] string Role,
     [property: JsonPropertyName("descriptions")] IEnumerable<ActiveAppUserRoleDescription> Descriptions);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
@@ -299,6 +299,7 @@ public class UserRolesRepository : IUserRolesRepository
                 x.Active
                     ? x.Roles.Select(role =>
                         new ActiveAppRoleDetails(
+                            role.Id,
                             role.UserRoleText,
                             role.UserRoleDescriptions.Where(description =>
                                 (languageShortName != null && description.LanguageShortName == languageShortName) ||
@@ -325,6 +326,7 @@ public class UserRolesRepository : IUserRolesRepository
                 x.Provider
                     ? x.Roles.Select(role =>
                         new ActiveAppRoleDetails(
+                            role.Id,
                             role.UserRoleText,
                             role.UserRoleDescriptions.Where(description =>
                                 (languageShortName != null && description.LanguageShortName == languageShortName) ||

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppChangeBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppChangeBusinessLogicTest.cs
@@ -1192,10 +1192,12 @@ public class AppChangeBusinessLogicTest
     {
         // Arrange
         var appId = _fixture.Create<Guid>();
-        var userRole1 = new ActiveAppRoleDetails("TestRole1", [
+        var roleId1 = _fixture.Create<Guid>();
+        var roleId2 = _fixture.Create<Guid>();
+        var userRole1 = new ActiveAppRoleDetails(roleId1, "TestRole1", [
             new ActiveAppUserRoleDescription("en", "TestRole1 description")
         ]);
-        var userRole2 = new ActiveAppRoleDetails("TestRole2", [
+        var userRole2 = new ActiveAppRoleDetails(roleId2, "TestRole2", [
             new ActiveAppUserRoleDescription("en", "TestRole2 description")
         ]);
         var activeAppRoleDetails = (true, true, new[] {
@@ -1212,8 +1214,8 @@ public class AppChangeBusinessLogicTest
         // Assert
         result.Should().HaveCount(2)
             .And.Satisfy(
-                x => x.Role == "TestRole1" && x.Descriptions.Count() == 1 && x.Descriptions.Single().Description == "TestRole1 description",
-                x => x.Role == "TestRole2" && x.Descriptions.Count() == 1 && x.Descriptions.Single().Description == "TestRole2 description");
+                x => x.RoleId == roleId1 && x.Role == "TestRole1" && x.Descriptions.Count() == 1 && x.Descriptions.Single().Description == "TestRole1 description",
+                x => x.RoleId == roleId2 && x.Role == "TestRole2" && x.Descriptions.Count() == 1 && x.Descriptions.Single().Description == "TestRole2 description");
         A.CallTo(() => _userRolesRepository.GetActiveOfferRolesAsync(appId, OfferTypeId.APP, "de", "en"))
             .MustHaveHappenedOnceExactly();
     }

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -1252,10 +1252,12 @@ public class AppReleaseBusinessLogicTest
     {
         // Arrange
         var appId = _fixture.Create<Guid>();
-        var userRole1 = new ActiveAppRoleDetails("TestRole1", [
+        var roleId1 = _fixture.Create<Guid>();
+        var roleId2 = _fixture.Create<Guid>();
+        var userRole1 = new ActiveAppRoleDetails(roleId1, "TestRole1", [
             new ActiveAppUserRoleDescription("en", "TestRole1 description")
         ]);
-        var userRole2 = new ActiveAppRoleDetails("TestRole2", [
+        var userRole2 = new ActiveAppRoleDetails(roleId2, "TestRole2", [
             new ActiveAppUserRoleDescription("en", "TestRole2 description")
         ]);
         var activeAppRoleDetails = (true, true, new[] {
@@ -1272,8 +1274,8 @@ public class AppReleaseBusinessLogicTest
         // Assert
         result.Should().HaveCount(2)
             .And.Satisfy(
-                x => x.Role == "TestRole1" && x.Descriptions.Count() == 1 && x.Descriptions.Single().Description == "TestRole1 description",
-                x => x.Role == "TestRole2" && x.Descriptions.Count() == 1 && x.Descriptions.Single().Description == "TestRole2 description");
+                x => x.RoleId == roleId1 && x.Role == "TestRole1" && x.Descriptions.Count() == 1 && x.Descriptions.Single().Description == "TestRole1 description",
+                x => x.RoleId == roleId2 && x.Role == "TestRole2" && x.Descriptions.Count() == 1 && x.Descriptions.Single().Description == "TestRole2 description");
         A.CallTo(() => _userRolesRepository.GetOfferProviderRolesAsync(appId, OfferTypeId.APP, _identity.CompanyId, "de", "en"))
             .MustHaveHappenedOnceExactly();
     }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -229,8 +229,8 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         data.IsActive.Should().BeTrue();
         data.AppRoleDetails.Should().HaveCount(2)
             .And.Satisfy(
-                x => x.Role == "EarthCommerce.AdministratorRC_QAS2" && x.Descriptions.Count() == 2 && x.Descriptions.Any(x => x.LanguageCode == "de") && x.Descriptions.Any(x => x.LanguageCode == "en"),
-                x => x.Role == "EarthCommerce.Advanced.BuyerRC_QAS2" && x.Descriptions.Count() == 2 && x.Descriptions.Any(x => x.LanguageCode == "de") && x.Descriptions.Any(x => x.LanguageCode == "en"));
+                x => x.RoleId == new Guid("efc20368-9e82-46ff-b88f-6495b9810253") && x.Role == "EarthCommerce.AdministratorRC_QAS2" && x.Descriptions.Count() == 2 && x.Descriptions.Any(x => x.LanguageCode == "de") && x.Descriptions.Any(x => x.LanguageCode == "en"),
+                x => x.RoleId == new Guid("aabcdfeb-6669-4c74-89f0-19cda090873f") && x.Role == "EarthCommerce.Advanced.BuyerRC_QAS2" && x.Descriptions.Count() == 2 && x.Descriptions.Any(x => x.LanguageCode == "de") && x.Descriptions.Any(x => x.LanguageCode == "en"));
     }
 
     #endregion
@@ -281,8 +281,8 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         data.IsProvider.Should().BeTrue();
         data.AppRoleDetails.Should().HaveCount(2)
             .And.Satisfy(
-                x => x.Role == "EarthCommerce.AdministratorRC_QAS2" && x.Descriptions.Count() == 2 && x.Descriptions.Any(x => x.LanguageCode == "de") && x.Descriptions.Any(x => x.LanguageCode == "en"),
-                x => x.Role == "EarthCommerce.Advanced.BuyerRC_QAS2" && x.Descriptions.Count() == 2 && x.Descriptions.Any(x => x.LanguageCode == "de") && x.Descriptions.Any(x => x.LanguageCode == "en"));
+                x => x.RoleId == new Guid("efc20368-9e82-46ff-b88f-6495b9810253") && x.Role == "EarthCommerce.AdministratorRC_QAS2" && x.Descriptions.Count() == 2 && x.Descriptions.Any(x => x.LanguageCode == "de") && x.Descriptions.Any(x => x.LanguageCode == "en"),
+                x => x.RoleId == new Guid("aabcdfeb-6669-4c74-89f0-19cda090873f") && x.Role == "EarthCommerce.Advanced.BuyerRC_QAS2" && x.Descriptions.Count() == 2 && x.Descriptions.Any(x => x.LanguageCode == "de") && x.Descriptions.Any(x => x.LanguageCode == "en"));
     }
 
     #endregion


### PR DESCRIPTION
## Description

added roleId for exitisting activeRoleDetails

## Why

added roleId field for exiting get endpoints in app marketplace

## Issue

Ref : #705 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
