### PR TITLE
fix(role assignment): fix query for core offer role assignment

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
@@ -154,13 +154,16 @@ public class UserRolesRepository : IUserRolesRepository
             .Select(role => new
             {
                 Role = role,
+                IsRequested = userRoles.Contains(role.UserRoleText),
                 IsAssigned = role.IdentityAssignedRoles.Any(iar => iar.IdentityId == identityId),
                 IsAssignable = role.UserRoleCollections.Any(collection => collection.CompanyRoleAssignedRoleCollection!.CompanyRole!.CompanyAssignedRoles.Any(assigned => assigned.Company!.Identities.Any(identity => identity.Id == identityId)))
             })
-            .Where(x =>
-                userRoles.Contains(x.Role.UserRoleText) ||
-                x.IsAssigned ||
-                x.IsAssignable)
+            // x.IsRequested && x.IsAssigned && x.IsAssignable ||   // no change but required to detect duplicates
+            // x.IsRequested && !x.IsAssigned && x.IsAssignable ||  // to be assigned
+            // !x.IsRequested && x.IsAssigned ||                    // to be unassigned
+            // x.IsRequested && !x.IsAssignable                     // invalid
+            // can be simplified to:
+            .Where(x => x.IsRequested || x.IsAssigned)
             .Select(x => new UserRoleModificationData(
                 x.Role.UserRoleText,
                 x.Role.Id,


### PR DESCRIPTION
## Description

The query being used to determine roles to be assigned has been adjusted to not include unassigned but not requested and assignable roles.

## Why

update of core-offer-roles would result in all roles to be assigned that are assignable in respect to the assigned company-roles

## Issue

#748 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
- [X] I have commented my code, particularly in hard-to-understand areas
