### PR TITLE
fix(ownCompany): allow deletion of configured url for own company

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/ProviderDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ProviderDetailData.cs
@@ -20,6 +20,6 @@
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
-public record ProviderDetailData(string Url, string? CallbackUrl);
+public record ProviderDetailData(string? Url, string? CallbackUrl);
 
 public record ProviderDetailReturnData(Guid? Id, Guid CompanyId, string? Url);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -408,4 +408,8 @@ public class CompanyRepository(PortalDbContext context)
                         c.Wallet.AuthenticationServiceUrl
                     )))
             .SingleOrDefaultAsync();
+
+    public void RemoveProviderCompanyDetails(Guid providerCompanyDetailId) =>
+        context.ProviderCompanyDetails
+            .Remove(new ProviderCompanyDetail(providerCompanyDetailId, Guid.Empty, null!, default));
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -178,4 +178,5 @@ public interface ICompanyRepository
     Task<(bool Exists, Guid CompanyId, IEnumerable<Guid> SubmittedCompanyApplicationId)> GetCompanyIdByBpn(string bpn);
     Task<(string? Bpn, string? Did, string? WalletUrl)> GetDimServiceUrls(Guid companyId);
     Task<(string? Holder, string? BusinessPartnerNumber, WalletInformation? WalletInformation)> GetWalletData(Guid identityId);
+    void RemoveProviderCompanyDetails(Guid providerCompanyDetailId);
 }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -1002,6 +1002,29 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
+    #region RemoveProviderCompanyDetails
+
+    [Fact]
+    public async Task RemoveProviderCompanyDetails_ExecutesExpected()
+    {
+        // Arrange
+        var (sut, context) = await CreateSut();
+
+        // Act
+        sut.RemoveProviderCompanyDetails(new Guid("7e86a0b8-6903-496b-96d1-0ef508206833"));
+
+        // Assert
+        var changeTracker = context.ChangeTracker;
+        var changedEntries = changeTracker.Entries().ToList();
+        changeTracker.HasChanges().Should().BeTrue();
+        changedEntries.Should().NotBeEmpty();
+        changedEntries.Should().HaveCount(1);
+        var removedEntity = changedEntries.Single();
+        removedEntity.State.Should().Be(EntityState.Deleted);
+    }
+
+    #endregion
+
     #region Setup
 
     private async Task<(ICompanyRepository, PortalDbContext)> CreateSut()


### PR DESCRIPTION
## Description

Adjust endpoint PUT /api/administration/SubscriptionConfiguration/owncompany to allow the deletion of the configured url

## Why

To allow the deletion of the configured url

## Issue

Refs: #764

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
