### PR TITLE
fix(decline): moved email validation in decline application process api

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -463,6 +463,11 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
     public async Task DeclineRegistrationVerification(Guid applicationId, string comment, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(comment))
+        {
+            throw new ConflictException("No comment set.");
+        }
+
         var result = await _portalRepositories.GetInstance<IApplicationRepository>().GetCompanyIdNameForSubmittedApplication(applicationId).ConfigureAwait(ConfigureAwaitOptions.None);
         if (result == default)
         {
@@ -546,11 +551,6 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
 
     private void PostRegistrationCancelEmailAsync(ICollection<EmailData> emailData, string companyName, string comment)
     {
-        if (string.IsNullOrWhiteSpace(comment))
-        {
-            throw new ConflictException("No comment set.");
-        }
-
         foreach (var user in emailData)
         {
             var userName = string.Join(" ", new[] { user.FirstName, user.LastName }.Where(item => !string.IsNullOrWhiteSpace(item)));

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -530,6 +530,22 @@ public class RegistrationBusinessLogicTest
     }
 
     [Fact]
+    public async Task DeclineRegistrationVerification_WithNoComment_ThrowsConflictException()
+    {
+        // Arrange
+        var applicationId = Guid.NewGuid();
+        A.CallTo(() => _applicationRepository.GetCompanyIdNameForSubmittedApplication(applicationId))
+            .Returns<(Guid, string, Guid?, IEnumerable<(Guid, string, IdentityProviderTypeId, IEnumerable<Guid>)>, IEnumerable<Guid>)>(default);
+        Task Act() => _logic.DeclineRegistrationVerification(applicationId, "", CancellationToken.None);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+
+        // Assert
+        ex.Message.Should().Be("No comment set.");
+    }
+
+    [Fact]
     public async Task DeclineRegistrationVerification_WithMultipleIdps_CallsExpected()
     {
         // Arrange


### PR DESCRIPTION
## Description

Moved the validation of blank or null comment from child method to parent method.
fixes #820  closes #820 

## Why

There is a required validation on the comment field at a later stage in this API. Before this, the code makes a call to Keycloak to delete the client for this company.
If we call this API with a blank comment, it throws an exception after deleting the data from Keycloak.
and after that its impossible to cancel the application process

## Issue

[#820](https://github.com/eclipse-tractusx/portal-backend/issues/820)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
