### PR TITLE
chore(migrations): rename migration for rc10

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20240517135403_2.0.0-rc10.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20240517135403_2.0.0-rc10.Designer.cs
@@ -29,8 +29,8 @@ using System.Text.Json;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    [Migration("20240517135403_CPLP-3548-declineRegistration")]
-    partial class CPLP3548declineRegistration
+    [Migration("20240517135403_2.0.0-rc10")]
+    partial class _200rc10
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20240517135403_2.0.0-rc10.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20240517135403_2.0.0-rc10.cs
@@ -26,7 +26,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations.Migrations
 {
     /// <inheritdoc />
-    public partial class CPLP3548declineRegistration : Migration
+    public partial class _200rc10 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
## Description

migration 20240517135403_CPLP-3548-declineRegistration is renamed to 20240517135403_2.0.0-rc10

## Why

released migrations should refer to the release-name, not individual tickets

## Issue

https://github.com/eclipse-tractusx/portal/issues/328

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
