### PR TITLE
fix(serviceaccount): fix conflict errors for inactive and pending serviceaccounts

### DIFF
--- a/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
+++ b/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
@@ -27,10 +27,10 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 
 public record ServiceAccountConnectorOfferData(
     [property: JsonPropertyName("serviceAccountId")] Guid ServiceAccountId,
-    [property: JsonPropertyName("clientId")] string ClientId,
+    [property: JsonPropertyName("clientId")] string? ClientId,
     [property: JsonPropertyName("name")] string Name,
     [property: JsonPropertyName("description")] string Description,
-    [property: JsonPropertyName("authenticationType")] IamClientAuthMethod IamClientAuthMethod,
+    [property: JsonPropertyName("authenticationType")] IamClientAuthMethod? IamClientAuthMethod,
     [property: JsonPropertyName("roles")] IEnumerable<UserRoleData> UserRoleDatas,
     [property: JsonPropertyName("companyServiceAccountTypeId")] CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
     [property: JsonPropertyName("status")] UserStatusId UserStatusId,

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -237,7 +237,7 @@ public class ServiceAccountBusinessLogicTests
     }
 
     [Fact]
-    public async Task GetOwnCompanyServiceAccountDetailsAsync_WithInvalidUser_NotFoundException()
+    public async Task GetOwnCompanyServiceAccountDetailsAsync_WithInvalidCompany_NotFoundException()
     {
         // Arrange
         SetupGetOwnCompanyServiceAccountDetails();
@@ -249,7 +249,7 @@ public class ServiceAccountBusinessLogicTests
         async Task Act() => await sut.GetOwnCompanyServiceAccountDetailsAsync(ValidServiceAccountId);
 
         // Assert
-        var exception = await Assert.ThrowsAsync<ConflictException>(Act);
+        var exception = await Assert.ThrowsAsync<NotFoundException>(Act);
         exception.Message.Should().Be(AdministrationServiceAccountErrors.SERVICE_ACCOUNT_NOT_CONFLICT.ToString());
     }
 
@@ -265,7 +265,7 @@ public class ServiceAccountBusinessLogicTests
         async Task Act() => await sut.GetOwnCompanyServiceAccountDetailsAsync(invalidServiceAccountId);
 
         // Assert
-        var exception = await Assert.ThrowsAsync<ConflictException>(Act);
+        var exception = await Assert.ThrowsAsync<NotFoundException>(Act);
         exception.Message.Should().Be(AdministrationServiceAccountErrors.SERVICE_ACCOUNT_NOT_CONFLICT.ToString());
     }
 
@@ -733,6 +733,7 @@ public class ServiceAccountBusinessLogicTests
     private void SetupGetOwnCompanyServiceAccount()
     {
         var data = _fixture.Build<CompanyServiceAccountDetailedData>()
+            .With(x => x.Status, UserStatusId.ACTIVE)
             .With(x => x.DimServiceAccountData, default(DimServiceAccountData?))
             .Create();
 


### PR DESCRIPTION
## Description

endpoint GET /api/administration/serviceaccount/owncompany/serviceaccounts/<serviceaccountid> has been adjusted to allow null clientId, iamClientAuthMethod and secret.
SERVICE_UNDEFINED_CLIENTID_CONFLICT is not raised any more in case clientId is null

## Why

when calling this endpoint for serviceaccounts in status PENDING or INACTIVE the iamClientAuthMethod and secret cannot be retrieved from keycloak and should be returned as null but error SERVICE_UNDEFINED_CLIENTID_CONFLICT was raised (which is only appropriate for status ACTIVE).

## Issue

#760 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes