### PR TITLE
fix(permission): adjust permission for /declineregistration

### DIFF
--- a/src/registration/Registration.Service/Controllers/RegistrationController.cs
+++ b/src/registration/Registration.Service/Controllers/RegistrationController.cs
@@ -502,7 +502,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Service.Controllers
         /// <response code="204">Successfully declined the application</response>
         /// <response code="404">Application ID not found.</response>
         [HttpPost]
-        [Authorize(Roles = "decline_new_partner")]
+        [Authorize(Roles = "view_registration")]
         [Authorize(Policy = PolicyTypes.CompanyUser)]
         [Route("applications/{applicationId}/declineregistration")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]


### PR DESCRIPTION
## Description

Adjust permission for POST: /api/registration/application/{applicationId}/declineregistration

## Why

Currently the wrong permission is set for the endpoint

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
