### PR TITLE
feat(serviceaccount): get serviceaccount with all status besides DELETED

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
@@ -21,6 +21,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Dim.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
@@ -32,7 +33,7 @@ public interface IServiceAccountBusinessLogic
     Task<ServiceAccountConnectorOfferData> GetOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId);
     Task<ServiceAccountDetails> UpdateOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId, ServiceAccountEditableDetails serviceAccountDetails);
     Task<ServiceAccountDetails> ResetOwnCompanyServiceAccountSecretAsync(Guid serviceAccountId);
-    Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, string? clientId, bool? isOwner, bool filterForInactive);
+    Task<Pagination.Response<CompanyServiceAccountData>> GetOwnCompanyServiceAccountsDataAsync(int page, int size, string? clientId, bool? isOwner, bool filterForInactive, IEnumerable<UserStatusId>? userStatusIds);
     IAsyncEnumerable<UserRoleWithDescription> GetServiceAccountRolesAsync(string? languageShortName);
     Task HandleServiceAccountCreationCallback(Guid processId, AuthenticationDetail callbackData);
 }

--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -26,6 +26,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Web.Identity;
 
@@ -162,6 +163,7 @@ public class ServiceAccountController : ControllerBase
     /// <param name="isOwner">isOwner either true or false</param>
     /// <param name="clientId">clientId is string clientclientid</param>
     /// <param name="filterForInactive">isUserStatusActive is True or False</param>
+    /// <param name="userStatus">userStatus is ACTIVE, INACTIVE, PENDING or DELETED (optional, multiple values allowed)</param>
     /// <returns>Returns the specific number of service account data for the given page.</returns>
     /// <remarks>Example: GET: api/administration/serviceaccount/owncompany/serviceaccounts</remarks>
     /// <response code="200">Returns the specific number of service account data for the given page.</response>
@@ -170,8 +172,8 @@ public class ServiceAccountController : ControllerBase
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("owncompany/serviceaccounts")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyServiceAccountData>), StatusCodes.Status200OK)]
-    public Task<Pagination.Response<CompanyServiceAccountData>> GetServiceAccountsData([FromQuery] int page, [FromQuery] int size, [FromQuery] bool? isOwner, [FromQuery] string? clientId, [FromQuery] bool filterForInactive) =>
-        _logic.GetOwnCompanyServiceAccountsDataAsync(page, size, clientId, isOwner, filterForInactive);
+    public Task<Pagination.Response<CompanyServiceAccountData>> GetServiceAccountsData([FromQuery] int page, [FromQuery] int size, [FromQuery] bool? isOwner, [FromQuery] string? clientId, [FromQuery] bool filterForInactive = false, [FromQuery] IEnumerable<UserStatusId>? userStatus = null) =>
+        _logic.GetOwnCompanyServiceAccountsDataAsync(page, size, clientId, isOwner, filterForInactive, userStatus);
 
     /// <summary>
     /// Get all service account roles

--- a/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
+++ b/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
@@ -33,6 +33,7 @@ public record ServiceAccountConnectorOfferData(
     [property: JsonPropertyName("authenticationType")] IamClientAuthMethod IamClientAuthMethod,
     [property: JsonPropertyName("roles")] IEnumerable<UserRoleData> UserRoleDatas,
     [property: JsonPropertyName("companyServiceAccountTypeId")] CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
+    [property: JsonPropertyName("status")] UserStatusId UserStatusId,
     [property: JsonPropertyName("secret")] string? Secret,
     [property: JsonPropertyName("connector")] ConnectorResponseData? Connector,
     [property: JsonPropertyName("offer")] OfferResponseData? Offer,

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
@@ -28,6 +28,7 @@ public record CompanyServiceAccountData(
     [property: JsonPropertyName("clientId")] string? ClientId,
     [property: JsonPropertyName("name")] string Name,
     [property: JsonPropertyName("serviceAccountType")] CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
+    [property: JsonPropertyName("status")] UserStatusId UserStatusId,
     [property: JsonPropertyName("isOwner")] bool IsOwner,
     [property: JsonPropertyName("isProvider")] bool IsProvider,
     [property: JsonPropertyName("offerSubscriptionId")] Guid? OfferSubscriptionId,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
@@ -38,7 +38,7 @@ public interface IServiceAccountRepository
     Task<CompanyServiceAccountWithRoleDataClientId?> GetOwnCompanyServiceAccountWithIamClientIdAsync(Guid serviceAccountId, Guid userCompanyId);
     Task<(IEnumerable<Guid> UserRoleIds, Guid? ConnectorId, string? ClientClientId, ConnectorStatusId? statusId, OfferSubscriptionStatusId? OfferStatusId)> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId);
     Task<CompanyServiceAccountDetailedData?> GetOwnCompanyServiceAccountDetailedDataUntrackedAsync(Guid serviceAccountId, Guid companyId);
-    Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnCompanyServiceAccountsUntracked(Guid userCompanyId, string? clientId, bool? isOwner, UserStatusId userStatusId);
+    Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnCompanyServiceAccountsUntracked(Guid userCompanyId, string? clientId, bool? isOwner, IEnumerable<UserStatusId> userStatusIds);
     Task<bool> CheckActiveServiceAccountExistsForCompanyAsync(Guid technicalUserId, Guid companyId);
     public Task<(Guid IdentityId, Guid CompanyId)> GetServiceAccountDataByClientId(string clientId);
     void CreateDimCompanyServiceAccount(Guid serviceAccountId, string authenticationServiceUrl, byte[] secret, byte[] initializationVector, int encryptionMode);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -177,7 +177,7 @@ public class ServiceAccountRepository : IServiceAccountRepository
                         : x.IsOwner || x.IsProvider) &&
                     userStatusIds.Contains(x.ServiceAccount.Identity!.UserStatusId) &&
                     (clientId == null || EF.Functions.ILike(x.ServiceAccount.ClientClientId!, $"%{clientId.EscapeForILike()}%")))
-                .GroupBy(x => x.ServiceAccount.Identity!.UserStatusId),
+                .GroupBy(x => x.ServiceAccount.Identity!.IdentityTypeId),
             x => x.OrderBy(x => x.ServiceAccount.Name),
             x => new CompanyServiceAccountData(
                 x.ServiceAccount.Id,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -116,7 +116,7 @@ public class ServiceAccountRepository : IServiceAccountRepository
             .AsNoTracking()
             .Where(serviceAccount =>
                 serviceAccount.Id == serviceAccountId &&
-                serviceAccount.Identity!.UserStatusId == UserStatusId.ACTIVE &&
+                serviceAccount.Identity!.UserStatusId != UserStatusId.DELETED &&
                 (serviceAccount.CompaniesLinkedServiceAccount!.Owners == companyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == companyId))
             .Select(serviceAccount => new CompanyServiceAccountDetailedData(
                     serviceAccount.Id,

--- a/tests/administration/Administration.Service.Tests/Controllers/ServiceAccountControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/ServiceAccountControllerTests.cs
@@ -17,7 +17,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Microsoft.AspNetCore.Mvc;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Controllers;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
@@ -27,6 +26,7 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
+using System.Collections.Immutable;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Controllers;
 
@@ -106,19 +106,26 @@ public class ServiceAccountControllerTests
 
     }
 
-    [Fact]
-    public async Task GetServiceAccountsData_CallsExpected()
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task GetServiceAccountsData_CallsExpected(bool filterInactive, bool withStatusIds)
     {
         //Arrange
         var paginationResponse = new Pagination.Response<CompanyServiceAccountData>(new Pagination.Metadata(15, 1, 1, 15), _fixture.CreateMany<CompanyServiceAccountData>(5));
-        A.CallTo(() => _logic.GetOwnCompanyServiceAccountsDataAsync(0, 15, null, null, true))
+        IEnumerable<UserStatusId>? userStatusIds = withStatusIds
+            ? _fixture.CreateMany<UserStatusId>().ToImmutableArray()
+            : null;
+        A.CallTo(() => _logic.GetOwnCompanyServiceAccountsDataAsync(0, 15, null, null, filterInactive, userStatusIds))
                   .Returns(paginationResponse);
 
         //Act
-        var result = await _controller.GetServiceAccountsData(0, 15, null, null, true);
+        var result = await _controller.GetServiceAccountsData(0, 15, null, null, filterInactive, userStatusIds);
 
         //Assert
-        A.CallTo(() => _logic.GetOwnCompanyServiceAccountsDataAsync(0, 15, null, null, true)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetOwnCompanyServiceAccountsDataAsync(0, 15, null, null, filterInactive, userStatusIds)).MustHaveHappenedOnceExactly();
         Assert.IsType<Pagination.Response<CompanyServiceAccountData>>(result);
         result.Content.Should().HaveCount(5);
     }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -232,14 +232,16 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(newvalidCompanyId, null, null, [UserStatusId.ACTIVE])(page, size);
 
         // Assert
-        result.Should().NotBeNull();
-        result!.Count.Should().Be(count);
-        result.Data.Should().HaveCount(expected);
+        result.Should().NotBeNull()
+            .And.Match<Framework.Models.Pagination.Source<Models.CompanyServiceAccountData>>(x =>
+                x.Count == count &&
+                x.Data.Count() == expected);
         if (expected > 0)
         {
-            result.Data.First().CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.MANAGED);
-            result.Data.First().IsOwner.Should().BeTrue();
-            result.Data.First().IsProvider.Should().BeFalse();
+            result!.Data.First().Should().Match<Models.CompanyServiceAccountData>(y =>
+                y.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED &&
+                y.IsOwner &&
+                !y.IsProvider);
         }
     }
 
@@ -268,6 +270,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, true, [UserStatusId.ACTIVE])(0, 10).ConfigureAwait(false);
 
         // Assert
+        result.Should().NotBeNull();
         result!.Count.Should().Be(15);
         result.Data.Should().HaveCount(10)
             .And.AllSatisfy(x => x.Should().Match<Models.CompanyServiceAccountData>(y =>
@@ -297,6 +300,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, false, [UserStatusId.ACTIVE])(0, 10).ConfigureAwait(false);
 
         // Assert
+        result.Should().NotBeNull();
         result!.Count.Should().Be(1);
         result.Data.Should().HaveCount(1)
             .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED
@@ -313,6 +317,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(new("41fd2ab8-71cd-4546-9bef-a388d91b2543"), "sa-x-2", false, [UserStatusId.ACTIVE])(0, 10);
 
         // Assert
+        result.Should().NotBeNull();
         result!.Count.Should().Be(1);
         result.Data.Should().HaveCount(1)
             .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED);
@@ -328,6 +333,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-2", null, [UserStatusId.ACTIVE])(0, 10);
 
         // Assert
+        result.Should().NotBeNull();
         result!.Count.Should().Be(1);
         result.Data.Should().HaveCount(1)
             .And.Satisfy(x => x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN);
@@ -343,6 +349,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null, [UserStatusId.ACTIVE])(0, 10);
 
         // Assert
+        result.Should().NotBeNull();
         result!.Count.Should().Be(13);
         result.Data.Should().HaveCount(10);
     }
@@ -357,13 +364,41 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetOwnCompanyServiceAccountsUntracked(new Guid("729e0af2-6723-4a7f-85a1-833d84b39bdf"), null, null, [UserStatusId.INACTIVE])(0, 10);
 
         // Assert
+        result.Should().NotBeNull();
         result!.Count.Should().Be(1);
-        result.Data.Should().HaveCount(1)
-            .And.Satisfy(x =>
+        result.Data.Should().ContainSingle()
+            .Which.Should().Match<Models.CompanyServiceAccountData>(x =>
                 x.ServiceAccountId == new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94d") &&
                 x.ClientId == "sa-x-inactive" &&
                 x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED &&
                 x.UserStatusId == UserStatusId.INACTIVE);
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithMultipleStatus_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new("729e0af2-6723-4a7f-85a1-833d84b39bdf"), null, null, [UserStatusId.ACTIVE, UserStatusId.INACTIVE, UserStatusId.PENDING, UserStatusId.DELETED])(0, 10);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Data.DistinctBy(x => x.UserStatusId).Should().HaveCountGreaterThan(1);
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountsUntracked_WithInvalidCompanyId_ReturnsNull()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new Guid("deadbeef-dead-beef-dead-beefdeadbeef"), null, null, [UserStatusId.ACTIVE, UserStatusId.INACTIVE, UserStatusId.PENDING, UserStatusId.DELETED])(0, 10);
+
+        // Assert
+        result.Should().BeNull();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -229,7 +229,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var newvalidCompanyId = new Guid("41fd2ab8-71cd-4546-9bef-a388d91b2542");
         var (sut, _) = await CreateSut();
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(newvalidCompanyId, null, null, UserStatusId.ACTIVE)(page, size);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(newvalidCompanyId, null, null, [UserStatusId.ACTIVE])(page, size);
 
         // Assert
         result.Should().NotBeNull();
@@ -250,7 +250,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-2", true, UserStatusId.ACTIVE)(0, 10);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-2", true, [UserStatusId.ACTIVE])(0, 10);
 
         // Assert
         result!.Count.Should().Be(1);
@@ -265,12 +265,14 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, true, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, true, [UserStatusId.ACTIVE])(0, 10).ConfigureAwait(false);
 
         // Assert
         result!.Count.Should().Be(15);
         result.Data.Should().HaveCount(10)
-            .And.AllSatisfy(x => x.CompanyServiceAccountTypeId.Should().Be(CompanyServiceAccountTypeId.OWN))
+            .And.AllSatisfy(x => x.Should().Match<Models.CompanyServiceAccountData>(y =>
+                y.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN &&
+                y.UserStatusId == UserStatusId.ACTIVE))
             .And.BeInAscendingOrder(x => x.Name)
             .And.Satisfy(
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201029"),
@@ -292,7 +294,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut().ConfigureAwait(false);
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, false, UserStatusId.ACTIVE)(0, 10).ConfigureAwait(false);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, null, false, [UserStatusId.ACTIVE])(0, 10).ConfigureAwait(false);
 
         // Assert
         result!.Count.Should().Be(1);
@@ -308,7 +310,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new("41fd2ab8-71cd-4546-9bef-a388d91b2543"), "sa-x-2", false, UserStatusId.ACTIVE)(0, 10);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new("41fd2ab8-71cd-4546-9bef-a388d91b2543"), "sa-x-2", false, [UserStatusId.ACTIVE])(0, 10);
 
         // Assert
         result!.Count.Should().Be(1);
@@ -323,7 +325,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-2", null, UserStatusId.ACTIVE)(0, 10);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl5-custodian-2", null, [UserStatusId.ACTIVE])(0, 10);
 
         // Assert
         result!.Count.Should().Be(1);
@@ -338,7 +340,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null, UserStatusId.ACTIVE)(0, 10);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(_validCompanyId, "sa-cl", null, [UserStatusId.ACTIVE])(0, 10);
 
         // Assert
         result!.Count.Should().Be(13);
@@ -352,15 +354,16 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new Guid("729e0af2-6723-4a7f-85a1-833d84b39bdf"), null, null, UserStatusId.INACTIVE)(0, 10);
+        var result = await sut.GetOwnCompanyServiceAccountsUntracked(new Guid("729e0af2-6723-4a7f-85a1-833d84b39bdf"), null, null, [UserStatusId.INACTIVE])(0, 10);
 
         // Assert
         result!.Count.Should().Be(1);
         result.Data.Should().HaveCount(1)
             .And.Satisfy(x =>
-                x.ServiceAccountId == new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94d")
-                && x.ClientId == "sa-x-inactive"
-                && x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED);
+                x.ServiceAccountId == new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94d") &&
+                x.ClientId == "sa-x-inactive" &&
+                x.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.MANAGED &&
+                x.UserStatusId == UserStatusId.INACTIVE);
     }
 
     #endregion


### PR DESCRIPTION
## Description

query of endpoint /api/administration/serviceaccount/owncompany/serviceaccounts/<serviceaccountid> has been changed to allow serviceaccounts in all status besides DELETED

## Why

only serviceaccounts in status ACTIVE were returned, but other status are required as well.

## Issue

#760 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
