### PR TITLE
fix(keycloak): set clockSkew to 5 minutes for token lifetime

### DIFF
--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -57,7 +57,7 @@
       "ValidAudience": "",
       "ValidateAudience": true,
       "ValidateLifetime": true,
-      "ClockSkew": 600000
+      "ClockSkew": "00:05:00"
     }
   },
   "Provisioning": {

--- a/src/notifications/Notifications.Service/appsettings.json
+++ b/src/notifications/Notifications.Service/appsettings.json
@@ -56,7 +56,7 @@
       "ValidAudience": "",
       "ValidateAudience": true,
       "ValidateLifetime": true,
-      "ClockSkew": 600000
+      "ClockSkew": "00:05:00"
     }
   },
   "Notifications": {

--- a/src/registration/Registration.Service/appsettings.json
+++ b/src/registration/Registration.Service/appsettings.json
@@ -63,7 +63,7 @@
       "ValidAudience": "",
       "ValidateAudience": true,
       "ValidateLifetime": true,
-      "ClockSkew": 600000
+      "ClockSkew": "00:05:00"
     }
   },
   "Provisioning": {

--- a/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
@@ -40,7 +40,7 @@
       "ValidAudience": "",
       "ValidateAudience": true,
       "ValidateLifetime": true,
-      "ClockSkew": 600000
+      "ClockSkew": "00:05:00"
     }
   },
   "Provisioning": {

--- a/tests/marketplace/Apps.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/marketplace/Apps.Service.Tests/appsettings.IntegrationTests.json
@@ -28,7 +28,7 @@
       "ValidAudience": "",
       "ValidateAudience": true,
       "ValidateLifetime": true,
-      "ClockSkew": 600000
+      "ClockSkew": "00:05:00"
     }
   },
   "ConnectionStrings": {

--- a/tests/marketplace/Services.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/marketplace/Services.Service.Tests/appsettings.IntegrationTests.json
@@ -28,7 +28,7 @@
       "ValidAudience": "",
       "ValidateAudience": true,
       "ValidateLifetime": true,
-      "ClockSkew": 600000
+      "ClockSkew": "00:05:00"
     }
   },
   "ConnectionStrings": {

--- a/tests/notifications/Notifications.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/notifications/Notifications.Service.Tests/appsettings.IntegrationTests.json
@@ -55,7 +55,7 @@
       "ValidAudience": "",
       "ValidateAudience": true,
       "ValidateLifetime": true,
-      "ClockSkew": 600000
+      "ClockSkew": "00:05:00"
     }
   },
   "Notifications": {


### PR DESCRIPTION
## Description

security configuration jwtBearerOptions value of ClockSkew is set to 5 minutes.

## Why

ClockSkew is configured as 600000, but as json-deserialization expects a string and not a number to deserialize a TimeSpan the resulting grace-period for token expiry is way to long to be acceptable. This is a security issue.

## Issue

#586 

Link to Github issue.

corresponding PR in CD-repo: https://github.com/eclipse-tractusx/portal/pull/324

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
