### PR TITLE
feat(legal entity): extended legal entity length

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -45,7 +45,6 @@ public class CompanyDataBusinessLogic(
 {
     private static readonly Regex BpnsRegex = new(ValidationExpressions.Bpns, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private static readonly Regex EcmRegex = new(ValidationExpressions.ExternalCertificateNumber, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private readonly IIdentityData _identityData = identityService.IdentityData;
     private readonly CompanyDataSettings _settings = options.Value;
 

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -266,7 +266,7 @@ public class CompanyDataBusinessLogic(
             throw new ControllerArgumentException("ValidTill date should be greater than current date");
         }
 
-        if (!string.IsNullOrEmpty(data.Issuer) && !ValidationExpressionsValidator.IsValidCompanyName(data.Issuer))
+        if (data.Issuer != null && !data.Issuer.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", nameof(data.Issuer))]);
         }

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -268,7 +268,7 @@ public class CompanyDataBusinessLogic(
 
         if (!string.IsNullOrEmpty(data.Issuer) && !ValidationExpressionsValidator.IsValidCompanyName(data.Issuer))
         {
-            throw new ControllerArgumentException($"Issuer: {ValidationExpressionErrorMessages.CompanyError}", nameof(data.Issuer));
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", nameof(data.Issuer))]);
         }
 
         var documentContentType = data.Document.ContentType.ParseMediaTypeId();

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -267,9 +267,9 @@ public class CompanyDataBusinessLogic(
             throw new ControllerArgumentException("ValidTill date should be greater than current date");
         }
 
-        if (data.Issuer != null && !Company.IsMatch(data.Issuer!))
+        if (!string.IsNullOrEmpty(data.Issuer) && !ValidationExpressionsValidator.IsValidCompanyName(data.Issuer))
         {
-            throw new ControllerArgumentException("Issuer length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name");
+            throw new ControllerArgumentException($"Issuer: {ValidationExpressionErrorMessages.CompanyError}", nameof(data.Issuer));
         }
 
         var documentContentType = data.Document.ContentType.ParseMediaTypeId();

--- a/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
@@ -48,12 +48,7 @@ public class InvitationBusinessLogic : IInvitationBusinessLogic
             throw new ControllerArgumentException("email must not be empty", "email");
         }
 
-        if (string.IsNullOrWhiteSpace(invitationData.OrganisationName))
-        {
-            throw new ControllerArgumentException("organisationName must not be empty", "organisationName");
-        }
-
-        if (!string.IsNullOrEmpty(invitationData.OrganisationName) && !ValidationExpressionsValidator.IsValidCompanyName(invitationData.OrganisationName))
+        if (invitationData.OrganisationName == null || !invitationData.OrganisationName.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", nameof(invitationData.OrganisationName))]);
         }

--- a/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
@@ -57,7 +57,7 @@ public class InvitationBusinessLogic : IInvitationBusinessLogic
 
         if (!string.IsNullOrEmpty(invitationData.OrganisationName) && !Company.IsMatch(invitationData.OrganisationName))
         {
-            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressions.CompanyError}", "organisationName");
+            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError}", "organisationName");
         }
 
         return ExecuteInvitationInternalAsync(invitationData);

--- a/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
@@ -24,13 +24,11 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.Library;
-using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 
 public class InvitationBusinessLogic : IInvitationBusinessLogic
 {
-    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private readonly IPortalRepositories _portalRepositories;
 
     /// <summary>
@@ -55,7 +53,7 @@ public class InvitationBusinessLogic : IInvitationBusinessLogic
             throw new ControllerArgumentException("organisationName must not be empty", "organisationName");
         }
 
-        if (!string.IsNullOrEmpty(invitationData.OrganisationName) && !Company.IsMatch(invitationData.OrganisationName))
+        if (!string.IsNullOrEmpty(invitationData.OrganisationName) && !ValidationExpressionsValidator.IsValidCompanyName(invitationData.OrganisationName))
         {
             throw new ControllerArgumentException($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError}", "organisationName");
         }

--- a/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
@@ -57,7 +57,7 @@ public class InvitationBusinessLogic : IInvitationBusinessLogic
 
         if (!string.IsNullOrEmpty(invitationData.OrganisationName) && !Company.IsMatch(invitationData.OrganisationName))
         {
-            throw new ControllerArgumentException("OrganisationName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", "organisationName");
+            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressions.CompanyError}", "organisationName");
         }
 
         return ExecuteInvitationInternalAsync(invitationData);

--- a/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
@@ -55,7 +55,7 @@ public class InvitationBusinessLogic : IInvitationBusinessLogic
 
         if (!string.IsNullOrEmpty(invitationData.OrganisationName) && !ValidationExpressionsValidator.IsValidCompanyName(invitationData.OrganisationName))
         {
-            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError}", "organisationName");
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", nameof(invitationData.OrganisationName))]);
         }
 
         return ExecuteInvitationInternalAsync(invitationData);

--- a/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
@@ -47,14 +47,12 @@ public class NetworkBusinessLogic(
 {
     private static readonly Regex Name = new(ValidationExpressions.Name, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private static readonly Regex ExternalId = new("^[A-Za-z0-9\\-+_/,.]{6,36}$", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-
     private readonly IIdentityData _identityData = identityService.IdentityData;
     private readonly PartnerRegistrationSettings _settings = options.Value;
 
     public async Task HandlePartnerRegistration(PartnerRegistrationData data)
     {
-        if (!string.IsNullOrEmpty(data.Name) && !Company.IsMatch(data.Name))
+        if (!ValidationExpressionsValidator.IsValidCompanyName(data.Name))
         {
             throw new ControllerArgumentException($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError}", "organisationName");
         }

--- a/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
@@ -52,7 +52,7 @@ public class NetworkBusinessLogic(
 
     public async Task HandlePartnerRegistration(PartnerRegistrationData data)
     {
-        if (!ValidationExpressionsValidator.IsValidCompanyName(data.Name))
+        if (!data.Name.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "OrganisationName")]);
         }

--- a/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
@@ -54,7 +54,7 @@ public class NetworkBusinessLogic(
     {
         if (!ValidationExpressionsValidator.IsValidCompanyName(data.Name))
         {
-            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError}", "organisationName");
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "OrganisationName")]);
         }
 
         var ownerCompanyId = _identityData.CompanyId;

--- a/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
@@ -56,7 +56,7 @@ public class NetworkBusinessLogic(
     {
         if (!string.IsNullOrEmpty(data.Name) && !Company.IsMatch(data.Name))
         {
-            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressions.CompanyError}", "organisationName");
+            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError}", "organisationName");
         }
 
         var ownerCompanyId = _identityData.CompanyId;

--- a/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
@@ -56,7 +56,7 @@ public class NetworkBusinessLogic(
     {
         if (!string.IsNullOrEmpty(data.Name) && !Company.IsMatch(data.Name))
         {
-            throw new ControllerArgumentException("OrganisationName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", "organisationName");
+            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressions.CompanyError}", "organisationName");
         }
 
         var ownerCompanyId = _identityData.CompanyId;

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -87,7 +87,7 @@ public sealed class RegistrationBusinessLogic(
         }
         if (!ValidationExpressionsValidator.IsValidCompanyName(companyWithAddress.Name))
         {
-            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError}", "organisationName");
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "OrganisationName")]);
         }
 
         return new CompanyWithAddressData(
@@ -126,7 +126,7 @@ public sealed class RegistrationBusinessLogic(
     {
         if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
         {
-            throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}", nameof(companyName));
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }
         var applications = portalRepositories.GetInstance<IApplicationRepository>()
             .GetCompanyApplicationsFilteredQuery(
@@ -201,7 +201,7 @@ public sealed class RegistrationBusinessLogic(
     {
         if (!ValidationExpressionsValidator.IsValidCompanyName(companyName))
         {
-            throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}", nameof(companyName));
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }
         var applications = portalRepositories.GetInstance<IApplicationRepository>().GetAllCompanyApplicationsDetailsQuery(companyName);
 

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -164,9 +164,9 @@ public sealed class RegistrationBusinessLogic(
 
     public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName)
     {
-        if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
+        if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
         {
-            throw new ControllerArgumentException("CompanyName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name", nameof(companyName));
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }
         var applications = portalRepositories.GetInstance<IApplicationRepository>()
             .GetExternalCompanyApplicationsFilteredQuery(_identityData.CompanyId,

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -87,7 +87,7 @@ public sealed class RegistrationBusinessLogic(
         }
         if (!string.IsNullOrEmpty(companyWithAddress.Name) && !Company.IsMatch(companyWithAddress.Name))
         {
-            throw new ControllerArgumentException("OrganisationName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", "organisationName");
+            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressions.CompanyError}", "organisationName");
         }
 
         return new CompanyWithAddressData(
@@ -126,7 +126,7 @@ public sealed class RegistrationBusinessLogic(
     {
         if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
         {
-            throw new ControllerArgumentException("CompanyName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name", nameof(companyName));
+            throw new ControllerArgumentException($"CompanyName: {ValidationExpressions.CompanyError}", nameof(companyName));
         }
         var applications = portalRepositories.GetInstance<IApplicationRepository>()
             .GetCompanyApplicationsFilteredQuery(
@@ -201,7 +201,7 @@ public sealed class RegistrationBusinessLogic(
     {
         if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
         {
-            throw new ControllerArgumentException("CompanyName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name", nameof(companyName));
+            throw new ControllerArgumentException($"CompanyName: {ValidationExpressions.CompanyError}", nameof(companyName));
         }
         var applications = portalRepositories.GetInstance<IApplicationRepository>().GetAllCompanyApplicationsDetailsQuery(companyName);
 

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -198,7 +198,7 @@ public sealed class RegistrationBusinessLogic(
     }
     public Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName)
     {
-         if (companyName != null && !companyName.IsValidCompanyName())  
+        if (companyName != null && !companyName.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -85,7 +85,7 @@ public sealed class RegistrationBusinessLogic(
         {
             throw NotFoundException.Create(AdministrationRegistrationErrors.APPLICATION_NOT_FOUND, [new("applicationId", applicationId.ToString())]);
         }
-        if (!string.IsNullOrEmpty(companyWithAddress.Name) && !Company.IsMatch(companyWithAddress.Name))
+        if (!ValidationExpressionsValidator.IsValidCompanyName(companyWithAddress.Name))
         {
             throw new ControllerArgumentException($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError}", "organisationName");
         }
@@ -124,7 +124,7 @@ public sealed class RegistrationBusinessLogic(
 
     public Task<Pagination.Response<CompanyApplicationDetails>> GetCompanyApplicationDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName)
     {
-        if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
+        if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
         {
             throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}", nameof(companyName));
         }
@@ -199,7 +199,7 @@ public sealed class RegistrationBusinessLogic(
     }
     public Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName)
     {
-        if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
+        if (!ValidationExpressionsValidator.IsValidCompanyName(companyName))
         {
             throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}", nameof(companyName));
         }

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -63,7 +63,6 @@ public sealed class RegistrationBusinessLogic(
     : IRegistrationBusinessLogic
 {
     private static readonly Regex BpnRegex = new(ValidationExpressions.Bpn, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
     private readonly IIdentityData _identityData = identityService.IdentityData;
     private readonly RegistrationSettings _settings = configuration.Value;

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -87,7 +87,7 @@ public sealed class RegistrationBusinessLogic(
         }
         if (!string.IsNullOrEmpty(companyWithAddress.Name) && !Company.IsMatch(companyWithAddress.Name))
         {
-            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressions.CompanyError}", "organisationName");
+            throw new ControllerArgumentException($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError}", "organisationName");
         }
 
         return new CompanyWithAddressData(
@@ -126,7 +126,7 @@ public sealed class RegistrationBusinessLogic(
     {
         if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
         {
-            throw new ControllerArgumentException($"CompanyName: {ValidationExpressions.CompanyError}", nameof(companyName));
+            throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}", nameof(companyName));
         }
         var applications = portalRepositories.GetInstance<IApplicationRepository>()
             .GetCompanyApplicationsFilteredQuery(
@@ -201,7 +201,7 @@ public sealed class RegistrationBusinessLogic(
     {
         if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
         {
-            throw new ControllerArgumentException($"CompanyName: {ValidationExpressions.CompanyError}", nameof(companyName));
+            throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}", nameof(companyName));
         }
         var applications = portalRepositories.GetInstance<IApplicationRepository>().GetAllCompanyApplicationsDetailsQuery(companyName);
 

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -84,7 +84,7 @@ public sealed class RegistrationBusinessLogic(
         {
             throw NotFoundException.Create(AdministrationRegistrationErrors.APPLICATION_NOT_FOUND, [new("applicationId", applicationId.ToString())]);
         }
-        if (!ValidationExpressionsValidator.IsValidCompanyName(companyWithAddress.Name))
+        if (!companyWithAddress.Name.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "OrganisationName")]);
         }
@@ -123,7 +123,7 @@ public sealed class RegistrationBusinessLogic(
 
     public Task<Pagination.Response<CompanyApplicationDetails>> GetCompanyApplicationDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName)
     {
-        if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
+        if (companyName != null && !companyName.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }
@@ -163,7 +163,7 @@ public sealed class RegistrationBusinessLogic(
 
     public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName)
     {
-        if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
+        if (companyName != null && !companyName.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }
@@ -198,7 +198,7 @@ public sealed class RegistrationBusinessLogic(
     }
     public Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName)
     {
-        if (!ValidationExpressionsValidator.IsValidCompanyName(companyName))
+         if (companyName != null && !companyName.IsValidCompanyName())  
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -21,6 +21,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.IssuerComponent.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
@@ -94,7 +95,8 @@ await WebAppHelper
             .AddSingleton<IErrorMessageContainer, AdministrationMailErrorMessageContainer>()
             .AddSingleton<IErrorMessageContainer, AdministrationRegistrationErrorMessageContainer>()
             .AddSingleton<IErrorMessageContainer, AdministrationServiceAccountErrorMessageContainer>()
-            .AddSingleton<IErrorMessageContainer, ProvisioningServiceErrorMessageContainer>();
+            .AddSingleton<IErrorMessageContainer, ProvisioningServiceErrorMessageContainer>()
+            .AddSingleton<IErrorMessageContainer, ValidationExpressionErrorMessageContainer>();
 
         builder.Services.AddProvisioningDBAccess(builder.Configuration);
     }).ConfigureAwait(ConfigureAwaitOptions.None);

--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/ValidationExpressionErrorMessages.cs
+++ b/src/framework/Framework.Models/ValidationExpressionErrorMessages.cs
@@ -17,10 +17,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using System.Collections.Immutable;
+
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 
 // This class contains error messages for validation expressions
-public static class ValidationExpressionErrorMessages
+public class ValidationExpressionErrorMessageContainer : IErrorMessageContainer
 {
-    public const string CompanyError = "length must be between 1 and 160 characters and not start or end with a white space";
+    private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<ValidationExpressionErrors, string> {
+                { ValidationExpressionErrors.INCORRECT_COMPANY_NAME, "{name}: length must be between 1 and 160 characters and not start or end with a white space" },
+
+            }.ToImmutableDictionary(x => (int)x.Key, x => x.Value);
+
+    public Type Type { get => typeof(ValidationExpressionErrors); }
+    public IReadOnlyDictionary<int, string> MessageContainer { get => _messageContainer; }
+}
+
+public enum ValidationExpressionErrors
+{
+    INCORRECT_COMPANY_NAME
 }

--- a/src/framework/Framework.Models/ValidationExpressionErrorMessages.cs
+++ b/src/framework/Framework.Models/ValidationExpressionErrorMessages.cs
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
+
+// This class contains error messages for validation expressions
+public static class ValidationExpressionErrorMessages
+{
+    public const string CompanyError = "length must be between 1 and 160 characters and not start or end with a white space";
+}

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -28,5 +28,4 @@ public static class ValidationExpressions
     public const string Bpns = @"^(BPNS|bpns)[\w|\d]{12}$";
     public const string Company = @"^(?!.*\s$)([\wÀ-ÿ£$€¥¢@%*+\-/\\,.:;=<>!?&^#'\x22()[\]]\s?){1,160}$";
     public const string ExternalCertificateNumber = @"^[a-zA-Z0-9]{0,36}$";
-    public static readonly Regex CompanyRegex = new(ValidationExpressions.Company, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(1));
 }

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -17,8 +17,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using System.Text.RegularExpressions;
-
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 
 public static class ValidationExpressions

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -24,6 +24,6 @@ public static class ValidationExpressions
     public const string Name = @"^.+$";
     public const string Bpn = @"^(BPNL|bpnl)[\w|\d]{12}$";
     public const string Bpns = @"^(BPNS|bpns)[\w|\d]{12}$";
-    public const string Company = @"^\d*?[A-Za-zÀ-ÿ]\d?([A-Za-z0-9À-ÿ-_+=.,:;!?'\x22&#@()]\s?){2,40}$";
+    public const string Company = @"^(?!.*\s$)([\wÀ-ÿ£$€¥¢@%*+\-/\\,.:;=<>!?&^#'\x22()[\]]\s?){1,160}$";
     public const string ExternalCertificateNumber = @"^[a-zA-Z0-9]{0,36}$";
 }

--- a/src/framework/Framework.Models/ValidationExpressionsValidator.cs
+++ b/src/framework/Framework.Models/ValidationExpressionsValidator.cs
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Models/ValidationExpressionsValidator.cs
+++ b/src/framework/Framework.Models/ValidationExpressionsValidator.cs
@@ -23,8 +23,9 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 
 public static class ValidationExpressionsValidator
 {
-    public static bool IsValidCompanyName(string companyName)
+    private static readonly Regex CompanyRegex = new(ValidationExpressions.Company, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(1));
+    public static bool IsValidCompanyName(this string companyName)
     {
-        return ValidationExpressions.CompanyRegex.IsMatch(companyName);
+        return CompanyRegex.IsMatch(companyName);
     }
 }

--- a/src/framework/Framework.Models/ValidationExpressionsValidator.cs
+++ b/src/framework/Framework.Models/ValidationExpressionsValidator.cs
@@ -21,12 +21,10 @@ using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 
-public static class ValidationExpressions
+public static class ValidationExpressionsValidator
 {
-    public const string Name = @"^.+$";
-    public const string Bpn = @"^(BPNL|bpnl)[\w|\d]{12}$";
-    public const string Bpns = @"^(BPNS|bpns)[\w|\d]{12}$";
-    public const string Company = @"^(?!.*\s$)([\wÀ-ÿ£$€¥¢@%*+\-/\\,.:;=<>!?&^#'\x22()[\]]\s?){1,160}$";
-    public const string ExternalCertificateNumber = @"^[a-zA-Z0-9]{0,36}$";
-    public static readonly Regex CompanyRegex = new(ValidationExpressions.Company, RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(1));
+    public static bool IsValidCompanyName(string companyName)
+    {
+        return ValidationExpressions.CompanyRegex.IsMatch(companyName);
+    }
 }

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -187,7 +187,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
             throw new ControllerArgumentException("Use Case Ids must not be null or empty", nameof(appRequestModel.UseCaseIds));
         }
 
-        if (!string.IsNullOrEmpty(appRequestModel.Provider) && !ValidationExpressionsValidator.IsValidCompanyName(appRequestModel.Provider))
+        if (appRequestModel.Provider != null && !appRequestModel.Provider.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", nameof(appRequestModel.Provider))]);
         }
@@ -267,7 +267,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
             throw new ForbiddenException($"Company {companyId} is not the app provider.");
         }
 
-        if (!string.IsNullOrEmpty(appRequestModel.Provider) && !ValidationExpressionsValidator.IsValidCompanyName(appRequestModel.Provider))
+        if (appRequestModel.Provider != null && !appRequestModel.Provider.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", nameof(appRequestModel.Provider))]);
         }

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -191,7 +191,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
 
         if (!string.IsNullOrEmpty(appRequestModel.Provider) && !Company.IsMatch(appRequestModel.Provider))
         {
-            throw new ControllerArgumentException("Provider length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", nameof(appRequestModel.Provider));
+            throw new ControllerArgumentException($"Provider: {ValidationExpressions.CompanyError}", nameof(appRequestModel.Provider));
         }
 
         return CreateAppAsync(appRequestModel);
@@ -271,7 +271,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
 
         if (!string.IsNullOrEmpty(appRequestModel.Provider) && !Company.IsMatch(appRequestModel.Provider))
         {
-            throw new ControllerArgumentException("Provider length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the Organisation name", nameof(appRequestModel.Provider));
+            throw new ControllerArgumentException($"Provider: {ValidationExpressions.CompanyError}", nameof(appRequestModel.Provider));
         }
 
         if (appRequestModel.SalesManagerId.HasValue)

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -31,7 +31,6 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
-using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Apps.Service.BusinessLogic;
 
@@ -40,7 +39,6 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Apps.Service.BusinessLogic;
 /// </summary>
 public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
 {
-    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private readonly IPortalRepositories _portalRepositories;
     private readonly AppsSettings _settings;
     private readonly IOfferService _offerService;
@@ -189,7 +187,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
             throw new ControllerArgumentException("Use Case Ids must not be null or empty", nameof(appRequestModel.UseCaseIds));
         }
 
-        if (!string.IsNullOrEmpty(appRequestModel.Provider) && !Company.IsMatch(appRequestModel.Provider))
+        if (!string.IsNullOrEmpty(appRequestModel.Provider) && !ValidationExpressionsValidator.IsValidCompanyName(appRequestModel.Provider))
         {
             throw new ControllerArgumentException($"Provider: {ValidationExpressionErrorMessages.CompanyError}", nameof(appRequestModel.Provider));
         }
@@ -269,7 +267,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
             throw new ForbiddenException($"Company {companyId} is not the app provider.");
         }
 
-        if (!string.IsNullOrEmpty(appRequestModel.Provider) && !Company.IsMatch(appRequestModel.Provider))
+        if (!string.IsNullOrEmpty(appRequestModel.Provider) && !ValidationExpressionsValidator.IsValidCompanyName(appRequestModel.Provider))
         {
             throw new ControllerArgumentException($"Provider: {ValidationExpressionErrorMessages.CompanyError}", nameof(appRequestModel.Provider));
         }

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -189,7 +189,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
 
         if (!string.IsNullOrEmpty(appRequestModel.Provider) && !ValidationExpressionsValidator.IsValidCompanyName(appRequestModel.Provider))
         {
-            throw new ControllerArgumentException($"Provider: {ValidationExpressionErrorMessages.CompanyError}", nameof(appRequestModel.Provider));
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", nameof(appRequestModel.Provider))]);
         }
 
         return CreateAppAsync(appRequestModel);
@@ -269,7 +269,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
 
         if (!string.IsNullOrEmpty(appRequestModel.Provider) && !ValidationExpressionsValidator.IsValidCompanyName(appRequestModel.Provider))
         {
-            throw new ControllerArgumentException($"Provider: {ValidationExpressionErrorMessages.CompanyError}", nameof(appRequestModel.Provider));
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", nameof(appRequestModel.Provider))]);
         }
 
         if (appRequestModel.SalesManagerId.HasValue)

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -191,7 +191,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
 
         if (!string.IsNullOrEmpty(appRequestModel.Provider) && !Company.IsMatch(appRequestModel.Provider))
         {
-            throw new ControllerArgumentException($"Provider: {ValidationExpressions.CompanyError}", nameof(appRequestModel.Provider));
+            throw new ControllerArgumentException($"Provider: {ValidationExpressionErrorMessages.CompanyError}", nameof(appRequestModel.Provider));
         }
 
         return CreateAppAsync(appRequestModel);
@@ -271,7 +271,7 @@ public class AppReleaseBusinessLogic : IAppReleaseBusinessLogic
 
         if (!string.IsNullOrEmpty(appRequestModel.Provider) && !Company.IsMatch(appRequestModel.Provider))
         {
-            throw new ControllerArgumentException($"Provider: {ValidationExpressions.CompanyError}", nameof(appRequestModel.Provider));
+            throw new ControllerArgumentException($"Provider: {ValidationExpressionErrorMessages.CompanyError}", nameof(appRequestModel.Provider));
         }
 
         if (appRequestModel.SalesManagerId.HasValue)

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -30,7 +30,6 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
-using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Apps.Service.BusinessLogic;
 
@@ -39,7 +38,6 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Apps.Service.BusinessLogic;
 /// </summary>
 public class AppsBusinessLogic : IAppsBusinessLogic
 {
-    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private readonly IPortalRepositories _portalRepositories;
     private readonly IOfferSubscriptionService _offerSubscriptionService;
     private readonly AppsSettings _settings;
@@ -158,7 +156,7 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     /// <inheritdoc/>
     public async Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName = null)
     {
-        if (!string.IsNullOrWhiteSpace(companyName) && !Company.IsMatch(companyName))
+        if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
         {
             throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}");
         }

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -160,7 +160,7 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     {
         if (!string.IsNullOrWhiteSpace(companyName) && !Company.IsMatch(companyName))
         {
-            throw new ControllerArgumentException("CompanyName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name");
+            throw new ControllerArgumentException($"CompanyName: {ValidationExpressions.CompanyError}");
         }
 
         async Task<Pagination.Source<OfferCompanySubscriptionStatusResponse>?> GetCompanyProvidedAppSubscriptionStatusData(int skip, int take)

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -160,7 +160,7 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     {
         if (!string.IsNullOrWhiteSpace(companyName) && !Company.IsMatch(companyName))
         {
-            throw new ControllerArgumentException($"CompanyName: {ValidationExpressions.CompanyError}");
+            throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}");
         }
 
         async Task<Pagination.Source<OfferCompanySubscriptionStatusResponse>?> GetCompanyProvidedAppSubscriptionStatusData(int skip, int take)

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -158,7 +158,7 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     {
         if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
         {
-            throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}");
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }
 
         async Task<Pagination.Source<OfferCompanySubscriptionStatusResponse>?> GetCompanyProvidedAppSubscriptionStatusData(int skip, int take)

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -156,7 +156,7 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     /// <inheritdoc/>
     public async Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName = null)
     {
-        if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
+        if (companyName != null && !companyName.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }

--- a/src/marketplace/Apps.Service/Program.cs
+++ b/src/marketplace/Apps.Service/Program.cs
@@ -50,6 +50,7 @@ await WebAppHelper
             .AddTransient<IAppChangeBusinessLogic, AppChangeBusinessLogic>()
             .AddTransient<IOfferService, OfferService>()
             .AddTransient<IOfferSubscriptionService, OfferSubscriptionService>()
+            .AddSingleton<IErrorMessageService, ErrorMessageService>()
             .AddSingleton<IErrorMessageContainer, ValidationExpressionErrorMessageContainer>()
             .AddTechnicalUserProfile()
             .ConfigureAppsSettings(builder.Configuration.GetSection("AppMarketPlace"))

--- a/src/marketplace/Apps.Service/Program.cs
+++ b/src/marketplace/Apps.Service/Program.cs
@@ -19,6 +19,8 @@
 
 using Org.Eclipse.TractusX.Portal.Backend.Apps.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Dim.Library.DependencyInjection;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Service;
@@ -48,6 +50,7 @@ await WebAppHelper
             .AddTransient<IAppChangeBusinessLogic, AppChangeBusinessLogic>()
             .AddTransient<IOfferService, OfferService>()
             .AddTransient<IOfferSubscriptionService, OfferSubscriptionService>()
+            .AddSingleton<IErrorMessageContainer, ValidationExpressionErrorMessageContainer>()
             .AddTechnicalUserProfile()
             .ConfigureAppsSettings(builder.Configuration.GetSection("AppMarketPlace"))
             .AddOfferDocumentServices();

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -137,7 +137,7 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
     {
         if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
         {
-            throw new ControllerArgumentException($"CompanyName: {ValidationExpressions.CompanyError}");
+            throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}");
         }
         async Task<Pagination.Source<OfferCompanySubscriptionStatusResponse>?> GetCompanyProvidedAppSubscriptionStatusData(int skip, int take)
         {

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -29,7 +29,6 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 using Org.Eclipse.TractusX.Portal.Backend.Services.Service.ViewModels;
-using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.BusinessLogic;
 
@@ -38,7 +37,6 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.BusinessLogic;
 /// </summary>
 public class ServiceBusinessLogic : IServiceBusinessLogic
 {
-    private static readonly Regex Company = new(ValidationExpressions.Company, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private readonly IPortalRepositories _portalRepositories;
     private readonly IOfferService _offerService;
     private readonly IOfferSubscriptionService _offerSubscriptionService;
@@ -135,7 +133,7 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
     /// <inheritdoc/>
     public async Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedServiceSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName = null)
     {
-        if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
+        if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
         {
             throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}");
         }

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -137,7 +137,7 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
     {
         if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
         {
-            throw new ControllerArgumentException("CompanyName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name");
+            throw new ControllerArgumentException($"CompanyName: {ValidationExpressions.CompanyError}");
         }
         async Task<Pagination.Source<OfferCompanySubscriptionStatusResponse>?> GetCompanyProvidedAppSubscriptionStatusData(int skip, int take)
         {

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -133,7 +133,7 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
     /// <inheritdoc/>
     public async Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedServiceSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName = null)
     {
-        if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
+        if (companyName != null && !companyName.IsValidCompanyName())
         {
             throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -135,7 +135,7 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
     {
         if (!string.IsNullOrEmpty(companyName) && !ValidationExpressionsValidator.IsValidCompanyName(companyName))
         {
-            throw new ControllerArgumentException($"CompanyName: {ValidationExpressionErrorMessages.CompanyError}");
+            throw ControllerArgumentException.Create(ValidationExpressionErrors.INCORRECT_COMPANY_NAME, [new("name", "CompanyName")]);
         }
         async Task<Pagination.Source<OfferCompanySubscriptionStatusResponse>?> GetCompanyProvidedAppSubscriptionStatusData(int skip, int take)
         {

--- a/src/marketplace/Services.Service/Program.cs
+++ b/src/marketplace/Services.Service/Program.cs
@@ -18,6 +18,8 @@
  ********************************************************************************/
 
 using Org.Eclipse.TractusX.Portal.Backend.Dim.Library.DependencyInjection;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Web.DependencyInjection;
@@ -48,6 +50,7 @@ await WebAppHelper
             .AddServiceBusinessLogic(builder.Configuration)
             .AddTransient<IServiceReleaseBusinessLogic, ServiceReleaseBusinessLogic>()
             .AddTransient<IServiceChangeBusinessLogic, ServiceChangeBusinessLogic>()
+            .AddSingleton<IErrorMessageContainer, ValidationExpressionErrorMessageContainer>()
             .AddTechnicalUserProfile()
             .AddOfferDocumentServices();
 

--- a/src/marketplace/Services.Service/Program.cs
+++ b/src/marketplace/Services.Service/Program.cs
@@ -50,6 +50,7 @@ await WebAppHelper
             .AddServiceBusinessLogic(builder.Configuration)
             .AddTransient<IServiceReleaseBusinessLogic, ServiceReleaseBusinessLogic>()
             .AddTransient<IServiceChangeBusinessLogic, ServiceChangeBusinessLogic>()
+            .AddSingleton<IErrorMessageService, ErrorMessageService>()
             .AddSingleton<IErrorMessageContainer, ValidationExpressionErrorMessageContainer>()
             .AddTechnicalUserProfile()
             .AddOfferDocumentServices();

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -885,7 +885,7 @@ public class CompanyDataBusinessLogicTests
         var file = FormFileHelper.GetFormFile("test content", "test.pdf", MediaTypeId.PDF.MapToMediaType());
         var externalCertificateNumber = "2345678";
         var sites = new[] { "BPNS00000003CRHK" };
-        var data = new CompanyCertificateCreationData(CompanyCertificateTypeId.IATF, file, externalCertificateNumber, sites, _now.AddMicroseconds(-1), _now.AddMicroseconds(1), "+ACC");
+        var data = new CompanyCertificateCreationData(CompanyCertificateTypeId.IATF, file, externalCertificateNumber, sites, _now.AddMicroseconds(-1), _now.AddMicroseconds(1), " +ACC");
 
         A.CallTo(() => _companyCertificateRepository.CheckCompanyCertificateType(CompanyCertificateTypeId.IATF))
         .Returns(false);
@@ -895,7 +895,8 @@ public class CompanyDataBusinessLogicTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
-        ex.Message.Should().Be($"Issuer length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name");
+        ex.Message.Should().Be($"Issuer: {ValidationExpressionErrorMessages.CompanyError} (Parameter 'Issuer')");
+        ex.ParamName.Should().Be("Issuer");
     }
 
     #endregion

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/CompanyDataBusinessLogicTests.cs
@@ -895,8 +895,7 @@ public class CompanyDataBusinessLogicTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
-        ex.Message.Should().Be($"Issuer: {ValidationExpressionErrorMessages.CompanyError} (Parameter 'Issuer')");
-        ex.ParamName.Should().Be("Issuer");
+        ex.Message.Should().Be(ValidationExpressionErrors.INCORRECT_COMPANY_NAME.ToString());
     }
 
     #endregion

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -151,8 +151,7 @@ public class InvitationBusinessLogicTests
         async Task Act() => await _sut.ExecuteInvitation(invitationData);
 
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
-        ex.Message.Should().Be($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError} (Parameter 'organisationName')");
-        ex.ParamName.Should().Be("organisationName");
+        ex.Message.Should().Be(ValidationExpressionErrors.INCORRECT_COMPANY_NAME.ToString());
     }
 
     #endregion

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -128,7 +128,6 @@ public class InvitationBusinessLogicTests
     [InlineData("Special Characters ^&%#@*/_-\\")]
     [InlineData("German: ÄÖÜß")]
     [InlineData("Icelandic: ÆÐÞ")]
-    [InlineData("C")]
     public async Task ExecuteInvitation_WithValidOrganisationName_DoesNotThrowException(string validName)
     {
         var invitationData = _fixture.Build<CompanyInvitationData>()

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -73,23 +73,6 @@ public class InvitationBusinessLogicTests
     }
 
     [Fact]
-    public async Task ExecuteInvitation_WithoutOrganisationName_ThrowsControllerArgumentException()
-    {
-        var invitationData = _fixture.Build<CompanyInvitationData>()
-            .With(x => x.OrganisationName, (string?)null)
-            .WithNamePattern(x => x.FirstName)
-            .WithNamePattern(x => x.LastName)
-            .WithEmailPattern(x => x.Email)
-            .Create();
-
-        async Task Act() => await _sut.ExecuteInvitation(invitationData);
-
-        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
-        ex.Message.Should().Be("organisationName must not be empty (Parameter 'organisationName')");
-        ex.ParamName.Should().Be("organisationName");
-    }
-
-    [Fact]
     public async Task ExecuteInvitation_WithValidData_CreatesExpected()
     {
         var processes = new List<Process>();
@@ -140,6 +123,7 @@ public class InvitationBusinessLogicTests
     }
 
     [Theory]
+    [InlineData((string?)null)] // null value
     [InlineData("Organisation Name ")] // Ends with whitespace
     [InlineData("1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWX")] // Exceeds 160 characters
     public async Task ExecuteInvitation_WithInvalidOrganisationName_ThrowsControllerArgumentException(string invalidName)

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -20,6 +20,7 @@
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
@@ -110,6 +111,49 @@ public class InvitationBusinessLogicTests
         processes.Should().ContainSingle().And.Satisfy(x => x.ProcessTypeId == ProcessTypeId.INVITATION);
         processSteps.Should().ContainSingle().And.Satisfy(x => x.ProcessStepTypeId == ProcessStepTypeId.INVITATION_CREATE_CENTRAL_IDP && x.ProcessStepStatusId == ProcessStepStatusId.TODO);
         invitations.Should().ContainSingle().And.Satisfy(x => x.ProcessId == processes.Single().Id && x.UserName == "testUserName");
+    }
+
+    [Theory]
+    [InlineData("ValidOrganisationName123")]
+    [InlineData("Organisation Name")]
+    [InlineData("Organisation$Name")]
+    [InlineData("Organisation\\Name")]
+    [InlineData("Organisation/Name")]
+    [InlineData("Organisation<Name>")]
+    [InlineData("Organisation Name!")]
+    [InlineData("7-ELEVEN INTERNATIONAL LLC")]
+    [InlineData("C")]
+    [InlineData("+SEN Inc.")]
+    [InlineData("Double \"Quote\" Company S.A.")]
+    [InlineData("Special Characters ^&%#@*/_-\\")]
+    [InlineData("German: ÄÖÜß")]
+    [InlineData("Icelandic: ÆÐÞ")]
+    [InlineData("C")]
+    public async Task ExecuteInvitation_WithValidOrganisationName_DoesNotThrowException(string validName)
+    {
+        var invitationData = _fixture.Build<CompanyInvitationData>()
+            .With(x => x.OrganisationName, validName)
+            .Create();
+
+        Func<Task> Act = async () => await _sut.ExecuteInvitation(invitationData);
+
+        await Act.Should().NotThrowAsync<ControllerArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("Organisation Name ")] // Ends with whitespace
+    [InlineData("1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWX")] // Exceeds 160 characters
+    public async Task ExecuteInvitation_WithInvalidOrganisationName_ThrowsControllerArgumentException(string invalidName)
+    {
+        var invitationData = _fixture.Build<CompanyInvitationData>()
+            .With(x => x.OrganisationName, invalidName)
+            .Create();
+
+        async Task Act() => await _sut.ExecuteInvitation(invitationData);
+
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+        ex.Message.Should().Be($"OrganisationName: {ValidationExpressionErrorMessages.CompanyError} (Parameter 'organisationName')");
+        ex.ParamName.Should().Be("organisationName");
     }
 
     #endregion

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -123,10 +123,10 @@ public class InvitationBusinessLogicTests
     }
 
     [Theory]
-    [InlineData((string?)null)] // null value
+    [InlineData(null)] // null value
     [InlineData("Organisation Name ")] // Ends with whitespace
     [InlineData("1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWX")] // Exceeds 160 characters
-    public async Task ExecuteInvitation_WithInvalidOrganisationName_ThrowsControllerArgumentException(string invalidName)
+    public async Task ExecuteInvitation_WithInvalidOrganisationName_ThrowsControllerArgumentException(string? invalidName)
     {
         var invitationData = _fixture.Build<CompanyInvitationData>()
             .With(x => x.OrganisationName, invalidName)

--- a/tests/framework/Framework.Models.Tests/ValidationExpressionsTests.cs
+++ b/tests/framework/Framework.Models.Tests/ValidationExpressionsTests.cs
@@ -1,0 +1,67 @@
+
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using System.Text.RegularExpressions;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Tests;
+
+public class ValidationExpressionsTests
+{
+    private static readonly Regex regex = new Regex(ValidationExpressions.Company);
+
+    [Theory]
+    [InlineData("ValidCompanyName123", true)] // Valid company name
+    [InlineData("Company Name", true)] // Valid with space
+    [InlineData("Company$Name", true)] // Valid with special character
+    [InlineData("Company\\Name", true)] // Valid with backslash
+    [InlineData("Company/Name", true)] // Valid with forward slash
+    [InlineData("Company<Name>", true)] // Valid with angle brackets
+    [InlineData("Company Name!", true)] // Valid with exclamation mark
+    [InlineData("Company@Name", true)] // Valid with @ symbol
+    [InlineData("C", true)] // Minimum valid length
+    [InlineData("7-ELEVEN INTERNATIONAL LLC", true)]
+    [InlineData("Recht 24/7 Schröder Rechtsanwaltsgesellschaft mbH", true)]
+    [InlineData("Currency £$€¥¢", true)]
+    [InlineData("Brackets []()", true)]
+    [InlineData("Punctuation !?,.;:", true)]
+    [InlineData("Double \"Quote\" Company S.A.", true)]
+    [InlineData("Single 'Quote' Company LLC", true)]
+    [InlineData("Special Characters ^&%#@*/_-\\", true)]
+    [InlineData("German: ÄÖÜß", true)]
+    [InlineData("+SEN Inc.", true)] // leading special character
+    [InlineData("Danish: ÆØÅ", true)]
+    [InlineData("Bayerische Motoren Werke Aktiengesellschaft ", false)] // Ends with whitespace
+    [InlineData(" Bayerische Motoren Werke Aktiengesellschaft", false)] // starts with whitespace
+    [InlineData("Bayerische  Motoren Werke Aktiengesellschaft", false)] // double whitespace
+    [InlineData(@"123456789012345678901234567890
+                  123456789012345678901234567890
+                  123456789012345678901234567890
+                  123456789012345678901234567890
+                  123456789012345678901234567890
+                  12345678901234567890", false)] // Exceeds 160 characters
+    [InlineData("", false)] // Empty string
+    [InlineData(" ", false)] // Single space
+    [InlineData("   ", false)] // Multiple spaces
+    public void TestCompanyNameRegex(string companyName, bool expectedResult)
+    {
+        var result = ValidationExpressionsValidator.IsValidCompanyName(companyName);
+        Assert.Equal(expectedResult, result);
+    }
+}

--- a/tests/framework/Framework.Models.Tests/ValidationExpressionsTests.cs
+++ b/tests/framework/Framework.Models.Tests/ValidationExpressionsTests.cs
@@ -24,8 +24,6 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Tests;
 
 public class ValidationExpressionsTests
 {
-    private static readonly Regex regex = new Regex(ValidationExpressions.Company);
-
     [Theory]
     [InlineData("ValidCompanyName123", true)] // Valid company name
     [InlineData("Company Name", true)] // Valid with space

--- a/tests/framework/Framework.Models.Tests/ValidationExpressionsTests.cs
+++ b/tests/framework/Framework.Models.Tests/ValidationExpressionsTests.cs
@@ -59,7 +59,7 @@ public class ValidationExpressionsTests
     [InlineData("   ", false)] // Multiple spaces
     public void TestCompanyNameRegex(string companyName, bool expectedResult)
     {
-        var result = ValidationExpressionsValidator.IsValidCompanyName(companyName);
+        var result = companyName.IsValidCompanyName();
         Assert.Equal(expectedResult, result);
     }
 }

--- a/tests/framework/Framework.Models.Tests/ValidationExpressionsTests.cs
+++ b/tests/framework/Framework.Models.Tests/ValidationExpressionsTests.cs
@@ -1,6 +1,6 @@
 
 /********************************************************************************
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.


### PR DESCRIPTION
## Description

BE adjustment for: [portal-frontend-registration:216](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/216)

Extended pattern with additional currency characters and length adjustment.

Min length: 1
Max lenth: 160

Allows " (double quote \x22) to follow back-end implementation.
Allows £$€¥¢ to allow some additional currency symbols that are used in existing companies.

## Why

Much longer company names exist than currently allowed.

Example:
https://find-and-update.company-information.service.gov.uk/company/03249311 
88 characters

## Issue

Refs: eclipse-tractusx/portal#360

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
