### PR TITLE
fix(offersubscription): suppress activation of external serviceaccounts on activation of offersubscription

### DIFF
--- a/src/marketplace/Offers.Library/Service/OfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSetupService.cs
@@ -712,7 +712,7 @@ public class OfferSetupService : IOfferSetupService
 
         try
         {
-            foreach (var serviceAccountClientId in offerDetails.ServiceAccountClientIds)
+            foreach (var serviceAccountClientId in offerDetails.InternalServiceAccountClientIds)
             {
                 await _provisioningManager.EnableClient(serviceAccountClientId).ConfigureAwait(ConfigureAwaitOptions.None);
             }

--- a/src/portalbackend/PortalBackend.DBAccess/Models/TriggerProviderInformation.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/TriggerProviderInformation.cs
@@ -49,5 +49,5 @@ public record SubscriptionActivationData(
     Guid? SalesManagerId,
     Guid? ProviderCompanyId,
     string? ClientClientId,
-    IEnumerable<string> ServiceAccountClientIds
+    IEnumerable<string> InternalServiceAccountClientIds
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -396,7 +396,7 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                 x.Offer.OfferTypeId == OfferTypeId.APP && (x.Offer.AppInstanceSetup == null || !x.Offer.AppInstanceSetup!.IsSingleInstance) ?
                     x.AppSubscriptionDetail!.AppInstance!.IamClient!.ClientClientId :
                     null,
-                x.CompanyServiceAccounts.Where(sa => sa.ClientClientId != null).Select(sa => sa.ClientClientId!)
+                x.CompanyServiceAccounts.Where(sa => sa.CompanyServiceAccountKindId == CompanyServiceAccountKindId.INTERNAL && sa.ClientClientId != null).Select(sa => sa.ClientClientId!)
             ))
             .SingleOrDefaultAsync();
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -490,6 +490,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         result!.OfferName.Should().Be("Trace-X");
         result.InstanceData.Should().Be((true, "https://test.com"));
         result.Status.Should().Be(OfferSubscriptionStatusId.ACTIVE);
+        result.InternalServiceAccountClientIds.Should().ContainSingle().Which.Should().Be("sa-os-internal");
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionViewTests.cs
@@ -49,7 +49,7 @@ public class OfferSubscriptionViewTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var result = await sut.OfferSubscriptionView.ToListAsync();
-        result.Should().HaveCount(14);
+        result.Should().HaveCount(15);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -68,5 +68,23 @@
     "company_service_account_kind_id": 1,
     "offer_subscription_id": null,
     "client_client_id": "sa-x-0"
+  },
+  {
+    "id": "a946f314-f53e-4c72-9124-40b72bcc59aa",
+    "name": "offersubscription-sa-0",
+    "description": "internal test user for offersubscription",
+    "company_service_account_type_id": 2,
+    "company_service_account_kind_id": 1,
+    "offer_subscription_id": "ed4de48d-fd4b-4384-a72f-ecae3c6cc5ba",
+    "client_client_id": "sa-os-internal"
+  },
+  {
+    "id": "4ce1b774-3d00-4e07-9a53-ae1f64193392",
+    "name": "offersubscription-sa-0",
+    "description": "internal test user for offersubscription",
+    "company_service_account_type_id": 2,
+    "company_service_account_kind_id": 2,
+    "offer_subscription_id": "ed4de48d-fd4b-4384-a72f-ecae3c6cc5ba",
+    "client_client_id": "sa-os-external"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
@@ -167,5 +167,23 @@
     "user_entity_id": "3d8142f1-860b-48aa-8c2b-1ccb18699f66",
     "identity_type_id": 2,
     "last_editor_id":"8b42e6de-7b59-4217-a63c-198e83d93777"
+  },
+  {
+    "id": "a946f314-f53e-4c72-9124-40b72bcc59aa",
+    "date_created": "2024-07-22 18:01:33.439000 +00:00",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "user_status_id": 1,
+    "user_entity_id": null,
+    "identity_type_id": 2,
+    "last_editor_id":"8b42e6de-7b59-4217-a63c-198e83d93777"
+  },
+  {
+    "id": "4ce1b774-3d00-4e07-9a53-ae1f64193392",
+    "date_created": "2024-07-22 18:01:33.439000 +00:00",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "user_status_id": 1,
+    "user_entity_id": null,
+    "identity_type_id": 2,
+    "last_editor_id":"8b42e6de-7b59-4217-a63c-198e83d93777"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -291,13 +291,15 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result!.Count.Should().Be(15);
+        result!.Count.Should().Be(17);
         result.Data.Should().HaveCount(10)
             .And.AllSatisfy(x => x.Should().Match<Models.CompanyServiceAccountData>(y =>
                 y.CompanyServiceAccountTypeId == CompanyServiceAccountTypeId.OWN &&
                 y.UserStatusId == UserStatusId.ACTIVE))
             .And.BeInAscendingOrder(x => x.Name)
             .And.Satisfy(
+                x => x.ServiceAccountId == new Guid("4ce1b774-3d00-4e07-9a53-ae1f64193392"),
+                x => x.ServiceAccountId == new Guid("a946f314-f53e-4c72-9124-40b72bcc59aa"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201029"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201026"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201027"),
@@ -305,9 +307,7 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
                 x => x.ServiceAccountId == new Guid("f3498fe6-e0e5-413b-a725-39bf5c7c1959"),
                 x => x.ServiceAccountId == new Guid("ab7f01ea-cbb9-4d58-9efa-ea992395f997"),
                 x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201031"),
-                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201032"),
-                x => x.ServiceAccountId == new Guid("33480038-9acf-40e2-9127-c9c7a9cbed99"),
-                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201023"));
+                x => x.ServiceAccountId == new Guid("7e85a0b8-0001-ab67-10d1-0ef508201032"));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

the query that retrieves the to-be-activated-on-keycloak service-accounts is being restricted to return service-accounts of CompanyServiceAccountKindId.INTERNAL only and the subscription is not being activated.

## Why

on activation of an autosetup-offersubscription that includes the creation of external (dim-) serviceaccounts the process-step ACTIVATE_SUBSCRIPTION tries to activate all serviceaccounts on keycloak. this includes the external-serviceaccounts that do not exist on keycloak which results in an error 'clientId <external client id>not found in central keycloak'

## Issue

https://github.com/eclipse-tractusx/portal-backend/issues/856

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
