### PR TITLE
feat(registration): make submit document type validation optional

### DIFF
--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -543,14 +543,17 @@ public class RegistrationBusinessLogic(
 
         if (GetAndValidateUpdateApplicationStatus(applicationUserData.CompanyApplicationStatusId, UpdateApplicationSteps.SubmitRegistration) != CompanyApplicationStatusId.SUBMITTED)
         {
-            throw new UnexpectedConditionException("updateStatus should allways be SUBMITTED here");
+            throw new UnexpectedConditionException("updateStatus should always be SUBMITTED here");
         }
 
-        portalRepositories.GetInstance<IDocumentRepository>().AttachAndModifyDocuments(
-            applicationUserData.DocumentDatas.Select(x => new ValueTuple<Guid, Action<Document>?, Action<Document>>(
-                x.DocumentId,
-                doc => doc.DocumentStatusId = x.StatusId,
-                doc => doc.DocumentStatusId = DocumentStatusId.LOCKED)));
+        if (applicationUserData.DocumentDatas != null && applicationUserData.DocumentDatas.Any())
+        {
+            portalRepositories.GetInstance<IDocumentRepository>().AttachAndModifyDocuments(
+               applicationUserData.DocumentDatas.Select(x => new ValueTuple<Guid, Action<Document>?, Action<Document>>(
+                   x.DocumentId,
+                   doc => doc.DocumentStatusId = x.StatusId,
+                   doc => doc.DocumentStatusId = DocumentStatusId.LOCKED)));
+        }
 
         var entries = await checklistService.CreateInitialChecklistAsync(applicationId);
 
@@ -637,7 +640,7 @@ public class RegistrationBusinessLogic(
         {
             throw new ConflictException($"Agreement and Consent must not be empty");
         }
-        if (!applicationUserData.DocumentDatas.Any())
+        if (!_settings.IsSubmitDocumentValidationOptional && !applicationUserData.DocumentDatas.Any())
         {
             throw new ConflictException($"At least one Document type Id must be [{string.Join(", ", docTypeIds)}]");
         }

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationSettings.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationSettings.cs
@@ -77,6 +77,14 @@ public class RegistrationSettings
     public IEnumerable<DocumentTypeId> SubmitDocumentTypeIds { get; set; } = null!;
 
     /// <summary>
+    /// Is Submit DocumentType Validation Optional
+    /// </summary>
+    /// <value></value>
+    [Required]
+    [DistinctValues]
+    public bool IsSubmitDocumentValidationOptional { get; set; } = false;
+
+    /// <summary>
     /// Url to the password resend of the portal
     /// </summary>
     [Required]

--- a/src/registration/Registration.Service/appsettings.json
+++ b/src/registration/Registration.Service/appsettings.json
@@ -33,7 +33,8 @@
     "ApplicationDeclineStatusIds": [],
     "DocumentTypeIds": [],
     "RegistrationDocumentTypeIds": [],
-    "SubmitDocumentTypeIds": []
+    "SubmitDocumentTypeIds": [],
+    "IsSubmitDocumentValidationOptional": false
   },
   "BPN_Address": "",
   "Keycloak": {

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -2012,7 +2012,8 @@ public class RegistrationBusinessLogicTest
         {
             SubmitDocumentTypeIds = [
                 DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
-            ]
+            ],
+            IsSubmitDocumentValidationOptional = false
         };
         A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(A<Guid>._, A<Guid>._, A<IEnumerable<DocumentTypeId>>._))
             .Returns<CompanyApplicationUserEmailData?>(null);
@@ -2031,135 +2032,7 @@ public class RegistrationBusinessLogicTest
     [Fact]
     public async Task SubmitRegistrationAsync_WithDocumentId_Success()
     {
-        // Arrange
-        var applicationId = _fixture.Create<Guid>();
-        var now = DateTimeOffset.Now;
-        var documents = new DocumentStatusData[] {
-            new(Guid.NewGuid(),DocumentStatusId.PENDING),
-            new(Guid.NewGuid(),DocumentStatusId.INACTIVE)
-        };
-        var checklist = _fixture.CreateMany<ApplicationChecklistEntryTypeId>(3).Select(x => (x, ApplicationChecklistEntryStatusId.TO_DO)).ToImmutableArray();
-        var stepTypeIds = _fixture.CreateMany<ProcessStepTypeId>(3).ToImmutableArray();
-        var uniqueIds = _fixture.CreateMany<UniqueIdentifierId>(3).ToImmutableArray();
-        var companyRoleIds = _fixture.CreateMany<CompanyRoleId>(3).ToImmutableArray();
-        var agreementConsents = new[]
-        {
-            (Guid.NewGuid(), ConsentStatusId.ACTIVE),
-        };
-        var companyData = new CompanyData("Test Company", Guid.NewGuid(), "Strabe Street", "Munich", "Germany", uniqueIds, companyRoleIds);
-        A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
-        A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(A<Guid>._, A<Guid>._, A<IEnumerable<DocumentTypeId>>._))
-            .Returns(new CompanyApplicationUserEmailData(CompanyApplicationStatusId.VERIFY, true, "test@mail.de", documents, companyData, agreementConsents));
-
-        var modifiedDocuments = new List<(Document Initial, Document Modified)>();
-
-        A.CallTo(() => _documentRepository.AttachAndModifyDocuments(A<IEnumerable<(Guid DocumentId, Action<Document>?, Action<Document>)>>._))
-            .Invokes((IEnumerable<(Guid DocumentId, Action<Document>? Initialize, Action<Document> Modify)> documentKeyActions) =>
-            {
-                foreach (var x in documentKeyActions)
-                {
-                    var initial = new Document(x.DocumentId, null!, null!, null!, default, default, default, default);
-                    x.Initialize?.Invoke(initial);
-                    var modified = new Document(x.DocumentId, null!, null!, null!, default, default, default, default);
-                    x.Modify(modified);
-                    modifiedDocuments.Add((initial, modified));
-                }
-            });
-
-        A.CallTo(() => _checklistService.CreateInitialChecklistAsync(applicationId))
-            .Returns(checklist);
-
-        A.CallTo(() => _checklistService.GetInitialProcessStepTypeIds(A<IEnumerable<(ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId)>>.That.IsSameSequenceAs(checklist)))
-            .Returns(stepTypeIds);
-
-        var utcNow = DateTimeOffset.UtcNow;
-
-        Process? process = null;
-
-        A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.APPLICATION_CHECKLIST))
-            .ReturnsLazily((ProcessTypeId processTypeId) =>
-            {
-                process = new Process(Guid.NewGuid(), processTypeId, Guid.NewGuid());
-                return process;
-            });
-
-        CompanyApplication? application = null;
-
-        A.CallTo(() => _applicationRepository.AttachAndModifyCompanyApplication(A<Guid>._, A<Action<CompanyApplication>>._))
-            .Invokes((Guid applicationId, Action<CompanyApplication> setOptionalParameters) =>
-            {
-                application = new CompanyApplication(applicationId, Guid.Empty, default, default, default);
-                setOptionalParameters(application);
-            });
-
-        IEnumerable<ProcessStep>? processSteps = null;
-
-        A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId, ProcessStepStatusId, Guid)>>._))
-            .ReturnsLazily((IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)> processStepTypeStatus) =>
-            {
-                processSteps = processStepTypeStatus.Select(x => new ProcessStep(Guid.NewGuid(), x.ProcessStepTypeId, x.ProcessStepStatusId, x.ProcessId, utcNow)).ToImmutableArray();
-                return processSteps;
-            });
-        var settings = new RegistrationSettings
-        {
-            SubmitDocumentTypeIds = [
-                DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
-            ]
-        };
-        var sut = new RegistrationBusinessLogic(Options.Create(settings), null!, null!, null!, _portalRepositories, _checklistService, _identityService, _dateTimeProvider, _mailingProcessCreation);
-
-        // Act
-        await sut.SubmitRegistrationAsync(applicationId);
-
-        // Assert
-        A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(applicationId, _identity.IdentityId, A<IEnumerable<DocumentTypeId>>.That.IsSameSequenceAs(new[] { DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT })))
-            .MustHaveHappenedOnceExactly();
-
-        A.CallTo(() => _documentRepository.AttachAndModifyDocuments(A<IEnumerable<(Guid DocumentId, Action<Document>?, Action<Document>)>>.That.Matches(x => x.Count() == 2)))
-            .MustHaveHappenedOnceExactly();
-
-        modifiedDocuments.Should().HaveCount(2).And.Satisfy(
-            x => x.Initial.Id == documents[0].DocumentId && x.Initial.DocumentStatusId == documents[0].StatusId && x.Modified.Id == documents[0].DocumentId && x.Modified.DocumentStatusId == DocumentStatusId.LOCKED,
-            x => x.Initial.Id == documents[1].DocumentId && x.Initial.DocumentStatusId == documents[1].StatusId && x.Modified.Id == documents[1].DocumentId && x.Modified.DocumentStatusId == DocumentStatusId.LOCKED
-        );
-
-        A.CallTo(() => _checklistService.CreateInitialChecklistAsync(applicationId))
-            .MustHaveHappenedOnceExactly();
-
-        A.CallTo(() => _checklistService.GetInitialProcessStepTypeIds(A<IEnumerable<(ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId)>>.That.IsSameSequenceAs(checklist)))
-            .MustHaveHappenedOnceExactly();
-
-        A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.APPLICATION_CHECKLIST))
-            .MustHaveHappenedOnceExactly();
-
-        process.Should().NotBeNull();
-        process!.ProcessTypeId.Should().Be(ProcessTypeId.APPLICATION_CHECKLIST);
-
-        A.CallTo(() => _applicationRepository.AttachAndModifyCompanyApplication(A<Guid>._, A<Action<CompanyApplication>>._))
-            .MustHaveHappenedOnceExactly();
-
-        application.Should().NotBeNull();
-        application!.ChecklistProcessId.Should().Be(process!.Id);
-        application.ApplicationStatusId.Should().Be(CompanyApplicationStatusId.SUBMITTED);
-        application.DateLastChanged.Should().Be(now);
-
-        A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId, ProcessStepStatusId, Guid)>>._))
-            .MustHaveHappenedOnceExactly();
-
-        processSteps.Should().NotBeNull()
-            .And.HaveCount(stepTypeIds.Length)
-            .And.AllSatisfy(x =>
-                {
-                    x.ProcessId.Should().Be(process.Id);
-                    x.ProcessStepStatusId.Should().Be(ProcessStepStatusId.TODO);
-                })
-            .And.Satisfy(
-                x => x.ProcessStepTypeId == stepTypeIds[0],
-                x => x.ProcessStepTypeId == stepTypeIds[1],
-                x => x.ProcessStepTypeId == stepTypeIds[2]
-            );
-
-        A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
+        await SubmitRegistrationAsync_SuccessHelper(false);
     }
 
     [Theory]
@@ -2192,7 +2065,8 @@ public class RegistrationBusinessLogicTest
         {
             SubmitDocumentTypeIds = [
                 DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
-            ]
+            ],
+            IsSubmitDocumentValidationOptional = false
         };
         var companyData = new CompanyData("Test Company", Guid.NewGuid(), "Strabe Street", "Munich", "Germany", uniqueIds, companyRoleIds);
         A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(A<Guid>._, A<Guid>._, A<IEnumerable<DocumentTypeId>>._))
@@ -2238,7 +2112,8 @@ public class RegistrationBusinessLogicTest
         {
             SubmitDocumentTypeIds = [
                 DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
-            ]
+            ],
+            IsSubmitDocumentValidationOptional = false
         };
         A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(A<Guid>._, A<Guid>._, A<IEnumerable<DocumentTypeId>>._))
             .Returns(new CompanyApplicationUserEmailData(statusId, true, _fixture.Create<string>(), documents, companyData, agreementConsents));
@@ -2276,7 +2151,8 @@ public class RegistrationBusinessLogicTest
         {
             SubmitDocumentTypeIds = [
                 DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
-            ]
+            ],
+            IsSubmitDocumentValidationOptional = false
         };
         A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(A<Guid>._, A<Guid>._, A<IEnumerable<DocumentTypeId>>._))
             .Returns(new CompanyApplicationUserEmailData(CompanyApplicationStatusId.VERIFY, false, null, null!, companyData, agreementConsents));
@@ -2314,7 +2190,8 @@ public class RegistrationBusinessLogicTest
         {
             SubmitDocumentTypeIds = [
                 DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
-            ]
+            ],
+            IsSubmitDocumentValidationOptional = false
         };
         A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(applicationId, userId, A<IEnumerable<DocumentTypeId>>._))
             .Returns(new CompanyApplicationUserEmailData(CompanyApplicationStatusId.VERIFY, true, _fixture.Create<string>(), Enumerable.Empty<DocumentStatusData>(), companyData, agreementConsents));
@@ -2557,7 +2434,8 @@ public class RegistrationBusinessLogicTest
         {
             SubmitDocumentTypeIds = [
                 DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
-            ]
+            ],
+            IsSubmitDocumentValidationOptional = false
         };
         var application = _fixture.Build<CompanyApplication>()
             .With(x => x.Id, applicationId)
@@ -2607,7 +2485,8 @@ public class RegistrationBusinessLogicTest
         {
             SubmitDocumentTypeIds = [
                 DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
-            ]
+            ],
+            IsSubmitDocumentValidationOptional = false
         };
         var application = _fixture.Build<CompanyApplication>()
             .With(x => x.Id, applicationId)
@@ -2634,6 +2513,296 @@ public class RegistrationBusinessLogicTest
             .MustNotHaveHappened();
         result.Should().BeTrue();
         application.DateLastChanged.Should().Be(now);
+    }
+
+    [Fact]
+    public async Task SubmitRegistrationAsync_WithMandatorySubmitDocument_ThrowsConflictException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var identityData = A.Fake<IIdentityData>();
+        A.CallTo(() => identityData.IdentityId).Returns(userId);
+        A.CallTo(() => identityData.IdentityTypeId).Returns(IdentityTypeId.COMPANY_USER);
+        A.CallTo(() => identityData.CompanyId).Returns(Guid.NewGuid());
+        A.CallTo(() => _identityService.IdentityData).Returns(identityData);
+        var applicationId = _fixture.Create<Guid>();
+        var uniqueIds = _fixture.CreateMany<UniqueIdentifierId>(3).ToImmutableArray();
+        var companyRoleIds = _fixture.CreateMany<CompanyRoleId>(3).ToImmutableArray();
+        var agreementConsents = new[]
+        {
+            (Guid.NewGuid(), ConsentStatusId.ACTIVE),
+        };
+        var companyData = new CompanyData("Test Company", Guid.NewGuid(), "Strabe Street", "Munich", "Germany", uniqueIds, companyRoleIds);
+        var settings = new RegistrationSettings
+        {
+            SubmitDocumentTypeIds = [
+                DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
+            ],
+            IsSubmitDocumentValidationOptional = false,
+        };
+        A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(applicationId, userId, A<IEnumerable<DocumentTypeId>>._))
+            .Returns(new CompanyApplicationUserEmailData(CompanyApplicationStatusId.VERIFY, true, _fixture.Create<string>(), Enumerable.Empty<DocumentStatusData>(), companyData, agreementConsents));
+        var sut = new RegistrationBusinessLogic(Options.Create(settings), null!, null!, null!, _portalRepositories, null!, _identityService, _dateTimeProvider, _mailingProcessCreation);
+
+        // Act
+        Task Act() => sut.SubmitRegistrationAsync(applicationId);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+        ex.Message.Should().Be($"At least one Document type Id must be [{string.Join(", ", settings.SubmitDocumentTypeIds)}]");
+    }
+
+    [Fact]
+    public async Task SubmitRegistrationAsync_WithOptionalValidationEnableAndNoSubmitDocumentId_Success()
+    {
+        // Arrange
+        var applicationId = _fixture.Create<Guid>();
+        var now = DateTimeOffset.Now;
+
+        var checklist = _fixture.CreateMany<ApplicationChecklistEntryTypeId>(3).Select(x => (x, ApplicationChecklistEntryStatusId.TO_DO)).ToImmutableArray();
+        var stepTypeIds = _fixture.CreateMany<ProcessStepTypeId>(3).ToImmutableArray();
+        var uniqueIds = _fixture.CreateMany<UniqueIdentifierId>(3).ToImmutableArray();
+        var companyRoleIds = _fixture.CreateMany<CompanyRoleId>(3).ToImmutableArray();
+        var agreementConsents = new[]
+        {
+            (Guid.NewGuid(), ConsentStatusId.ACTIVE),
+        };
+        var companyData = new CompanyData("Test Company", Guid.NewGuid(), "Strabe Street", "Munich", "Germany", uniqueIds, companyRoleIds);
+        A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
+        A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(A<Guid>._, A<Guid>._, A<IEnumerable<DocumentTypeId>>._))
+            .Returns(new CompanyApplicationUserEmailData(CompanyApplicationStatusId.VERIFY, true, "test@mail.de", [], companyData, agreementConsents));
+
+        A.CallTo(() => _checklistService.CreateInitialChecklistAsync(applicationId))
+            .Returns(checklist);
+
+        A.CallTo(() => _checklistService.GetInitialProcessStepTypeIds(A<IEnumerable<(ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId)>>.That.IsSameSequenceAs(checklist)))
+            .Returns(stepTypeIds);
+
+        var utcNow = DateTimeOffset.UtcNow;
+
+        Process? process = null;
+
+        A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.APPLICATION_CHECKLIST))
+            .ReturnsLazily((ProcessTypeId processTypeId) =>
+            {
+                process = new Process(Guid.NewGuid(), processTypeId, Guid.NewGuid());
+                return process;
+            });
+
+        CompanyApplication? application = null;
+
+        A.CallTo(() => _applicationRepository.AttachAndModifyCompanyApplication(A<Guid>._, A<Action<CompanyApplication>>._))
+            .Invokes((Guid applicationId, Action<CompanyApplication> setOptionalParameters) =>
+            {
+                application = new CompanyApplication(applicationId, Guid.Empty, default, default, default);
+                setOptionalParameters(application);
+            });
+
+        IEnumerable<ProcessStep>? processSteps = null;
+
+        A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId, ProcessStepStatusId, Guid)>>._))
+            .ReturnsLazily((IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)> processStepTypeStatus) =>
+            {
+                processSteps = processStepTypeStatus.Select(x => new ProcessStep(Guid.NewGuid(), x.ProcessStepTypeId, x.ProcessStepStatusId, x.ProcessId, utcNow)).ToImmutableArray();
+                return processSteps;
+            });
+        var settings = new RegistrationSettings
+        {
+            SubmitDocumentTypeIds = [
+                DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
+            ],
+            IsSubmitDocumentValidationOptional = true
+        };
+        var sut = new RegistrationBusinessLogic(Options.Create(settings), null!, null!, null!, _portalRepositories, _checklistService, _identityService, _dateTimeProvider, _mailingProcessCreation);
+
+        // Act
+        await sut.SubmitRegistrationAsync(applicationId);
+
+        // Assert
+        A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(applicationId, _identity.IdentityId, A<IEnumerable<DocumentTypeId>>.That.IsSameSequenceAs(new[] { DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT })))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _documentRepository.AttachAndModifyDocuments(
+           A<IEnumerable<(Guid DocumentId, Action<Document>?, Action<Document>)>>.Ignored
+       )).MustNotHaveHappened();
+
+        A.CallTo(() => _checklistService.CreateInitialChecklistAsync(applicationId))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _checklistService.GetInitialProcessStepTypeIds(A<IEnumerable<(ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId)>>.That.IsSameSequenceAs(checklist)))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.APPLICATION_CHECKLIST))
+            .MustHaveHappenedOnceExactly();
+
+        process.Should().NotBeNull();
+        process!.ProcessTypeId.Should().Be(ProcessTypeId.APPLICATION_CHECKLIST);
+
+        A.CallTo(() => _applicationRepository.AttachAndModifyCompanyApplication(A<Guid>._, A<Action<CompanyApplication>>._))
+            .MustHaveHappenedOnceExactly();
+
+        application.Should().NotBeNull();
+        application!.ChecklistProcessId.Should().Be(process!.Id);
+        application.ApplicationStatusId.Should().Be(CompanyApplicationStatusId.SUBMITTED);
+        application.DateLastChanged.Should().Be(now);
+
+        A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId, ProcessStepStatusId, Guid)>>._))
+            .MustHaveHappenedOnceExactly();
+
+        processSteps.Should().NotBeNull()
+            .And.HaveCount(stepTypeIds.Length)
+            .And.AllSatisfy(x =>
+                {
+                    x.ProcessId.Should().Be(process.Id);
+                    x.ProcessStepStatusId.Should().Be(ProcessStepStatusId.TODO);
+                })
+            .And.Satisfy(
+                x => x.ProcessStepTypeId == stepTypeIds[0],
+                x => x.ProcessStepTypeId == stepTypeIds[1],
+                x => x.ProcessStepTypeId == stepTypeIds[2]
+            );
+
+        A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task SubmitRegistrationAsync_WithOptionalValidationEnableAndWithSubmitDocumentId_Success()
+    {
+        await SubmitRegistrationAsync_SuccessHelper(true);
+    }
+
+    private async Task SubmitRegistrationAsync_SuccessHelper(bool isSubmitDocumentValidationOptional)
+    {
+        // Arrange
+        var applicationId = _fixture.Create<Guid>();
+        var now = DateTimeOffset.Now;
+        var documents = new DocumentStatusData[] {
+            new(Guid.NewGuid(),DocumentStatusId.PENDING),
+            new(Guid.NewGuid(),DocumentStatusId.INACTIVE)
+        };
+        var checklist = _fixture.CreateMany<ApplicationChecklistEntryTypeId>(3).Select(x => (x, ApplicationChecklistEntryStatusId.TO_DO)).ToImmutableArray();
+        var stepTypeIds = _fixture.CreateMany<ProcessStepTypeId>(3).ToImmutableArray();
+        var uniqueIds = _fixture.CreateMany<UniqueIdentifierId>(3).ToImmutableArray();
+        var companyRoleIds = _fixture.CreateMany<CompanyRoleId>(3).ToImmutableArray();
+        var agreementConsents = new[]
+        {
+            (Guid.NewGuid(), ConsentStatusId.ACTIVE),
+        };
+        var companyData = new CompanyData("Test Company", Guid.NewGuid(), "Strabe Street", "Munich", "Germany", uniqueIds, companyRoleIds);
+        A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
+        A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(A<Guid>._, A<Guid>._, A<IEnumerable<DocumentTypeId>>._))
+            .Returns(new CompanyApplicationUserEmailData(CompanyApplicationStatusId.VERIFY, true, "test@mail.de", documents, companyData, agreementConsents));
+
+        var modifiedDocuments = new List<(Document Initial, Document Modified)>();
+
+        A.CallTo(() => _documentRepository.AttachAndModifyDocuments(A<IEnumerable<(Guid DocumentId, Action<Document>?, Action<Document>)>>._))
+            .Invokes((IEnumerable<(Guid DocumentId, Action<Document>? Initialize, Action<Document> Modify)> documentKeyActions) =>
+            {
+                foreach (var x in documentKeyActions)
+                {
+                    var initial = new Document(x.DocumentId, null!, null!, null!, default, default, default, default);
+                    x.Initialize?.Invoke(initial);
+                    var modified = new Document(x.DocumentId, null!, null!, null!, default, default, default, default);
+                    x.Modify(modified);
+                    modifiedDocuments.Add((initial, modified));
+                }
+            });
+
+        A.CallTo(() => _checklistService.CreateInitialChecklistAsync(applicationId))
+            .Returns(checklist);
+
+        A.CallTo(() => _checklistService.GetInitialProcessStepTypeIds(A<IEnumerable<(ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId)>>.That.IsSameSequenceAs(checklist)))
+            .Returns(stepTypeIds);
+
+        var utcNow = DateTimeOffset.UtcNow;
+
+        Process? process = null;
+
+        A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.APPLICATION_CHECKLIST))
+            .ReturnsLazily((ProcessTypeId processTypeId) =>
+            {
+                process = new Process(Guid.NewGuid(), processTypeId, Guid.NewGuid());
+                return process;
+            });
+
+        CompanyApplication? application = null;
+
+        A.CallTo(() => _applicationRepository.AttachAndModifyCompanyApplication(A<Guid>._, A<Action<CompanyApplication>>._))
+            .Invokes((Guid applicationId, Action<CompanyApplication> setOptionalParameters) =>
+            {
+                application = new CompanyApplication(applicationId, Guid.Empty, default, default, default);
+                setOptionalParameters(application);
+            });
+
+        IEnumerable<ProcessStep>? processSteps = null;
+
+        A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId, ProcessStepStatusId, Guid)>>._))
+            .ReturnsLazily((IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)> processStepTypeStatus) =>
+            {
+                processSteps = processStepTypeStatus.Select(x => new ProcessStep(Guid.NewGuid(), x.ProcessStepTypeId, x.ProcessStepStatusId, x.ProcessId, utcNow)).ToImmutableArray();
+                return processSteps;
+            });
+        var settings = new RegistrationSettings
+        {
+            SubmitDocumentTypeIds = [
+                DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT
+            ],
+            IsSubmitDocumentValidationOptional = isSubmitDocumentValidationOptional
+        };
+        var sut = new RegistrationBusinessLogic(Options.Create(settings), null!, null!, null!, _portalRepositories, _checklistService, _identityService, _dateTimeProvider, _mailingProcessCreation);
+
+        // Act
+        await sut.SubmitRegistrationAsync(applicationId);
+
+        // Assert
+        A.CallTo(() => _applicationRepository.GetOwnCompanyApplicationUserEmailDataAsync(applicationId, _identity.IdentityId, A<IEnumerable<DocumentTypeId>>.That.IsSameSequenceAs(new[] { DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT })))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _documentRepository.AttachAndModifyDocuments(A<IEnumerable<(Guid DocumentId, Action<Document>?, Action<Document>)>>.That.Matches(x => x.Count() == 2)))
+            .MustHaveHappenedOnceExactly();
+
+        modifiedDocuments.Should().HaveCount(2).And.Satisfy(
+            x => x.Initial.Id == documents[0].DocumentId && x.Initial.DocumentStatusId == documents[0].StatusId && x.Modified.Id == documents[0].DocumentId && x.Modified.DocumentStatusId == DocumentStatusId.LOCKED,
+            x => x.Initial.Id == documents[1].DocumentId && x.Initial.DocumentStatusId == documents[1].StatusId && x.Modified.Id == documents[1].DocumentId && x.Modified.DocumentStatusId == DocumentStatusId.LOCKED
+        );
+
+        A.CallTo(() => _checklistService.CreateInitialChecklistAsync(applicationId))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _checklistService.GetInitialProcessStepTypeIds(A<IEnumerable<(ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId)>>.That.IsSameSequenceAs(checklist)))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.APPLICATION_CHECKLIST))
+            .MustHaveHappenedOnceExactly();
+
+        process.Should().NotBeNull();
+        process!.ProcessTypeId.Should().Be(ProcessTypeId.APPLICATION_CHECKLIST);
+
+        A.CallTo(() => _applicationRepository.AttachAndModifyCompanyApplication(A<Guid>._, A<Action<CompanyApplication>>._))
+            .MustHaveHappenedOnceExactly();
+
+        application.Should().NotBeNull();
+        application!.ChecklistProcessId.Should().Be(process!.Id);
+        application.ApplicationStatusId.Should().Be(CompanyApplicationStatusId.SUBMITTED);
+        application.DateLastChanged.Should().Be(now);
+
+        A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId, ProcessStepStatusId, Guid)>>._))
+            .MustHaveHappenedOnceExactly();
+
+        processSteps.Should().NotBeNull()
+            .And.HaveCount(stepTypeIds.Length)
+            .And.AllSatisfy(x =>
+            {
+                x.ProcessId.Should().Be(process.Id);
+                x.ProcessStepStatusId.Should().Be(ProcessStepStatusId.TODO);
+            })
+            .And.Satisfy(
+                x => x.ProcessStepTypeId == stepTypeIds[0],
+                x => x.ProcessStepTypeId == stepTypeIds[1],
+                x => x.ProcessStepTypeId == stepTypeIds[2]
+            );
+
+        A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
     }
 
     #endregion


### PR DESCRIPTION
## Description

As an Operator, we discovered that we don’t necessarily need documents to be submitted during registration.
We manage all the documents during the sales process before the Portal registration process.
We want to make the document submission step optional.

## Why

Currently it's mandatory to upload the document before registration submit. So to make it optional we have added this flag

## Issue

[Issue : 828](https://github.com/eclipse-tractusx/portal-backend/issues/828)

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
