### PR TITLE
chore(dependencies): bump efcore to 8.0.7

### DIFF
--- a/src/administration/Administration.Service/Administration.Service.csproj
+++ b/src/administration/Administration.Service/Administration.Service.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/framework/Framework.DBAccess/Framework.DBAccess.csproj
+++ b/src/framework/Framework.DBAccess/Framework.DBAccess.csproj
@@ -61,6 +61,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
   </ItemGroup>
 </Project>

--- a/src/framework/Framework.DateTimeProvider/Framework.DateTimeProvider.csproj
+++ b/src/framework/Framework.DateTimeProvider/Framework.DateTimeProvider.csproj
@@ -62,6 +62,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
   </ItemGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Framework.DependencyInjection.csproj
+++ b/src/framework/Framework.DependencyInjection/Framework.DependencyInjection.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Framework.HttpClientExtensions.csproj
+++ b/src/framework/Framework.HttpClientExtensions/Framework.HttpClientExtensions.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/framework/Framework.Seeding/Framework.Seeding.csproj
+++ b/src/framework/Framework.Seeding/Framework.Seeding.csproj
@@ -65,9 +65,9 @@
   </ItemGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.5" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.7" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />

--- a/src/maintenance/Maintenance.App/Maintenance.App.csproj
+++ b/src/maintenance/Maintenance.App/Maintenance.App.csproj
@@ -32,7 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/marketplace/Apps.Service/Apps.Service.csproj
+++ b/src/marketplace/Apps.Service/Apps.Service.csproj
@@ -29,7 +29,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/portalbackend/PortalBackend.DBAccess/PortalBackend.DBAccess.csproj
+++ b/src/portalbackend/PortalBackend.DBAccess/PortalBackend.DBAccess.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/portalbackend/PortalBackend.Migrations/PortalBackend.Migrations.csproj
+++ b/src/portalbackend/PortalBackend.Migrations/PortalBackend.Migrations.csproj
@@ -32,7 +32,7 @@
     <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/portalbackend/PortalBackend.PortalEntities/PortalBackend.PortalEntities.csproj
+++ b/src/portalbackend/PortalBackend.PortalEntities/PortalBackend.PortalEntities.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
     <PackageReference Include="Laraue.EfCoreTriggers.PostgreSql" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/processes/Processes.ProcessIdentity/Processes.ProcessIdentity.csproj
+++ b/src/processes/Processes.ProcessIdentity/Processes.ProcessIdentity.csproj
@@ -25,8 +25,8 @@
       <RootNamespace>Org.Eclipse.TractusX.Portal.Backend.Processes.ProcessIdentity</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/processes/Processes.Worker/Processes.Worker.csproj
+++ b/src/processes/Processes.Worker/Processes.Worker.csproj
@@ -33,7 +33,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/provisioning/Provisioning.DBAccess/Provisioning.DBAccess.csproj
+++ b/src/provisioning/Provisioning.DBAccess/Provisioning.DBAccess.csproj
@@ -27,11 +27,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/provisioning/Provisioning.Migrations/Provisioning.Migrations.csproj
+++ b/src/provisioning/Provisioning.Migrations/Provisioning.Migrations.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/provisioning/Provisioning.ProvisioningEntities/Provisioning.ProvisioningEntities.csproj
+++ b/src/provisioning/Provisioning.ProvisioningEntities/Provisioning.ProvisioningEntities.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/registration/ApplicationActivation.Library/ApplicationActivation.Library.csproj
+++ b/src/registration/ApplicationActivation.Library/ApplicationActivation.Library.csproj
@@ -30,7 +30,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/registration/Registration.Service/Registration.Service.csproj
+++ b/src/registration/Registration.Service/Registration.Service.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalBackend.DBAccess.Tests.csproj
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalBackend.DBAccess.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.7.0" />

--- a/tests/portalbackend/PortalBackend.Migrations.Tests/PortalBackend.Migrations.Tests.csproj
+++ b/tests/portalbackend/PortalBackend.Migrations.Tests/PortalBackend.Migrations.Tests.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
         <PackageReference Include="FakeItEasy" Version="8.1.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="xunit" Version="2.7.0" />

--- a/tests/provisioning/Provisioning.DBAccess.Tests/Provisioning.DBAccess.Tests.csproj
+++ b/tests/provisioning/Provisioning.DBAccess.Tests/Provisioning.DBAccess.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.7.0" />


### PR DESCRIPTION
## Description

increase efcore version to latest 8.0.7

## Why

efcore 8.0.2 has transitive dependency System.Text.Json 8.0.0 which has a security-vulerability that is clasified as high. Upgrade to efcore 8.0.7 implicitly upgrades this dependency to System.Text.Json 8.0.4 which resolves the vulnerability.

## Issue

[Link to Github issue.](https://github.com/eclipse-tractusx/portal/issues/369)

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
