### PR TITLE
fix(getAppRoles): change permissions

### DIFF
--- a/src/marketplace/Apps.Service/Controllers/AppChangeController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppChangeController.cs
@@ -268,7 +268,7 @@ public class AppChangeController : ControllerBase
     /// <response code="400">The language does not exist.</response>
     /// <response code="404">The app was not found.</response>
     [HttpGet]
-    [Authorize(Roles = "view_client_roles")]
+    [Authorize(Roles = "edit_apps")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("{appId}/roles")]
     [ProducesResponseType(typeof(IEnumerable<ActiveAppRoleDetails>), StatusCodes.Status200OK)]

--- a/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
@@ -505,7 +505,7 @@ public class AppReleaseProcessController : ControllerBase
     /// <response code="404">The app was not found.</response>
     /// <response code="403">The app is not the provider of the company</response>
     [HttpGet]
-    [Authorize(Roles = "view_client_roles")]
+    [Authorize(Roles = "add_apps")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("{appId}/roles")]
     [ProducesResponseType(typeof(IEnumerable<ActiveAppRoleDetails>), StatusCodes.Status200OK)]


### PR DESCRIPTION
## Description

`view_clinet_roles` is supposed to get used when it comes to actual role assignment. Since the App Manager is not supposed to assign roles to company users, the permission is not expected to be assigned.
Instead the permission of the following endpoints need to get switched

- GET /api/apps/AppChange/{appId}/roles => new permission validation `edit_apps`
- GET /api/apps/AppReleaseProcess/{appId}/roles => new permission validation `add_apps`

## Why

App manager encounters 403 error on Technical Integration while registering an app.

## Issue

[Refs: 826](https://github.com/eclipse-tractusx/portal-backend/issues/826)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes