### PR TITLE
fix(apps): remove leading '/' from the activate subscription endpoint

### DIFF
--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -230,7 +230,7 @@ public class AppsController : ControllerBase
     /// <response code="404">If sub claim is empty/invalid or user does not exist, or any other parameters are invalid.</response>
     /// <response code="500">Internal Server Error.</response>
     [HttpPut]
-    [Route("/subscription/{subscriptionId}/activate")]
+    [Route("subscription/{subscriptionId}/activate")]
     [Authorize(Roles = "activate_subscription")]
     [Authorize(Policy = PolicyTypes.ValidIdentity)]
     [Authorize(Policy = PolicyTypes.ValidCompany)]


### PR DESCRIPTION
## Description

the apps service routing definition of endpoint PUT /subscription/{subscriptionId}/activate is changed to PUT /api/apps/subscription/{subscriptionId}/activate

## Why

the service-internal definition of endpoint PUT /subscription/{subscriptionId}/activate is missing the path-prefix /api/apps and is therefore inaccessible as it is not routed to the service be the ingress.

## Issue

https://github.com/eclipse-tractusx/portal-backend/issues/856

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
