### PR TITLE
feat(clearinghouse): add feature toggle for sd connectivity

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -39,31 +39,17 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLog
 /// <summary>
 /// Implementation of <see cref="IConnectorsBusinessLogic"/> making use of <see cref="IConnectorsRepository"/> to retrieve data.
 /// </summary>
-public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
+public class ConnectorsBusinessLogic(
+    IPortalRepositories portalRepositories,
+    IOptions<ConnectorsSettings> options,
+    ISdFactoryBusinessLogic sdFactoryBusinessLogic,
+    IIdentityService identityService,
+    ILogger<ConnectorsBusinessLogic> logger)
+    : IConnectorsBusinessLogic
 {
-    private readonly IPortalRepositories _portalRepositories;
-    private readonly ISdFactoryBusinessLogic _sdFactoryBusinessLogic;
-    private readonly IIdentityData _identityData;
-    private readonly ILogger<ConnectorsBusinessLogic> _logger;
-    private readonly ConnectorsSettings _settings;
-    private static readonly Regex bpnRegex = new(@"(\w|\d){16}", RegexOptions.None, TimeSpan.FromSeconds(1));
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    /// <param name="portalRepositories">Access to the needed repositories</param>
-    /// <param name="options">The options</param>
-    /// <param name="sdFactoryBusinessLogic">Access to the connectorsSdFactory</param>
-    /// <param name="identityService">Access to the current logged in user</param>
-    /// <param name="logger">Access to the logger</param>
-    public ConnectorsBusinessLogic(IPortalRepositories portalRepositories, IOptions<ConnectorsSettings> options, ISdFactoryBusinessLogic sdFactoryBusinessLogic, IIdentityService identityService, ILogger<ConnectorsBusinessLogic> logger)
-    {
-        _portalRepositories = portalRepositories;
-        _settings = options.Value;
-        _sdFactoryBusinessLogic = sdFactoryBusinessLogic;
-        _identityData = identityService.IdentityData;
-        _logger = logger;
-    }
+    private static readonly Regex BpnRegex = new(@"(\w|\d){16}", RegexOptions.None, TimeSpan.FromSeconds(1));
+    private readonly IIdentityData _identityData = identityService.IdentityData;
+    private readonly ConnectorsSettings _settings = options.Value;
 
     /// <inheritdoc/>
     public Task<Pagination.Response<ConnectorData>> GetAllCompanyConnectorDatas(int page, int size) =>
@@ -71,7 +57,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
             page,
             size,
             _settings.MaxPageSize,
-            _portalRepositories.GetInstance<IConnectorsRepository>().GetAllCompanyConnectorsForCompanyId(_identityData.CompanyId));
+            portalRepositories.GetInstance<IConnectorsRepository>().GetAllCompanyConnectorsForCompanyId(_identityData.CompanyId));
 
     /// <inheritdoc/>
     public Task<Pagination.Response<ManagedConnectorData>> GetManagedConnectorForCompany(int page, int size) =>
@@ -79,12 +65,12 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
             page,
             size,
             _settings.MaxPageSize,
-            _portalRepositories.GetInstance<IConnectorsRepository>().GetManagedConnectorsForCompany(_identityData.CompanyId));
+            portalRepositories.GetInstance<IConnectorsRepository>().GetManagedConnectorsForCompany(_identityData.CompanyId));
 
     public async Task<ConnectorData> GetCompanyConnectorData(Guid connectorId)
     {
         var companyId = _identityData.CompanyId;
-        var result = await _portalRepositories.GetInstance<IConnectorsRepository>().GetConnectorByIdForCompany(connectorId, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
+        var result = await portalRepositories.GetInstance<IConnectorsRepository>().GetConnectorByIdForCompany(connectorId, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
         if (result == default)
         {
             throw NotFoundException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_FOUND, new ErrorParameter[] { new("connectorId", connectorId.ToString()) });
@@ -109,7 +95,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
         var (name, connectorUrl, location, technicalUserId) = connectorInputModel;
         await CheckLocationExists(location);
 
-        var result = await _portalRepositories
+        var result = await portalRepositories
             .GetInstance<ICompanyRepository>()
             .GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(companyId)
             .ConfigureAwait(ConfigureAwaitOptions.None);
@@ -140,7 +126,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
         var (name, connectorUrl, location, subscriptionId, technicalUserId) = connectorInputModel;
         await CheckLocationExists(location).ConfigureAwait(ConfigureAwaitOptions.None);
 
-        var result = await _portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
+        var result = await portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
             .CheckOfferSubscriptionWithOfferProvider(subscriptionId, companyId)
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
@@ -188,7 +174,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
 
     private async Task CheckLocationExists(string location)
     {
-        if (!await _portalRepositories.GetInstance<ICountryRepository>()
+        if (!await portalRepositories.GetInstance<ICountryRepository>()
                 .CheckCountryExistsByAlpha2CodeAsync(location.ToUpper()).ConfigureAwait(ConfigureAwaitOptions.None))
         {
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_LOCATION_NOT_EXIST, new ErrorParameter[] { new("location", location) });
@@ -202,7 +188,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
             return;
         }
 
-        if (!await _portalRepositories.GetInstance<IServiceAccountRepository>()
+        if (!await portalRepositories.GetInstance<IServiceAccountRepository>()
                 .CheckActiveServiceAccountExistsForCompanyAsync(technicalUserId.Value, companyId).ConfigureAwait(ConfigureAwaitOptions.None))
         {
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_NOT_ACTIVE, new ErrorParameter[] { new("technicalUserId", technicalUserId.Value.ToString()), new("companyId", companyId.ToString()) });
@@ -218,7 +204,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
     {
         var (name, connectorUrl, type, location, provider, host, technicalUserId) = connectorInputModel;
 
-        var connectorsRepository = _portalRepositories.GetInstance<IConnectorsRepository>();
+        var connectorsRepository = portalRepositories.GetInstance<IConnectorsRepository>();
         var createdConnector = connectorsRepository.CreateConnector(
             name,
             location.ToUpper(),
@@ -229,7 +215,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
                 connector.HostId = host;
                 connector.TypeId = type;
                 connector.DateLastChanged = DateTimeOffset.UtcNow;
-                connector.StatusId = ConnectorStatusId.PENDING;
+                connector.StatusId = _settings.ClearinghouseConnectDisabled ? ConnectorStatusId.ACTIVE : ConnectorStatusId.PENDING;
                 if (technicalUserId != null)
                 {
                     connector.CompanyServiceAccountId = technicalUserId;
@@ -241,12 +227,15 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
             connectorsRepository.CreateConnectorAssignedSubscriptions(createdConnector.Id, subscriptionId.Value);
         }
 
-        var selfDescriptionDocumentUrl = $"{_settings.SelfDescriptionDocumentUrl}/{selfDescriptionDocumentId}";
-        await _sdFactoryBusinessLogic
-            .RegisterConnectorAsync(createdConnector.Id, selfDescriptionDocumentUrl, businessPartnerNumber, cancellationToken)
-            .ConfigureAwait(ConfigureAwaitOptions.None);
+        if (!_settings.ClearinghouseConnectDisabled)
+        {
+            var selfDescriptionDocumentUrl = $"{_settings.SelfDescriptionDocumentUrl}/{selfDescriptionDocumentId}";
+            await sdFactoryBusinessLogic
+                .RegisterConnectorAsync(createdConnector.Id, selfDescriptionDocumentUrl, businessPartnerNumber, cancellationToken)
+                .ConfigureAwait(ConfigureAwaitOptions.None);
+        }
 
-        await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+        await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
         return createdConnector.Id;
     }
 
@@ -254,7 +243,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
     public async Task DeleteConnectorAsync(Guid connectorId)
     {
         var companyId = _identityData.CompanyId;
-        var connectorsRepository = _portalRepositories.GetInstance<IConnectorsRepository>();
+        var connectorsRepository = portalRepositories.GetInstance<IConnectorsRepository>();
         var result = await connectorsRepository.GetConnectorDeleteDataAsync(connectorId, companyId).ConfigureAwait(ConfigureAwaitOptions.None) ?? throw NotFoundException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_FOUND, new ErrorParameter[] { new("connectorId", connectorId.ToString()) });
         if (!result.IsProvidingOrHostCompany)
         {
@@ -262,7 +251,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
         }
         if (result.ServiceAccountId.HasValue && result.UserStatusId != UserStatusId.INACTIVE)
         {
-            _portalRepositories.GetInstance<IUserRepository>().AttachAndModifyIdentity(result.ServiceAccountId.Value, null, i =>
+            portalRepositories.GetInstance<IUserRepository>().AttachAndModifyIdentity(result.ServiceAccountId.Value, null, i =>
             {
                 i.UserStatusId = UserStatusId.INACTIVE;
             });
@@ -286,7 +275,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
 
     private async Task DeleteConnector(Guid connectorId, IEnumerable<ConnectorOfferSubscription> connectorOfferSubscriptions, Guid selfDescriptionDocumentId, DocumentStatusId documentStatus, IConnectorsRepository connectorsRepository)
     {
-        _portalRepositories.GetInstance<IDocumentRepository>().AttachAndModifyDocument(
+        portalRepositories.GetInstance<IDocumentRepository>().AttachAndModifyDocument(
             selfDescriptionDocumentId,
             a => { a.DocumentStatusId = documentStatus; },
             a => { a.DocumentStatusId = DocumentStatusId.INACTIVE; });
@@ -301,22 +290,22 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
             con.StatusId = ConnectorStatusId.INACTIVE;
             con.DateLastChanged = DateTimeOffset.UtcNow;
         });
-        await _portalRepositories.SaveAsync();
+        await portalRepositories.SaveAsync();
     }
 
     private async Task DeleteConnectorWithDocuments(Guid connectorId, Guid selfDescriptionDocumentId, IEnumerable<ConnectorOfferSubscription> connectorOfferSubscriptions, IConnectorsRepository connectorsRepository)
     {
-        _portalRepositories.GetInstance<IDocumentRepository>().RemoveDocument(selfDescriptionDocumentId);
+        portalRepositories.GetInstance<IDocumentRepository>().RemoveDocument(selfDescriptionDocumentId);
         RemoveConnectorAssignedOfferSubscriptions(connectorId, connectorOfferSubscriptions, connectorsRepository);
         connectorsRepository.DeleteConnector(connectorId);
-        await _portalRepositories.SaveAsync();
+        await portalRepositories.SaveAsync();
     }
 
     private async Task DeleteConnectorWithoutDocuments(Guid connectorId, IEnumerable<ConnectorOfferSubscription> connectorOfferSubscriptions, IConnectorsRepository connectorsRepository)
     {
         RemoveConnectorAssignedOfferSubscriptions(connectorId, connectorOfferSubscriptions, connectorsRepository);
         connectorsRepository.DeleteConnector(connectorId);
-        await _portalRepositories.SaveAsync();
+        await portalRepositories.SaveAsync();
     }
 
     private static void RemoveConnectorAssignedOfferSubscriptions(Guid connectorId, IEnumerable<ConnectorOfferSubscription> connectorOfferSubscriptions, IConnectorsRepository connectorsRepository)
@@ -339,10 +328,10 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
     {
         bpns ??= Enumerable.Empty<string>();
 
-        bpns.Where(bpn => !bpnRegex.IsMatch(bpn)).IfAny(invalid =>
+        bpns.Where(bpn => !BpnRegex.IsMatch(bpn)).IfAny(invalid =>
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_INCORRECT_BPN, new ErrorParameter[] { new("bpns", string.Join(", ", invalid)) }));
 
-        return _portalRepositories.GetInstance<IConnectorsRepository>()
+        return portalRepositories.GetInstance<IConnectorsRepository>()
             .GetConnectorEndPointDataAsync(bpns.Select(x => x.ToUpper()))
             .PreSortedGroupBy(data => data.BusinessPartnerNumber)
             .Select(group =>
@@ -354,9 +343,9 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
     /// <inheritdoc />
     public async Task ProcessClearinghouseSelfDescription(SelfDescriptionResponseData data, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Process SelfDescription called with the following data {Data}", data);
+        logger.LogInformation("Process SelfDescription called with the following data {Data}", data.ToString().Replace(Environment.NewLine, string.Empty));
 
-        var result = await _portalRepositories.GetInstance<IConnectorsRepository>()
+        var result = await portalRepositories.GetInstance<IConnectorsRepository>()
             .GetConnectorDataById(data.ExternalId)
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
@@ -370,8 +359,8 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
             throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_ALREADY_ASSIGNED, new ErrorParameter[] { new("externalId", data.ExternalId.ToString()) });
         }
 
-        await _sdFactoryBusinessLogic.ProcessFinishSelfDescriptionLpForConnector(data, _identityData.IdentityId, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
-        await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+        await sdFactoryBusinessLogic.ProcessFinishSelfDescriptionLpForConnector(data, _identityData.IdentityId, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
     }
 
     /// <inheritdoc />
@@ -383,7 +372,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
 
     private async Task UpdateConnectorUrlInternal(Guid connectorId, ConnectorUpdateRequest data)
     {
-        var connectorsRepository = _portalRepositories
+        var connectorsRepository = portalRepositories
             .GetInstance<IConnectorsRepository>();
         var connector = await connectorsRepository
             .GetConnectorUpdateInformation(connectorId, _identityData.CompanyId)
@@ -411,7 +400,7 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
 
         var bpn = connector.Type == ConnectorTypeId.CONNECTOR_AS_A_SERVICE
             ? connector.Bpn
-            : await _portalRepositories.GetInstance<IUserRepository>()
+            : await portalRepositories.GetInstance<IUserRepository>()
                 .GetCompanyBpnForIamUserAsync(_identityData.IdentityId)
                 .ConfigureAwait(ConfigureAwaitOptions.None);
         if (string.IsNullOrWhiteSpace(bpn))
@@ -424,11 +413,11 @@ public class ConnectorsBusinessLogic : IConnectorsBusinessLogic
             con.ConnectorUrl = data.ConnectorUrl;
         });
 
-        await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+        await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
     }
 
     /// <inheritdoc />
     public IAsyncEnumerable<OfferSubscriptionConnectorData> GetConnectorOfferSubscriptionData(bool? connectorIdSet) =>
-        _portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
+        portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
             .GetConnectorOfferSubscriptionData(connectorIdSet, _identityData.CompanyId);
 }

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsSettings.cs
@@ -46,6 +46,11 @@ public class ConnectorsSettings
     /// </summary>
     [Required(AllowEmptyStrings = false)]
     public string SelfDescriptionDocumentUrl { get; set; } = null!;
+
+    /// <summary>
+    ///  If <c>true</c> all sd factory calls are disabled and won't be called. The respective process steps will be skipped.
+    /// </summary>
+    public bool ClearinghouseConnectDisabled { get; set; }
 }
 
 public static class ConnectorsSettingsExtensions

--- a/src/externalsystems/SdFactory.Library/SdFactoryService.cs
+++ b/src/externalsystems/SdFactory.Library/SdFactoryService.cs
@@ -30,28 +30,14 @@ namespace Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library;
 /// <summary>
 /// Service to handle communication with the connectors sd factory
 /// </summary>
-public class SdFactoryService : ISdFactoryService
+public class SdFactoryService(ITokenService tokenService, IOptions<SdFactorySettings> options) : ISdFactoryService
 {
-    private readonly ITokenService _tokenService;
-    private readonly SdFactorySettings _settings;
-
-    /// <summary>
-    /// Creates a new instance of <see cref="SdFactoryService"/>
-    /// </summary>
-    /// <param name="tokenService">Access to the token service</param>
-    /// <param name="options">The options</param>
-    public SdFactoryService(
-        ITokenService tokenService,
-        IOptions<SdFactorySettings> options)
-    {
-        _settings = options.Value;
-        _tokenService = tokenService;
-    }
+    private readonly SdFactorySettings _settings = options.Value;
 
     /// <inheritdoc />
     public async Task RegisterConnectorAsync(Guid connectorId, string selfDescriptionDocumentUrl, string businessPartnerNumber, CancellationToken cancellationToken)
     {
-        var httpClient = await _tokenService.GetAuthorizedClient<SdFactoryService>(_settings, cancellationToken)
+        var httpClient = await tokenService.GetAuthorizedClient<SdFactoryService>(_settings, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);
         var requestModel = new ConnectorSdFactoryRequestModel(
             connectorId.ToString(),
@@ -70,7 +56,7 @@ public class SdFactoryService : ISdFactoryService
     /// <inheritdoc />
     public async Task RegisterSelfDescriptionAsync(Guid applicationId, IEnumerable<(UniqueIdentifierId Id, string Value)> uniqueIdentifiers, string countryCode, string businessPartnerNumber, CancellationToken cancellationToken)
     {
-        var httpClient = await _tokenService.GetAuthorizedClient<SdFactoryService>(_settings, cancellationToken)
+        var httpClient = await tokenService.GetAuthorizedClient<SdFactoryService>(_settings, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);
         var requestModel = new SdFactoryRequestModel(
             applicationId.ToString(),

--- a/src/externalsystems/SdFactory.Library/SdFactorySettings.cs
+++ b/src/externalsystems/SdFactory.Library/SdFactorySettings.cs
@@ -29,6 +29,11 @@ namespace Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library;
 public class SdFactorySettings : KeyVaultAuthSettings
 {
     /// <summary>
+    ///  If <c>true</c> all sd factory calls are disabled and won't be called. The respective process steps will be skipped.
+    /// </summary>
+    public bool ClearinghouseConnectDisabled { get; set; }
+
+    /// <summary>
     /// SD Factory endpoint for registering connectors.
     /// </summary>
     [Required]

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryServiceTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryServiceTests.cs
@@ -35,7 +35,7 @@ public class SdFactoryServiceTests
 
     private static readonly IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers = new List<(UniqueIdentifierId Id, string Value)>
     {
-        new (UniqueIdentifierId.VAT_ID, "JUSTATEST")
+        new(UniqueIdentifierId.VAT_ID, "JUSTATEST")
     };
 
     private readonly IPortalRepositories _portalRepositories;


### PR DESCRIPTION
## Description

Add feature toggle to disable all sd factory calls for the application checklist and connector registration

## Why

To be able to switch off the sd factory connection

## Issue

#792

## Corresponding Portal PR

https://github.com/eclipse-tractusx/portal/pull/344

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
