### PR TITLE
fix(dim): do not create keycloak sa for dim

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW Group AG
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -18,7 +17,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
@@ -43,6 +43,6 @@ public interface IServiceAccountRepository
     public Task<(Guid IdentityId, Guid CompanyId)> GetServiceAccountDataByClientId(string clientId);
     void CreateDimCompanyServiceAccount(Guid serviceAccountId, string authenticationServiceUrl, byte[] secret, byte[] initializationVector, int encryptionMode);
     void CreateDimUserCreationData(Guid serviceAccountId, Guid processId);
-    Task<(bool IsValid, string? Bpn, string? ClientClientId)> GetDimServiceAccountData(Guid dimServiceAccountId);
+    Task<(bool IsValid, string? Bpn, string Name)> GetDimServiceAccountData(Guid dimServiceAccountId);
     Task<Guid> GetDimServiceAccountIdForProcess(Guid processId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -224,13 +224,13 @@ public class ServiceAccountRepository : IServiceAccountRepository
     public void CreateDimUserCreationData(Guid serviceAccountId, Guid processId) =>
          _dbContext.DimUserCreationData.Add(new DimUserCreationData(Guid.NewGuid(), serviceAccountId, processId));
 
-    public Task<(bool IsValid, string? Bpn, string? ClientClientId)> GetDimServiceAccountData(Guid dimServiceAccountId) =>
+    public Task<(bool IsValid, string? Bpn, string Name)> GetDimServiceAccountData(Guid dimServiceAccountId) =>
         _dbContext.DimUserCreationData
             .Where(x => x.Id == dimServiceAccountId)
-            .Select(x => new ValueTuple<bool, string?, string?>(
+            .Select(x => new ValueTuple<bool, string?, string>(
                 true,
                 x.ServiceAccount!.Identity!.Company!.BusinessPartnerNumber,
-                x.ServiceAccount!.ClientClientId))
+                x.ServiceAccount!.Name))
             .SingleOrDefaultAsync();
 
     public Task<Guid> GetDimServiceAccountIdForProcess(Guid processId) =>

--- a/tests/processes/DimUserCreationProcess.Executor.Tests/DimUserCreationProcessServiceTests.cs
+++ b/tests/processes/DimUserCreationProcess.Executor.Tests/DimUserCreationProcessServiceTests.cs
@@ -60,9 +60,9 @@ public class DimUserCreationProcessServiceTests
         // Arrange
         var dimServiceAccountId = Guid.NewGuid();
         var processId = Guid.NewGuid();
-        var expectedServiceAccountName = "dim-sa-test";
+        var expectedServiceAccountName = "dim-sa-testFooBar";
         A.CallTo(() => _serviceAccountRepository.GetDimServiceAccountData(A<Guid>._))
-            .Returns((true, Bpn, "sa-test"));
+            .Returns((true, Bpn, "dim-sa-test Foo Bar"));
 
         // Act
         var result = await _sut.CreateDimUser(processId, dimServiceAccountId, CancellationToken.None);
@@ -86,7 +86,7 @@ public class DimUserCreationProcessServiceTests
         var dimServiceAccountId = Guid.NewGuid();
         var processId = Guid.NewGuid();
         A.CallTo(() => _serviceAccountRepository.GetDimServiceAccountData(A<Guid>._))
-            .Returns(default((bool, string?, string?)));
+            .Returns(default((bool, string?, string)));
         Task Act() => _sut.CreateDimUser(processId, dimServiceAccountId, CancellationToken.None);
 
         // Act
@@ -107,7 +107,7 @@ public class DimUserCreationProcessServiceTests
         var dimServiceAccountId = Guid.NewGuid();
         var processId = Guid.NewGuid();
         A.CallTo(() => _serviceAccountRepository.GetDimServiceAccountData(A<Guid>._))
-            .Returns((true, null, null));
+            .Returns((true, null, "foo"));
         Task Act() => _sut.CreateDimUser(processId, dimServiceAccountId, CancellationToken.None);
 
         // Act
@@ -128,14 +128,14 @@ public class DimUserCreationProcessServiceTests
         var dimServiceAccountId = Guid.NewGuid();
         var processId = Guid.NewGuid();
         A.CallTo(() => _serviceAccountRepository.GetDimServiceAccountData(A<Guid>._))
-            .Returns((true, Bpn, null));
+            .Returns((true, Bpn, "   "));
         Task Act() => _sut.CreateDimUser(processId, dimServiceAccountId, CancellationToken.None);
 
         // Act
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
 
         // Act
-        ex.Message.Should().Be("Service Account Name must not be null");
+        ex.Message.Should().Be("Service Account Name must not be empty");
         A.CallTo(() => _serviceAccountRepository.GetDimServiceAccountData(dimServiceAccountId))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => _dimService.CreateTechnicalUser(Bpn, A<TechnicalUserData>._, A<CancellationToken>._))

--- a/tests/provisioning/Provisioning.Library.Tests/Extensions/ServiceAccountCreationTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/Extensions/ServiceAccountCreationTests.cs
@@ -39,15 +39,21 @@ public class ServiceAccountCreationTests
     private const string Bpn = "CAXSDUMMYCATENAZZ";
     private readonly string _iamUserId = Guid.NewGuid().ToString();
     private readonly Guid _companyId = Guid.NewGuid();
-    private readonly Guid _serviceAccountId = Guid.NewGuid();
     private readonly Guid _identityId = Guid.NewGuid();
+    private readonly Guid _secondId = Guid.NewGuid();
+    private readonly string _validClientId;
     private readonly Guid _validUserRoleId = Guid.NewGuid();
+    private readonly string _dimClient;
+    private readonly string _dimRoleText;
+    private readonly Guid _dimUserRoleId = Guid.NewGuid();
     private readonly Guid _invalidUserRoleId = Guid.NewGuid();
+    private readonly Guid _processId = Guid.NewGuid();
+    private readonly Guid _processStepId = Guid.NewGuid();
 
     private readonly IServiceAccountRepository _serviceAccountRepository;
     private readonly IUserRepository _userRepository;
     private readonly IUserRolesRepository _userRolesRepository;
-
+    private readonly IProcessStepRepository _processStepRepository;
     private readonly IProvisioningManager _provisioningManager;
     private readonly IPortalRepositories _portalRepositories;
     private readonly IProvisioningDBAccess _provisioningDbAccess;
@@ -60,9 +66,14 @@ public class ServiceAccountCreationTests
             .ForEach(b => fixture.Behaviors.Remove(b));
         fixture.Behaviors.Add(new OmitOnRecursionBehavior());
 
+        _validClientId = fixture.Create<string>();
+        _dimClient = fixture.Create<string>();
+        _dimRoleText = fixture.Create<string>();
+
         _serviceAccountRepository = A.Fake<IServiceAccountRepository>();
         _userRepository = A.Fake<IUserRepository>();
         _userRolesRepository = A.Fake<IUserRolesRepository>();
+        _processStepRepository = A.Fake<IProcessStepRepository>();
 
         _provisioningManager = A.Fake<IProvisioningManager>();
         _portalRepositories = A.Fake<IPortalRepositories>();
@@ -71,42 +82,57 @@ public class ServiceAccountCreationTests
         var settings = new ServiceAccountCreationSettings
         {
             ServiceAccountClientPrefix = "sa",
-            DimUserRoles = [new UserRoleConfig("technical_user_management", ["Identity Wallet Management"])]
+            DimUserRoles = [new UserRoleConfig(_dimClient, [_dimRoleText])]
         };
 
         A.CallTo(() => _portalRepositories.GetInstance<IServiceAccountRepository>()).Returns(_serviceAccountRepository);
         A.CallTo(() => _portalRepositories.GetInstance<IUserRepository>()).Returns(_userRepository);
         A.CallTo(() => _portalRepositories.GetInstance<IUserRolesRepository>()).Returns(_userRolesRepository);
+        A.CallTo(() => _portalRepositories.GetInstance<IProcessStepRepository>()).Returns(_processStepRepository);
 
         _sut = new ServiceAccountCreation(_provisioningManager, _portalRepositories, _provisioningDbAccess, Options.Create(settings));
     }
+
+    private void ServiceAccountCreationAction(CompanyServiceAccount _) { }
 
     [Fact]
     public async Task CreateServiceAccountAsync_WithInvalidRole_ThrowsNotFoundException()
     {
         // Arrange
-        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, new[] { _invalidUserRoleId });
+        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_invalidUserRoleId]);
         Setup();
 
         // Act
-        async Task Act() => await _sut.CreateServiceAccountAsync(creationData, _companyId, Enumerable.Empty<string>(), CompanyServiceAccountTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null));
+        async Task Act() => await _sut.CreateServiceAccountAsync(creationData, _companyId, Enumerable.Empty<string>(), CompanyServiceAccountTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
         ex.Message.Should().Be(ProvisioningServiceErrors.USER_NOT_VALID_USERROLEID.ToString());
-        A.CallTo(() => _provisioningManager.AddBpnAttributetoUserAsync(A<string>._, A<IEnumerable<string>>._)).MustNotHaveHappened();
-        A.CallTo(() => _provisioningManager.AddProtocolMapperAsync(A<string>._)).MustNotHaveHappened();
-        A.CallTo(() => _userRolesRepository.DeleteCompanyUserAssignedRoles(A<IEnumerable<(Guid, Guid)>>._)).MustNotHaveHappened();
+
+        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, A<UserStatusId>._, A<IdentityTypeId>._, A<Action<Identity>>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _serviceAccountRepository.CreateCompanyServiceAccount(A<Guid>._, A<string>._, A<string>._, A<string>._, A<CompanyServiceAccountTypeId>._, A<CompanyServiceAccountKindId>._, A<Action<CompanyServiceAccount>>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _userRolesRepository.CreateIdentityAssignedRoleRange(A<IEnumerable<(Guid, Guid)>>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _provisioningManager.SetupCentralServiceAccountClientAsync(A<string>._, A<ClientConfigRolesData>._, A<bool>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _provisioningManager.AddBpnAttributetoUserAsync(A<string>._, A<IEnumerable<string>>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _provisioningManager.AddProtocolMapperAsync(A<string>._))
+            .MustNotHaveHappened();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
     }
 
-    [Fact]
-    public async Task CreateServiceAccountAsync_WithValidData_ReturnsExpected()
+    [Theory]
+    [InlineData(false, "testName")]
+    [InlineData(true, "sa1-testName")]
+    public async Task CreateServiceAccountAsync_WithValidData_ReturnsExpected(bool enhance, string serviceAccountName)
     {
         // Arrange
         var serviceAccounts = new List<CompanyServiceAccount>();
         var identities = new List<Identity>();
-        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, new[] { _validUserRoleId });
+        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_validUserRoleId]);
         var bpns = new[]
         {
             Bpn
@@ -114,21 +140,64 @@ public class ServiceAccountCreationTests
         Setup(serviceAccounts, identities);
 
         // Act
-        var result = await _sut.CreateServiceAccountAsync(creationData, _companyId, bpns, CompanyServiceAccountTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null));
+        var result = await _sut.CreateServiceAccountAsync(creationData, _companyId, bpns, CompanyServiceAccountTypeId.OWN, enhance, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
 
         // Assert
-        result.ServiceAccounts.Should().ContainSingle();
-        var serviceAccount = result.ServiceAccounts.Single();
-        serviceAccount.UserRoleData.Should().ContainSingle(x => x.UserRoleId == _validUserRoleId && x.UserRoleText == "UserRole");
-        serviceAccount.ServiceAccountData.InternalClientId.Should().Be("internal-sa1");
-        serviceAccount.ServiceAccountData.IamUserId.Should().Be(_iamUserId);
-        serviceAccount.ServiceAccountData.AuthData.IamClientAuthMethod.Should().Be(IamClientAuthMethod.SECRET);
-        A.CallTo(() => _provisioningManager.AddBpnAttributetoUserAsync(_iamUserId, bpns)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _provisioningManager.AddProtocolMapperAsync("internal-sa1")).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
+
+        result.ServiceAccounts.Should().ContainSingle()
+            .Which.Should().Match<CreatedServiceAccountData>(x =>
+                x.ClientId == "sa1" &&
+                x.Description == "abc" &&
+                x.UserRoleData.SequenceEqual(new[] { new UserRoleData(_validUserRoleId, _validClientId, "UserRole") }) &&
+                x.Name == serviceAccountName &&
+                x.ServiceAccountData != null &&
+                x.ServiceAccountData.InternalClientId == "internal-sa1" &&
+                x.ServiceAccountData.IamUserId == _iamUserId &&
+                x.ServiceAccountData.AuthData.IamClientAuthMethod == IamClientAuthMethod.SECRET
+            );
+
+        A.CallTo(() => _userRepository.CreateIdentity(_companyId, UserStatusId.ACTIVE, IdentityTypeId.COMPANY_SERVICE_ACCOUNT, null))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _serviceAccountRepository.CreateCompanyServiceAccount(_identityId, "testName", "abc", "sa1", CompanyServiceAccountTypeId.OWN, CompanyServiceAccountKindId.INTERNAL, ServiceAccountCreationAction))
+            .MustHaveHappenedOnceExactly();
+        var expectedRolesIds = new[] { (_identityId, _validUserRoleId) };
+        A.CallTo(() => _userRolesRepository.CreateIdentityAssignedRoleRange(A<IEnumerable<(Guid, Guid)>>.That.IsSameSequenceAs(expectedRolesIds)))
+            .MustHaveHappenedOnceExactly();
+        IEnumerable<string>? userRoles;
+        A.CallTo(() => _provisioningManager.SetupCentralServiceAccountClientAsync(
+            "sa1",
+            A<ClientConfigRolesData>.That.Matches(x =>
+                x.IamClientAuthMethod == IamClientAuthMethod.SECRET &&
+                x.Name == serviceAccountName &&
+                x.Description == "abc" &&
+                x.ClientRoles.Count() == 1 &&
+                x.ClientRoles.TryGetValue(_validClientId, out userRoles) &&
+                userRoles.SequenceEqual(new[] { "UserRole" })),
+            true))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _provisioningManager.AddBpnAttributetoUserAsync(_iamUserId, bpns))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _provisioningManager.AddProtocolMapperAsync("internal-sa1"))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, UserStatusId.PENDING, A<IdentityTypeId>._, A<Action<Identity>>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _serviceAccountRepository.CreateCompanyServiceAccount(A<Guid>._, A<string>._, A<string>._, A<string>._, A<CompanyServiceAccountTypeId>._, CompanyServiceAccountKindId.EXTERNAL, A<Action<CompanyServiceAccount>>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _userRolesRepository.CreateIdentityAssignedRoleRange(A<IEnumerable<(Guid, Guid)>>.That.Matches(x => x.Any(y => y.Item2 != _validUserRoleId))))
+            .MustNotHaveHappened();
+        A.CallTo(() => _processStepRepository.CreateProcess(A<ProcessTypeId>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _processStepRepository.CreateProcessStep(A<ProcessStepTypeId>._, A<ProcessStepStatusId>._, A<Guid>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _serviceAccountRepository.CreateDimUserCreationData(A<Guid>._, A<Guid>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _portalRepositories.SaveAsync())
+            .MustNotHaveHappened();
         serviceAccounts.Should().ContainSingle().Which.Should().Match<CompanyServiceAccount>(
             x => x.Name == "testName" &&
-                 x.ClientClientId == "sa1");
+                 x.ClientClientId == "sa1" &&
+                 x.CompanyServiceAccountKindId == CompanyServiceAccountKindId.INTERNAL);
         identities.Should().ContainSingle().Which.Should().Match<Identity>(
             x => x.CompanyId == _companyId &&
                  x.UserStatusId == UserStatusId.ACTIVE &&
@@ -136,12 +205,12 @@ public class ServiceAccountCreationTests
     }
 
     [Fact]
-    public async Task CreateServiceAccountAsync_WithNameSetAndValidData_ReturnsExpected()
+    public async Task CreateServiceAccountAsync_WithValidDimData_ReturnsExpected()
     {
         // Arrange
         var serviceAccounts = new List<CompanyServiceAccount>();
         var identities = new List<Identity>();
-        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, new[] { _validUserRoleId });
+        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_dimUserRoleId]);
         var bpns = new[]
         {
             Bpn
@@ -149,26 +218,139 @@ public class ServiceAccountCreationTests
         Setup(serviceAccounts, identities);
 
         // Act
-        var result = await _sut.CreateServiceAccountAsync(creationData, _companyId, bpns, CompanyServiceAccountTypeId.OWN, true, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null));
+        var result = await _sut.CreateServiceAccountAsync(creationData, _companyId, bpns, CompanyServiceAccountTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
 
         // Assert
-        result.ServiceAccounts.Should().ContainSingle();
-        var technicalUser = result.ServiceAccounts.Single();
-        technicalUser.UserRoleData.Should().ContainSingle(x => x.UserRoleId == _validUserRoleId && x.UserRoleText == "UserRole");
-        technicalUser.ServiceAccountData.InternalClientId.Should().Be("internal-sa1");
-        technicalUser.ServiceAccountData.IamUserId.Should().Be(_iamUserId);
-        technicalUser.ServiceAccountData.AuthData.IamClientAuthMethod.Should().Be(IamClientAuthMethod.SECRET);
-        A.CallTo(() => _provisioningManager.SetupCentralServiceAccountClientAsync(A<string>._, A<ClientConfigRolesData>.That.Matches(x => x.Name == "sa1-testName"), A<bool>._)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _provisioningManager.AddBpnAttributetoUserAsync(_iamUserId, bpns)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _provisioningManager.AddProtocolMapperAsync("internal-sa1")).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
+        result.ServiceAccounts.Should().ContainSingle()
+            .Which.Should().Match<CreatedServiceAccountData>(x =>
+                x.ClientId == null &&
+                x.Description == "abc" &&
+                x.UserRoleData.SequenceEqual(new[] { new UserRoleData(_dimUserRoleId, _dimClient, _dimRoleText) }) &&
+                x.Name == "dim-testName" &&
+                x.ServiceAccountData == null &&
+                x.Status == UserStatusId.PENDING
+            );
+
+        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, UserStatusId.ACTIVE, A<IdentityTypeId>._, A<Action<Identity>>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _serviceAccountRepository.CreateCompanyServiceAccount(A<Guid>._, A<string>._, A<string>._, A<string>._, A<CompanyServiceAccountTypeId>._, CompanyServiceAccountKindId.INTERNAL, A<Action<CompanyServiceAccount>>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _userRolesRepository.CreateIdentityAssignedRoleRange(A<IEnumerable<(Guid, Guid)>>.That.Matches(x => x.Any(y => y.Item2 != _dimUserRoleId))))
+            .MustNotHaveHappened();
+
+        A.CallTo(() => _provisioningManager.SetupCentralServiceAccountClientAsync(A<string>._, A<ClientConfigRolesData>._, A<bool>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _provisioningManager.AddBpnAttributetoUserAsync(A<string>._, A<IEnumerable<string>>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => _provisioningManager.AddProtocolMapperAsync(A<string>._))
+            .MustNotHaveHappened();
+
+        A.CallTo(() => _userRepository.CreateIdentity(_companyId, UserStatusId.PENDING, IdentityTypeId.COMPANY_SERVICE_ACCOUNT, null))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _serviceAccountRepository.CreateCompanyServiceAccount(_identityId, "dim-testName", "abc", null, CompanyServiceAccountTypeId.OWN, CompanyServiceAccountKindId.EXTERNAL, ServiceAccountCreationAction))
+            .MustHaveHappenedOnceExactly();
+        var expectedRolesIds = new[] { (_identityId, _dimUserRoleId) };
+        A.CallTo(() => _userRolesRepository.CreateIdentityAssignedRoleRange(A<IEnumerable<(Guid, Guid)>>.That.IsSameSequenceAs(expectedRolesIds)))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.DIM_TECHNICAL_USER))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _processStepRepository.CreateProcessStep(ProcessStepTypeId.CREATE_DIM_TECHNICAL_USER, ProcessStepStatusId.TODO, A<Guid>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _serviceAccountRepository.CreateDimUserCreationData(_identityId, _processId))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _portalRepositories.SaveAsync())
+            .MustNotHaveHappened();
+
         serviceAccounts.Should().ContainSingle().Which.Should().Match<CompanyServiceAccount>(
-            x => x.Name == "testName" &&
-                 x.ClientClientId == "sa1");
+            x => x.Name == "dim-testName" &&
+                 x.ClientClientId == null &&
+                 x.CompanyServiceAccountKindId == CompanyServiceAccountKindId.EXTERNAL);
         identities.Should().ContainSingle().Which.Should().Match<Identity>(
             x => x.CompanyId == _companyId &&
-                 x.UserStatusId == UserStatusId.ACTIVE &&
+                 x.UserStatusId == UserStatusId.PENDING &&
                  x.IdentityTypeId == IdentityTypeId.COMPANY_SERVICE_ACCOUNT);
+    }
+
+    [Fact]
+    public async Task CreateServiceAccountAsync_WithValidDataPlus_ReturnsExpected()
+    {
+        // Arrange
+        var serviceAccounts = new List<CompanyServiceAccount>();
+        var identities = new List<Identity>();
+        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_validUserRoleId, _dimUserRoleId]);
+        var bpns = new[]
+        {
+            Bpn
+        };
+        Setup(serviceAccounts, identities);
+
+        // Act
+        var result = await _sut.CreateServiceAccountAsync(creationData, _companyId, bpns, CompanyServiceAccountTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
+
+        // Assert
+        result.ServiceAccounts.Should().HaveCount(2)
+            .And.Satisfy(
+                x => x.ClientId == "sa1" &&
+                     x.Description == "abc" &&
+                     x.UserRoleData.SequenceEqual(new[] { new UserRoleData(_validUserRoleId, _validClientId, "UserRole") }) &&
+                     x.Name == "testName" &&
+                     x.ServiceAccountData != null &&
+                     x.ServiceAccountData.InternalClientId == "internal-sa1" &&
+                     x.ServiceAccountData.IamUserId == _iamUserId &&
+                     x.ServiceAccountData.AuthData.IamClientAuthMethod == IamClientAuthMethod.SECRET,
+                x => x.ClientId == null &&
+                     x.Description == "abc" &&
+                     x.UserRoleData.SequenceEqual(new[] { new UserRoleData(_dimUserRoleId, _dimClient, _dimRoleText) }) &&
+                     x.Name == "dim-testName" &&
+                     x.ServiceAccountData == null);
+
+        A.CallTo(() => _userRepository.CreateIdentity(_companyId, UserStatusId.ACTIVE, IdentityTypeId.COMPANY_SERVICE_ACCOUNT, null))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _serviceAccountRepository.CreateCompanyServiceAccount(_identityId, "testName", "abc", "sa1", CompanyServiceAccountTypeId.OWN, CompanyServiceAccountKindId.INTERNAL, ServiceAccountCreationAction))
+            .MustHaveHappenedOnceExactly();
+        var expectedRolesIds = new[] { (_identityId, _validUserRoleId) };
+        A.CallTo(() => _userRolesRepository.CreateIdentityAssignedRoleRange(A<IEnumerable<(Guid, Guid)>>.That.IsSameSequenceAs(expectedRolesIds)))
+            .MustHaveHappenedOnceExactly();
+        IEnumerable<string>? userRoles;
+        A.CallTo(() => _provisioningManager.SetupCentralServiceAccountClientAsync(
+            "sa1",
+            A<ClientConfigRolesData>.That.Matches(x =>
+                x.IamClientAuthMethod == IamClientAuthMethod.SECRET &&
+                x.Name == "testName" &&
+                x.Description == "abc" &&
+                x.ClientRoles.Count() == 1 &&
+                x.ClientRoles.TryGetValue(_validClientId, out userRoles) &&
+                userRoles.SequenceEqual(new[] { "UserRole" })),
+            true))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _provisioningManager.AddBpnAttributetoUserAsync(_iamUserId, bpns))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _provisioningManager.AddProtocolMapperAsync("internal-sa1"))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _userRepository.CreateIdentity(_companyId, UserStatusId.ACTIVE, IdentityTypeId.COMPANY_SERVICE_ACCOUNT, null))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _serviceAccountRepository.CreateCompanyServiceAccount(_secondId, "dim-testName", "abc", null, CompanyServiceAccountTypeId.OWN, CompanyServiceAccountKindId.EXTERNAL, ServiceAccountCreationAction))
+            .MustHaveHappenedOnceExactly();
+        var expectedDimRolesIds = new[] { (_secondId, _dimUserRoleId) };
+        A.CallTo(() => _userRolesRepository.CreateIdentityAssignedRoleRange(A<IEnumerable<(Guid, Guid)>>.That.IsSameSequenceAs(expectedDimRolesIds)))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _portalRepositories.SaveAsync())
+            .MustNotHaveHappened();
+
+        serviceAccounts.Should().HaveCount(2)
+            .And.Satisfy(
+                x => x.Name == "testName" && x.ClientClientId == "sa1" && x.CompanyServiceAccountKindId == CompanyServiceAccountKindId.INTERNAL,
+                x => x.Name == "dim-testName" && x.ClientClientId == null && x.CompanyServiceAccountKindId == CompanyServiceAccountKindId.EXTERNAL
+            );
+        identities.Should().HaveCount(2)
+            .And.AllSatisfy(x => x.Should().Match<Identity>(x => x.CompanyId == _companyId && x.IdentityTypeId == IdentityTypeId.COMPANY_SERVICE_ACCOUNT))
+            .And.Satisfy(
+                x => x.Id == _identityId && x.UserStatusId == UserStatusId.ACTIVE,
+                x => x.Id == _secondId && x.UserStatusId == UserStatusId.PENDING
+            );
     }
 
     #region Setup
@@ -176,21 +358,29 @@ public class ServiceAccountCreationTests
     private void Setup(ICollection<CompanyServiceAccount>? serviceAccounts = null, ICollection<Identity>? identities = null)
     {
         A.CallTo(() => _provisioningDbAccess.GetNextClientSequenceAsync())
-            .Returns(1);
+            .Returns(1).Once();
 
         A.CallTo(() => _provisioningManager.SetupCentralServiceAccountClientAsync(A<string>._, A<ClientConfigRolesData>._, A<bool>._))
-            .Returns(new ServiceAccountData("internal-sa1", _iamUserId, new ClientAuthData(IamClientAuthMethod.SECRET)));
+            .Returns(new ServiceAccountData("internal-sa1", _iamUserId, new ClientAuthData(IamClientAuthMethod.SECRET))).Once();
 
-        A.CallTo(() => _userRepository.CreateIdentity(_companyId, A<UserStatusId>._, IdentityTypeId.COMPANY_SERVICE_ACCOUNT, A<Action<Identity>>._))
-            .Invokes((Guid companyId, UserStatusId userStatusId, IdentityTypeId identityTypeId, Action<Identity>? setOptionalFields) =>
+        A.CallTo(() => _userRepository.CreateIdentity(A<Guid>._, A<UserStatusId>._, A<IdentityTypeId>._, A<Action<Identity>>._))
+            .ReturnsLazily((Guid companyId, UserStatusId userStatusId, IdentityTypeId identityTypeId, Action<Identity>? setOptionalFields) =>
             {
-                var identity = new Identity(Guid.NewGuid(), DateTimeOffset.UtcNow, companyId, userStatusId, identityTypeId);
+                var identity = new Identity(_identityId, DateTimeOffset.UtcNow, companyId, userStatusId, identityTypeId);
                 setOptionalFields?.Invoke(identity);
                 identities?.Add(identity);
-            })
-            .Returns(new Identity(_identityId, default, default, default, default));
-        A.CallTo(() => _serviceAccountRepository.CreateCompanyServiceAccount(_identityId, A<string>._, A<string>._, A<string>._, A<CompanyServiceAccountTypeId>._, A<CompanyServiceAccountKindId>._, A<Action<CompanyServiceAccount>>._))
-            .Invokes((Guid identityId, string name, string description, string clientClientId, CompanyServiceAccountTypeId companyServiceAccountTypeId, CompanyServiceAccountKindId companyServiceAccountKindId, Action<CompanyServiceAccount>? setOptionalParameters) =>
+                return identity;
+            }).Once()
+            .Then.ReturnsLazily((Guid companyId, UserStatusId userStatusId, IdentityTypeId identityTypeId, Action<Identity>? setOptionalFields) =>
+            {
+                var identity = new Identity(_secondId, DateTimeOffset.UtcNow, companyId, userStatusId, identityTypeId);
+                setOptionalFields?.Invoke(identity);
+                identities?.Add(identity);
+                return identity;
+            }).Once();
+
+        A.CallTo(() => _serviceAccountRepository.CreateCompanyServiceAccount(A<Guid>._, A<string>._, A<string>._, A<string>._, A<CompanyServiceAccountTypeId>._, A<CompanyServiceAccountKindId>._, A<Action<CompanyServiceAccount>>._))
+            .ReturnsLazily((Guid identityId, string name, string description, string clientClientId, CompanyServiceAccountTypeId companyServiceAccountTypeId, CompanyServiceAccountKindId companyServiceAccountKindId, Action<CompanyServiceAccount>? setOptionalParameters) =>
             {
                 var sa = new CompanyServiceAccount(
                     identityId,
@@ -203,13 +393,26 @@ public class ServiceAccountCreationTests
                 };
                 setOptionalParameters?.Invoke(sa);
                 serviceAccounts?.Add(sa);
-            })
-            .Returns(new CompanyServiceAccount(_serviceAccountId, null!, null!, default, default));
+                return sa;
+            });
 
-        A.CallTo(() => _userRolesRepository.GetUserRoleDataUntrackedAsync(A<IEnumerable<Guid>>.That.Matches(x => x.Count(y => y == _validUserRoleId) == 1)))
-            .Returns(new[] { new UserRoleData(_validUserRoleId, Guid.NewGuid().ToString(), "UserRole") }.ToAsyncEnumerable());
-        A.CallTo(() => _userRolesRepository.GetUserRoleDataUntrackedAsync(A<IEnumerable<Guid>>.That.Matches(x => x.Count(y => y == _invalidUserRoleId) == 1)))
+        A.CallTo(() => _userRolesRepository.GetUserRoleDataUntrackedAsync(A<IEnumerable<Guid>>.That.Contains(_validUserRoleId)))
+            .Returns(new[] { new UserRoleData(_validUserRoleId, _validClientId, "UserRole") }.ToAsyncEnumerable());
+        A.CallTo(() => _userRolesRepository.GetUserRoleDataUntrackedAsync(A<IEnumerable<Guid>>.That.Contains(_dimUserRoleId)))
+            .Returns(new[] { new UserRoleData(_dimUserRoleId, _dimClient, _dimRoleText) }.ToAsyncEnumerable());
+        A.CallTo(() => _userRolesRepository.GetUserRoleDataUntrackedAsync(A<IEnumerable<Guid>>.That.Contains(_invalidUserRoleId)))
             .Returns(Enumerable.Empty<UserRoleData>().ToAsyncEnumerable());
+        A.CallTo(() => _userRolesRepository.GetUserRoleDataUntrackedAsync(A<IEnumerable<Guid>>.That.IsSameSequenceAs(new[] { _validUserRoleId, _dimUserRoleId })))
+            .Returns(new UserRoleData[]
+            {
+                new(_validUserRoleId, _validClientId, "UserRole"),
+                new(_dimUserRoleId, _dimClient, _dimRoleText)
+            }.ToAsyncEnumerable());
+
+        A.CallTo(() => _processStepRepository.CreateProcess(A<ProcessTypeId>._))
+            .ReturnsLazily((ProcessTypeId processTypeId) => new Process(_processId, processTypeId, Guid.NewGuid())).Once();
+        A.CallTo(() => _processStepRepository.CreateProcessStep(A<ProcessStepTypeId>._, A<ProcessStepStatusId>._, A<Guid>._))
+            .ReturnsLazily((ProcessStepTypeId processStepTypeId, ProcessStepStatusId processStepStatusId, Guid processId) => new ProcessStep(_processStepId, processStepTypeId, processStepStatusId, processId, DateTimeOffset.UtcNow)).Once();
     }
 
     #endregion


### PR DESCRIPTION
## Description

technical user creation has been adjusted such that no keycloak-serviceaccount is created in case only the dim-role is being  requested.

## Why

The additional keycloak service-account that was created before this change is useless and therefore confuses the user.

## Issue

#593 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
