### PR TITLE
fix(sa): fix old autosetup process for dim technical user creation

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -79,7 +79,7 @@ public class ServiceAccountBusinessLogic(
             .IfAny(unassignable => throw ControllerArgumentException.Create(AdministrationServiceAccountErrors.SERVICE_ROLES_NOT_ASSIGN_ARGUMENT, parameters: [new("unassignable", string.Join(",", unassignable)), new("userRoleIds", string.Join(",", result.TechnicalUserRoleIds))]));
 
         const CompanyServiceAccountTypeId CompanyServiceAccountTypeId = CompanyServiceAccountTypeId.OWN;
-        var (_, serviceAccounts) = await serviceAccountCreation.CreateServiceAccountAsync(serviceAccountCreationInfos, companyId, [result.Bpn], CompanyServiceAccountTypeId, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null)).ConfigureAwait(ConfigureAwaitOptions.None);
+        var (_, _, serviceAccounts) = await serviceAccountCreation.CreateServiceAccountAsync(serviceAccountCreationInfos, companyId, [result.Bpn], CompanyServiceAccountTypeId, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null)).ConfigureAwait(ConfigureAwaitOptions.None);
 
         await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
         return serviceAccounts.Select(sa => new ServiceAccountDetails(

--- a/src/marketplace/Offers.Library/Service/IOfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferSetupService.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW Group AG
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/provisioning/Provisioning.Library/Service/IServiceAccountCreation.cs
+++ b/src/provisioning/Provisioning.Library/Service/IServiceAccountCreation.cs
@@ -37,7 +37,7 @@ public interface IServiceAccountCreation
     /// <param name="processData">The process that should be created if a role for a provider type was selected</param>
     /// <param name="setOptionalParameter"></param>
     /// <returns>Returns information about the created technical user</returns>
-    Task<(bool HasExternalServiceAccount, IEnumerable<CreatedServiceAccountData> ServiceAccounts)> CreateServiceAccountAsync(
+    Task<(bool HasExternalServiceAccount, Guid? processId, IEnumerable<CreatedServiceAccountData> ServiceAccounts)> CreateServiceAccountAsync(
             ServiceAccountCreationInfo creationData,
             Guid companyId,
             IEnumerable<string> bpns,

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -680,7 +680,7 @@ public class ServiceAccountBusinessLogicTests
             .Returns<(string?, IEnumerable<Guid>)>(default);
 
         A.CallTo(() => _serviceAccountCreation.CreateServiceAccountAsync(A<ServiceAccountCreationInfo>._, A<Guid>.That.Matches(x => x == ValidCompanyId), A<IEnumerable<string>>._, CompanyServiceAccountTypeId.OWN, A<bool>._, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), null))
-            .Returns((false, Guid.Empty, [new CreatedServiceAccountData(Guid.NewGuid(), "test", "description", UserStatusId.ACTIVE, ClientId, new(ClientId, Guid.NewGuid().ToString(), new ClientAuthData(IamClientAuthMethod.SECRET)), Enumerable.Empty<UserRoleData>())]));
+            .Returns((false, null, [new CreatedServiceAccountData(Guid.NewGuid(), "test", "description", UserStatusId.ACTIVE, ClientId, new(ClientId, Guid.NewGuid().ToString(), new ClientAuthData(IamClientAuthMethod.SECRET)), Enumerable.Empty<UserRoleData>())]));
 
         A.CallTo(() => _portalRepositories.GetInstance<ICompanyRepository>()).Returns(_companyRepository);
     }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -680,7 +680,7 @@ public class ServiceAccountBusinessLogicTests
             .Returns<(string?, IEnumerable<Guid>)>(default);
 
         A.CallTo(() => _serviceAccountCreation.CreateServiceAccountAsync(A<ServiceAccountCreationInfo>._, A<Guid>.That.Matches(x => x == ValidCompanyId), A<IEnumerable<string>>._, CompanyServiceAccountTypeId.OWN, A<bool>._, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), null))
-            .Returns((false, [new CreatedServiceAccountData(Guid.NewGuid(), "test", "description", UserStatusId.ACTIVE, ClientId, new(ClientId, Guid.NewGuid().ToString(), new ClientAuthData(IamClientAuthMethod.SECRET)), Enumerable.Empty<UserRoleData>())]));
+            .Returns((false, Guid.Empty, [new CreatedServiceAccountData(Guid.NewGuid(), "test", "description", UserStatusId.ACTIVE, ClientId, new(ClientId, Guid.NewGuid().ToString(), new ClientAuthData(IamClientAuthMethod.SECRET)), Enumerable.Empty<UserRoleData>())]));
 
         A.CallTo(() => _portalRepositories.GetInstance<ICompanyRepository>()).Returns(_companyRepository);
     }

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
@@ -256,9 +256,7 @@ public class OfferSetupServiceTests
     public async Task AutoSetup_WithMultipleTechnicalUsers_ThrowsException()
     {
         // Arrange
-        var offerSubscription = new OfferSubscription(Guid.NewGuid(), Guid.Empty, Guid.Empty, OfferSubscriptionStatusId.PENDING, Guid.Empty, default);
-        var companyServiceAccount = new CompanyServiceAccount(Guid.NewGuid(), "test", "test", CompanyServiceAccountTypeId.OWN, CompanyServiceAccountKindId.INTERNAL);
-        SetupAutoSetup(OfferTypeId.APP, offerSubscription, false, companyServiceAccount);
+        SetupAutoSetup(OfferTypeId.APP);
         var clientId = Guid.NewGuid();
         var appInstanceId = Guid.NewGuid();
         A.CallTo(() => _clientRepository.CreateClient(A<string>._))
@@ -1118,16 +1116,20 @@ public class OfferSetupServiceTests
                     setOptionalParameter?.Invoke(companyServiceAccount);
                 }
             })
-            .Returns((withMatchingDimRoles, Guid.Empty, [
-                new CreatedServiceAccountData(
+            .Returns((
+                withMatchingDimRoles,
+                withMatchingDimRoles
+                    ? Guid.NewGuid()
+                    : null,
+                [new CreatedServiceAccountData(
                     serviceAccountId,
                     "test",
                     "test description",
                     withMatchingDimRoles ? UserStatusId.PENDING : UserStatusId.ACTIVE,
                     clientId ?? $"{data.OfferName}-{data.CompanyName}",
                     serviceAccountData,
-                    userRoleData)
-            ]));
+                    userRoleData)]
+            ));
         var itAdminRoles = Enumerable.Repeat(new UserRoleConfig("Test", ["AdminRoles"]), 1);
 
         // Act

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
@@ -1118,7 +1118,7 @@ public class OfferSetupServiceTests
                     setOptionalParameter?.Invoke(companyServiceAccount);
                 }
             })
-            .Returns((withMatchingDimRoles, [
+            .Returns((withMatchingDimRoles, Guid.Empty, [
                 new CreatedServiceAccountData(
                     serviceAccountId,
                     "test",
@@ -1457,7 +1457,7 @@ public class OfferSetupServiceTests
                     setOptionalParameter?.Invoke(companyServiceAccount);
                 }
             })
-            .Returns(new ValueTuple<bool, List<CreatedServiceAccountData>>(false, [
+            .Returns(new ValueTuple<bool, Guid?, List<CreatedServiceAccountData>>(false, null, [
                 new CreatedServiceAccountData(
                     _technicalUserId,
                     "sa2",


### PR DESCRIPTION
## Description

Added the process id to the offer subscription for the dim user to retrieve the offer subscription

## Why

Currently the process to create the dim technical users fails because it is not linked to a offer subscription

## Issue

Refs: #762

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
