### PR TITLE
feat(permission): add fix for permission check on api endpoints

### DIFF
--- a/src/marketplace/Services.Service/Controllers/ServicesController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServicesController.cs
@@ -262,7 +262,7 @@ public class ServicesController : ControllerBase
     /// <response code="403">User's company does not provide the service.</response>
     /// <response code="404">No service or subscription found.</response>
     [HttpGet]
-    [Authorize(Roles = "add_service_offering")]
+    [Authorize(Roles = "service_management")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("{serviceId}/subscription/{subscriptionId}/provider")]
     [ProducesResponseType(typeof(ProviderSubscriptionDetailData), StatusCodes.Status200OK)]
@@ -282,7 +282,7 @@ public class ServicesController : ControllerBase
     /// <response code="403">User's company does not provide the service.</response>
     /// <response code="404">No service or subscription found.</response>
     [HttpGet]
-    [Authorize(Roles = "add_service_offering")]
+    [Authorize(Roles = "subscribe_service")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("{serviceId}/subscription/{subscriptionId}/subscriber")]
     [ProducesResponseType(typeof(SubscriberSubscriptionDetailData), StatusCodes.Status200OK)]
@@ -299,7 +299,7 @@ public class ServicesController : ControllerBase
     /// <response code="400">If sub claim is empty/invalid or user does not exist.</response>
     [HttpGet]
     [Route("subscribed/subscription-status")]
-    [Authorize(Roles = "view_subscription")]
+    [Authorize(Roles = "view_service_subscriptions")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [ProducesResponseType(typeof(Pagination.Response<OfferSubscriptionStatusDetailData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]


### PR DESCRIPTION
## Description

Need to change permission for below mentioned endpoints:

Endpoint: GET /api/services/subscribed/subscription-status
Change permission check to view_service_subscriptions

Endpoint: GET /api/services/{serviceId}/subscription/{subscriptionId}/subscriber
Change permission check to subscribe_service

Endpoint: GET /api/services/{serviceId}/subscription/{subscriptionId}/provider
Change permission check to service_management

## Why

updated permission roles for api endpoints as mentioned in description.

## Issue

#750 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
