### PR TITLE
fix(subscriptionConfig): adjust url null case

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -18,7 +18,7 @@ nuget/nuget/-/Laraue.EfCoreTriggers.Common/8.0.3, MIT, approved, #13968
 nuget/nuget/-/Laraue.EfCoreTriggers.PostgreSql/8.0.3, MIT, approved, #13984
 nuget/nuget/-/MailKit/4.3.0, MIT AND LicenseRef-scancode-ietf AND LicenseRef-scancode-ietf-trust AND (BSD-3-Clause AND LicenseRef-scancode-ietf-trust), approved, #13986
 nuget/nuget/-/MimeKit/4.3.0, MIT AND FSFULLRWD AND LicenseRef-scancode-ietf AND LicenseRef-scancode-ietf-trust AND (BSD-3-Clause AND LicenseRef-scancode-ietf-trust) AND BSD-3-Clause AND MS-PL AND CC-BY-SA-4.0 AND LicenseRef-MIT-style AND CC-PDDC AND GPL-2.0-only, approved, #13987
-nuget/nuget/-/Mono.TextTemplating/2.2.1, MIT, approved, clearlydefined
+nuget/nuget/-/Mono.TextTemplating/2.2.1, MIT, approved, #15073
 nuget/nuget/-/NHamcrest/3.4.0, MIT, approved, #13964
 nuget/nuget/-/NJsonSchema/10.9.0, MIT, approved, #9300
 nuget/nuget/-/Namotion.Reflection/2.1.2, MIT, approved, #9320

--- a/src/administration/Administration.Service/BusinessLogic/SubscriptionConfigurationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/SubscriptionConfigurationBusinessLogic.cs
@@ -88,7 +88,7 @@ public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfiguration
             await HandleCreateProviderCompanyDetails(data, companyId, companyRepository);
             hasChanges = true;
         }
-        else if (data.Url != null)
+        else if (providerDetailData != default && data.Url != null)
         {
             companyRepository.AttachAndModifyProviderCompanyDetails(
                 providerDetailData.ProviderCompanyDetailId,
@@ -100,7 +100,7 @@ public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfiguration
                 });
             hasChanges = true;
         }
-        else if (providerDetailData != default)
+        else if (providerDetailData != default && data.Url == null)
         {
             companyRepository.RemoveProviderCompanyDetails(providerDetailData.ProviderCompanyDetailId);
             hasChanges = true;

--- a/src/administration/Administration.Service/BusinessLogic/SubscriptionConfigurationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/SubscriptionConfigurationBusinessLogic.cs
@@ -82,9 +82,11 @@ public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfiguration
         var providerDetailData = await companyRepository
             .GetProviderCompanyDetailsExistsForUser(companyId)
             .ConfigureAwait(ConfigureAwaitOptions.None);
+        var hasChanges = false;
         if (providerDetailData == default && data.Url != null)
         {
             await HandleCreateProviderCompanyDetails(data, companyId, companyRepository);
+            hasChanges = true;
         }
         else if (data.Url != null)
         {
@@ -96,13 +98,18 @@ public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfiguration
                     details.AutoSetupUrl = data.Url;
                     details.DateLastChanged = DateTimeOffset.UtcNow;
                 });
+            hasChanges = true;
         }
-        else
+        else if (providerDetailData != default)
         {
             companyRepository.RemoveProviderCompanyDetails(providerDetailData.ProviderCompanyDetailId);
+            hasChanges = true;
         }
 
-        await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+        if (hasChanges)
+        {
+            await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+        }
     }
 
     private static async Task HandleCreateProviderCompanyDetails(ProviderDetailData data, Guid companyId, ICompanyRepository companyRepository)

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
@@ -199,8 +199,28 @@ public class SubscriptionConfigurationBusinessLogicTests
         // Assert
         A.CallTo(() => _companyRepository.CreateProviderCompanyDetail(A<Guid>._, A<string>._, A<Action<ProviderCompanyDetail>>._)).MustHaveHappened();
         A.CallTo(() => _companyRepository.AttachAndModifyProviderCompanyDetails(A<Guid>._, A<Action<ProviderCompanyDetail>>._, A<Action<ProviderCompanyDetail>>._)).MustNotHaveHappened();
-        A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappened(1, Times.OrMore);
+        A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         _serviceProviderDetails.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SetProviderCompanyDetailsAsync_WithNotExistingAndUrlNull_DoesNothing()
+    {
+        // Arrange
+        SetupProviderCompanyDetails();
+        var providerDetailData = new ProviderDetailData(null, null);
+        A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
+            .Returns((Guid.Empty, null!));
+
+        // Act
+        await _sut.SetProviderCompanyDetailsAsync(providerDetailData);
+
+        // Assert
+        A.CallTo(() => _companyRepository.CreateProviderCompanyDetail(A<Guid>._, A<string>._, A<Action<ProviderCompanyDetail>>._)).MustNotHaveHappened();
+        A.CallTo(() => _companyRepository.RemoveProviderCompanyDetails(A<Guid>._)).MustNotHaveHappened();
+        A.CallTo(() => _companyRepository.AttachAndModifyProviderCompanyDetails(A<Guid>._, A<Action<ProviderCompanyDetail>>._, A<Action<ProviderCompanyDetail>>._)).MustNotHaveHappened();
+        A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
+        _serviceProviderDetails.Should().BeEmpty();
     }
 
     [Fact]
@@ -255,7 +275,7 @@ public class SubscriptionConfigurationBusinessLogicTests
         //Assert
         A.CallTo(() => _companyRepository.CreateProviderCompanyDetail(A<Guid>._, A<string>._, null)).MustNotHaveHappened();
         A.CallTo(() => _companyRepository.AttachAndModifyProviderCompanyDetails(detailsId, A<Action<ProviderCompanyDetail>>._, A<Action<ProviderCompanyDetail>>._)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappened(1, Times.OrMore);
+        A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         initialDetail.Should().NotBeNull();
         initialDetail!.AutoSetupUrl.Should().Be(existingUrl);
         modifyDetail.Should().NotBeNull();


### PR DESCRIPTION
## Description

adjust handling if url null is send when no provider company detail is set

## Why

when trying to set url to null if no provider company detail is existing the endpoint throws a 500 error

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
