### PR TITLE
chore(2.1.0-rc1): rename migration

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20240527114938_2.1.0-rc1.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20240527114938_2.1.0-rc1.Designer.cs
@@ -32,8 +32,8 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    [Migration("20240527114938_538-RemoveSsiDetails")]
-    partial class _538RemoveSsiDetails
+    [Migration("20240527114938_2.1.0-rc1")]
+    partial class _210rc1
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20240527114938_2.1.0-rc1.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20240527114938_2.1.0-rc1.cs
@@ -27,7 +27,7 @@ using System;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations.Migrations
 {
     /// <inheritdoc />
-    public partial class _538RemoveSsiDetails : Migration
+    public partial class _210rc1 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
## Description

migration 20240527114938_538-RemoveSsiDetails is renamed to 20240527114938_2.1.0-rc1

## Why

https://github.com/eclipse-tractusx/portal/issues/350

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes