### PR TITLE
fix(invite): add locking to invite process

### DIFF
--- a/src/processes/Invitation.Executor/InvitationProcessTypeExecutor.cs
+++ b/src/processes/Invitation.Executor/InvitationProcessTypeExecutor.cs
@@ -48,6 +48,15 @@ public class InvitationProcessTypeExecutor : IProcessTypeExecutor
         ProcessStepTypeId.INVITATION_CREATE_DATABASE_IDP,
         ProcessStepTypeId.INVITATION_CREATE_USER);
 
+    private static readonly IEnumerable<ProcessStepTypeId> LockableProcessSteps = ImmutableArray.Create(
+        ProcessStepTypeId.INVITATION_CREATE_CENTRAL_IDP,
+        ProcessStepTypeId.INVITATION_CREATE_SHARED_IDP_SERVICE_ACCOUNT,
+        ProcessStepTypeId.INVITATION_CREATE_CENTRAL_IDP_ORG_MAPPER,
+        ProcessStepTypeId.INVITATION_CREATE_SHARED_REALM,
+        ProcessStepTypeId.INVITATION_CREATE_SHARED_CLIENT,
+        ProcessStepTypeId.INVITATION_CREATE_DATABASE_IDP,
+        ProcessStepTypeId.INVITATION_CREATE_USER);
+
     private readonly IPortalRepositories _portalRepositories;
     private readonly IInvitationProcessService _invitationProcessService;
     private Guid _companyInvitationId;
@@ -80,7 +89,7 @@ public class InvitationProcessTypeExecutor : IProcessTypeExecutor
         return new IProcessTypeExecutor.InitializationResult(false, null);
     }
 
-    public ValueTask<bool> IsLockRequested(ProcessStepTypeId processStepTypeId) => new(false);
+    public ValueTask<bool> IsLockRequested(ProcessStepTypeId processStepTypeId) => new(LockableProcessSteps.Contains(processStepTypeId));
 
     public ProcessTypeId GetProcessTypeId() => ProcessTypeId.INVITATION;
 

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -24,7 +24,6 @@ using Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.BusinessLogic;
-using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
@@ -859,33 +858,20 @@ public class CompanyDataBusinessLogicTests
 
     #region GetAllCompanyCertificates
 
-    [Fact]
-    public async Task GetAllCompanyCertificatesAsync_WithDefaultRequest_GetsExpectedEntries()
+    [Theory]
+    [InlineData(10, 0, 7, 7)]
+    [InlineData(10, 1, 7, 3)]
+    [InlineData(10, 0, 15, 10)]
+    public async Task GetAllCompanyCertificatesAsync_GetsExpectedEntries(int num, int page, int requested, int expected)
     {
         // Arrange
-        SetupPagination();
-        var sut = _fixture.Create<CompanyDataBusinessLogic>();
+        SetupPagination(num);
 
         // Act
-        var result = await sut.GetAllCompanyCertificatesAsync(0, 5, null, null, null);
+        var result = await _sut.GetAllCompanyCertificatesAsync(page, requested, null, null, null);
 
         // Assert
-        result.Content.Should().HaveCount(3);
-    }
-
-    [Fact]
-    public async Task GetAllCompanyCertificatesAsync_WithSmallSize_GetsExpectedEntries()
-    {
-        // Arrange
-        const int expectedCount = 3;
-        SetupPagination();
-        var sut = _fixture.Create<CompanyDataBusinessLogic>();
-
-        // Act
-        var result = await sut.GetAllCompanyCertificatesAsync(0, expectedCount, null, null, null);
-
-        // Assert
-        result.Content.Should().HaveCount(expectedCount);
+        result.Content.Should().HaveCount(expected);
     }
 
     #endregion
@@ -979,7 +965,6 @@ public class CompanyDataBusinessLogicTests
     public async Task DeleteCompanyCertificateAsync_WithDocumentNotExisting_ThrowsNotFoundException()
     {
         // Arrange
-        //var sut = _fixture.Create<CompanyDataBusinessLogic>();
         A.CallTo(() => _companyCertificateRepository.GetCompanyCertificateDocumentDetailsForIdUntrackedAsync(Guid.NewGuid(), _identity.CompanyId))
             .Returns((Guid.NewGuid(), DocumentStatusId.LOCKED, new[] { Guid.NewGuid() }.AsEnumerable(), false));
 

--- a/tests/processes/Invitation.Executor.Tests/InvitationProcessTypeExecutorTests.cs
+++ b/tests/processes/Invitation.Executor.Tests/InvitationProcessTypeExecutorTests.cs
@@ -312,14 +312,14 @@ public class InvitationProcessTypeExecutorTests
     #region IsLockRequested
 
     [Theory]
-    [InlineData(ProcessStepTypeId.INVITATION_CREATE_CENTRAL_IDP, false)]
-    [InlineData(ProcessStepTypeId.INVITATION_CREATE_SHARED_IDP_SERVICE_ACCOUNT, false)]
+    [InlineData(ProcessStepTypeId.INVITATION_CREATE_CENTRAL_IDP, true)]
+    [InlineData(ProcessStepTypeId.INVITATION_CREATE_SHARED_IDP_SERVICE_ACCOUNT, true)]
     [InlineData(ProcessStepTypeId.INVITATION_UPDATE_CENTRAL_IDP_URLS, false)]
-    [InlineData(ProcessStepTypeId.INVITATION_CREATE_CENTRAL_IDP_ORG_MAPPER, false)]
-    [InlineData(ProcessStepTypeId.INVITATION_CREATE_SHARED_REALM, false)]
+    [InlineData(ProcessStepTypeId.INVITATION_CREATE_CENTRAL_IDP_ORG_MAPPER, true)]
+    [InlineData(ProcessStepTypeId.INVITATION_CREATE_SHARED_REALM, true)]
     [InlineData(ProcessStepTypeId.INVITATION_ENABLE_CENTRAL_IDP, false)]
-    [InlineData(ProcessStepTypeId.INVITATION_CREATE_DATABASE_IDP, false)]
-    [InlineData(ProcessStepTypeId.INVITATION_CREATE_USER, false)]
+    [InlineData(ProcessStepTypeId.INVITATION_CREATE_DATABASE_IDP, true)]
+    [InlineData(ProcessStepTypeId.INVITATION_CREATE_USER, true)]
     public async Task IsLockRequested_ReturnsExpected(ProcessStepTypeId stepTypeId, bool isLocked)
     {
         // Act


### PR DESCRIPTION
## Description

Add locking to the invite process

## Why

If the process worker runs parallel with multiple instances, it leads to an error in the invite process due to an duplicate creation of a shared idps client

## Issue

Refs: #787

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
