### PR TITLE
fix(processes): fix offersubscription process initialization

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyInvitationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyInvitationRepository.cs
@@ -38,9 +38,10 @@ public class CompanyInvitationRepository : ICompanyInvitationRepository
     }
 
     public Task<Guid> GetCompanyInvitationForProcessId(Guid processId) =>
-        _context.Processes
-            .Where(process => process.Id == processId)
-            .Select(process => process.CompanyInvitation!.Id)
+        _context.CompanyInvitations
+            .AsNoTracking()
+            .Where(i => i.ProcessId == processId)
+            .Select(i => i.Id)
             .SingleOrDefaultAsync();
 
     public Task<string?> GetOrganisationNameForInvitation(Guid invitationId) =>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/NetworkRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/NetworkRepository.cs
@@ -45,10 +45,10 @@ public class NetworkRepository : INetworkRepository
 
     /// <inheritdoc />
     public Task<Guid> GetNetworkRegistrationDataForProcessIdAsync(Guid processId) =>
-        _context.Processes
+        _context.NetworkRegistrations
             .AsNoTracking()
-            .Where(process => process.Id == processId)
-            .Select(process => process.NetworkRegistration!.Id)
+            .Where(nr => nr.ProcessId == processId)
+            .Select(nr => nr.Id)
             .SingleOrDefaultAsync();
 
     public Task<(bool RegistrationIdExists, VerifyProcessData processData)> IsValidRegistration(string externalId, IEnumerable<ProcessStepTypeId> processStepTypeIds) =>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -332,10 +332,10 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
 
     /// <inheritdoc />
     public Task<Guid> GetOfferSubscriptionDataForProcessIdAsync(Guid processId) =>
-        _context.Processes
+        _context.OfferSubscriptions
             .AsNoTracking()
-            .Where(process => process.Id == processId)
-            .Select(process => process.OfferSubscription!.Id)
+            .Where(os => os.ProcessId == processId)
+            .Select(os => os.Id)
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />

--- a/src/processes/Processes.Worker.Library/IProcessTypeExecutor.cs
+++ b/src/processes/Processes.Worker.Library/IProcessTypeExecutor.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022 Microsoft and BMW Group AG
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -18,7 +17,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Processes.Worker.Library;


### PR DESCRIPTION
## Description

queries that return a single guid from a joined table are adjusted to join in the where-condition instead of the selection

## Why

EF throws 'System.InvalidOperationException: Nullable object must have a value' in case the where-condition of a query is not fulfilled and the query selects a single guid from a joined table.

## Issue

#754 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes