### PR TITLE
feat(osp): endpoint to get onboarding osp companies details

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -32,6 +32,7 @@ public interface IRegistrationBusinessLogic
 {
     Task<CompanyWithAddressData> GetCompanyWithAddressAsync(Guid applicationId);
     Task<Pagination.Response<CompanyApplicationDetails>> GetCompanyApplicationDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, string? companyName = null);
+    Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, string? companyName = null);
     Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName = null);
     Task UpdateCompanyBpn(Guid applicationId, string bpn);
 

--- a/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -31,9 +31,9 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLog
 public interface IRegistrationBusinessLogic
 {
     Task<CompanyWithAddressData> GetCompanyWithAddressAsync(Guid applicationId);
-    Task<Pagination.Response<CompanyApplicationDetails>> GetCompanyApplicationDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, string? companyName = null);
-    Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, string? companyName = null);
-    Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName = null);
+    Task<Pagination.Response<CompanyApplicationDetails>> GetCompanyApplicationDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName);
+    Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName);
+    Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName);
     Task UpdateCompanyBpn(Guid applicationId, string bpn);
 
     /// <summary>

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -217,7 +217,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
                         application.Company.CompanyAssignedRoles.Select(companyAssignedRoles => companyAssignedRoles.CompanyRoleId),
                         application.Company.IdentityProviders.Select(x => new IdentityProvidersDetails(x.Id, x.IamIdentityProvider!.IamIdpAlias)),
                         application.Company.BusinessPartnerNumber,
-                        application.Company.Identities.Where(x => x.CompanyUser!.Identity!.UserStatusId != UserStatusId.DELETED).Count()))
+                        application.Company.Identities.Count(x => x.CompanyUser!.Identity!.UserStatusId != UserStatusId.DELETED)))
                     .AsAsyncEnumerable()));
     }
     public Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName)

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -35,6 +35,7 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.Mailing.Library;
@@ -63,6 +64,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
     private readonly IProvisioningManager _provisioningManager;
     private readonly IMailingProcessCreation _mailingProcessCreation;
     private readonly ILogger<RegistrationBusinessLogic> _logger;
+    private readonly IIdentityData _identityData;
 
     public RegistrationBusinessLogic(
         IPortalRepositories portalRepositories,
@@ -74,6 +76,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
         IIssuerComponentBusinessLogic issuerComponentBusinessLogic,
         IProvisioningManager provisioningManager,
         IMailingProcessCreation mailingProcessCreation,
+        IIdentityService identityService,
         ILogger<RegistrationBusinessLogic> logger)
     {
         _portalRepositories = portalRepositories;
@@ -86,6 +89,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
         _provisioningManager = provisioningManager;
         _mailingProcessCreation = mailingProcessCreation;
         _logger = logger;
+        _identityData = identityService.IdentityData;
     }
 
     public Task<CompanyWithAddressData> GetCompanyWithAddressAsync(Guid applicationId)
@@ -181,6 +185,42 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
                     .AsAsyncEnumerable()));
     }
 
+    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, string? companyName = null)
+    {
+        if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
+        {
+            throw new ControllerArgumentException("CompanyName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name", nameof(companyName));
+        }
+        var applications = _portalRepositories.GetInstance<IApplicationRepository>()
+            .GetCompanyApplicationsFilteredQuery(
+                companyName?.Length >= 3 ? companyName : null,
+                GetCompanyApplicationStatusIds(companyApplicationStatusFilter));
+
+        return Pagination.CreateResponseAsync(
+            page,
+            size,
+            _settings.ApplicationsMaxPageSize,
+            (skip, take) => new Pagination.AsyncSource<CompanyDetailsOspOnboarding>(
+                applications.CountAsync(),
+                applications
+                    .AsSplitQuery()
+                    .OrderByDescending(application => application.DateCreated)
+                    .Skip(skip)
+                    .Take(take)
+                    .Where(x => x.CompanyApplicationTypeId == CompanyApplicationTypeId.EXTERNAL && x.CompanyId == _identityData.CompanyId && x.OnboardingServiceProviderId != null)
+                    .Select(application => new CompanyDetailsOspOnboarding(
+                        application.CompanyId,
+                        application.Id,
+                        application.ApplicationStatusId,
+                        application.DateCreated,
+                        application.DateLastChanged,
+                        application.Company!.Name,
+                        application.Company!.CompanyAssignedRoles.Select(companyAssignedRoles => companyAssignedRoles.CompanyRoleId),
+                        application.Company.IdentityProviders.Select(x => new IdentityProvidersDetails(x.Id, x.IamIdentityProvider!.IamIdpAlias)),
+                        application.Company!.BusinessPartnerNumber,
+                        application.Company.Identities.Select(x => x.CompanyUser!.Identity!.UserStatusId != UserStatusId.DELETED).Count()))
+                    .AsAsyncEnumerable()));
+    }
     public Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName = null)
     {
         if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))

--- a/src/administration/Administration.Service/Controllers/RegistrationController.cs
+++ b/src/administration/Administration.Service/Controllers/RegistrationController.cs
@@ -560,4 +560,25 @@ public class RegistrationController : ControllerBase
         await _logic.RetriggerDeleteCentralUser(processId).ConfigureAwait(false);
         return NoContent();
     }
+
+    /// <summary>
+    /// Get OSP Company Application Detail by Company Name or Status
+    /// </summary>
+    /// <param name="page">page index start from 0</param>
+    /// <param name="size">size to get number of records</param>
+    /// <param name="companyApplicationStatusFilter">Search by company applicationstatus</param>
+    /// <param name="companyName">search by company name</param>
+    /// <returns>OSp Company Application Details</returns>
+    /// <remarks>
+    /// Example: GET: api/administration/registration/network/companies?companyName=Car&amp;page=0&amp;size=4&amp;companyApplicationStatus=Closed <br />
+    /// Example: GET: api/administration/registration/network/companies?page=0&amp;size=4
+    /// </remarks>
+    /// <response code="200">Result as a OSP Company Application Details</response>
+    [HttpGet]
+    [Authorize(Roles = "view_submitted_applications")]
+    [Authorize(Policy = PolicyTypes.ValidCompany)]
+    [Route("network/companies")]
+    [ProducesResponseType(typeof(Pagination.Response<CompanyDetailsOspOnboarding>), StatusCodes.Status200OK)]
+    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync([FromQuery] int page, [FromQuery] int size, [FromQuery] CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, [FromQuery] string? companyName = null) =>
+        _logic.GetOspCompanyDetailsAsync(page, size, companyApplicationStatusFilter, companyName);
 }

--- a/src/administration/Administration.Service/Models/CompanyDetailsOspOnboarding.cs
+++ b/src/administration/Administration.Service/Models/CompanyDetailsOspOnboarding.cs
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using System.Text.Json.Serialization;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+
+public record CompanyDetailsOspOnboarding(
+
+    [property: JsonPropertyName("companyId")] Guid CompanyId,
+    [property: JsonPropertyName("applicationId")] Guid ApplicationId,
+    [property: JsonPropertyName("applicationStatus")] CompanyApplicationStatusId CompanyApplicationStatusId,
+    [property: JsonPropertyName("applicationDateCreated")] DateTimeOffset DateCreated,
+    [property: JsonPropertyName("lastChangedDate")] DateTimeOffset? DateLastChanged,
+    [property: JsonPropertyName("companyName")] string CompanyName,
+    [property: JsonPropertyName("companyRoles")] IEnumerable<CompanyRoleId> CompanyRoles,
+    [property: JsonPropertyName("identityProvider")] IEnumerable<IdentityProvidersDetails> IdentityProviders,
+    [property: JsonPropertyName("bpn")] string BusinessPartnerNumber,
+    [property: JsonPropertyName("activeUsers")] int ActiveCompanyUsers
+);
+
+public record IdentityProvidersDetails(
+    Guid IdentityProviderId,
+    string? Alias
+    );
+

--- a/src/administration/Administration.Service/Models/CompanyDetailsOspOnboarding.cs
+++ b/src/administration/Administration.Service/Models/CompanyDetailsOspOnboarding.cs
@@ -32,12 +32,12 @@ public record CompanyDetailsOspOnboarding(
     [property: JsonPropertyName("companyName")] string CompanyName,
     [property: JsonPropertyName("companyRoles")] IEnumerable<CompanyRoleId> CompanyRoles,
     [property: JsonPropertyName("identityProvider")] IEnumerable<IdentityProvidersDetails> IdentityProviders,
-    [property: JsonPropertyName("bpn")] string BusinessPartnerNumber,
+    [property: JsonPropertyName("bpn")] string? BusinessPartnerNumber,
     [property: JsonPropertyName("activeUsers")] int ActiveCompanyUsers
 );
 
 public record IdentityProvidersDetails(
     Guid IdentityProviderId,
     string? Alias
-    );
+);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -128,13 +128,21 @@ public class ApplicationRepository(PortalDbContext portalDbContext)
                 ))
             .SingleOrDefaultAsync();
 
-    public IQueryable<CompanyApplication> GetCompanyApplicationsFilteredQuery(string? companyName = null, IEnumerable<CompanyApplicationStatusId>? applicationStatusIds = null) =>
+    public IQueryable<CompanyApplication> GetCompanyApplicationsFilteredQuery(string? companyName, IEnumerable<CompanyApplicationStatusId> applicationStatusIds) =>
         portalDbContext.CompanyApplications.AsNoTracking()
             .Where(application =>
                 (companyName == null || EF.Functions.ILike(application.Company!.Name, $"{companyName.EscapeForILike()}%")) &&
                 (applicationStatusIds == null || applicationStatusIds.Contains(application.ApplicationStatusId)));
 
-    public Task<CompanyApplicationDetailData?> GetCompanyApplicationDetailDataAsync(Guid applicationId, Guid userCompanyId, Guid? companyId = null) =>
+    public IQueryable<CompanyApplication> GetExternalCompanyApplicationsFilteredQuery(Guid onboardingServiceProviderId, string? companyName, IEnumerable<CompanyApplicationStatusId> applicationStatusIds) =>
+        portalDbContext.CompanyApplications.AsNoTracking()
+            .Where(application =>
+                application.CompanyApplicationTypeId == CompanyApplicationTypeId.EXTERNAL &&
+                application.OnboardingServiceProviderId == onboardingServiceProviderId &&
+                (companyName == null || EF.Functions.ILike(application.Company!.Name, $"{companyName.EscapeForILike()}%")) &&
+                applicationStatusIds.Contains(application.ApplicationStatusId));
+
+    public Task<CompanyApplicationDetailData?> GetCompanyApplicationDetailDataAsync(Guid applicationId, Guid userCompanyId, Guid? companyId) =>
         portalDbContext.CompanyApplications
             .AsNoTracking()
             .Where(application => application.Id == applicationId &&

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -33,8 +33,9 @@ public interface IApplicationRepository
     Task<(bool Exists, CompanyApplicationStatusId StatusId)> GetOwnCompanyApplicationUserDataAsync(Guid applicationId, Guid userCompanyId);
     Task<(bool Exists, bool IsUserOfCompany, CompanyApplicationStatusId ApplicationStatus)> GetOwnCompanyApplicationStatusUserDataUntrackedAsync(Guid applicationId, Guid companyId);
     Task<CompanyApplicationUserEmailData?> GetOwnCompanyApplicationUserEmailDataAsync(Guid applicationId, Guid companyUserId, IEnumerable<DocumentTypeId> submitDocumentTypeIds);
-    IQueryable<CompanyApplication> GetCompanyApplicationsFilteredQuery(string? companyName = null, IEnumerable<CompanyApplicationStatusId>? applicationStatusIds = null);
-    Task<CompanyApplicationDetailData?> GetCompanyApplicationDetailDataAsync(Guid applicationId, Guid userCompanyId, Guid? companyId = null);
+    IQueryable<CompanyApplication> GetCompanyApplicationsFilteredQuery(string? companyName, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
+    IQueryable<CompanyApplication> GetExternalCompanyApplicationsFilteredQuery(Guid onboardingServiceProviderId, string? companyName, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
+    Task<CompanyApplicationDetailData?> GetCompanyApplicationDetailDataAsync(Guid applicationId, Guid userCompanyId, Guid? companyId);
     Task<(string CompanyName, string? FirstName, string? LastName, string? Email, IEnumerable<(Guid ApplicationId, CompanyApplicationStatusId ApplicationStatusId, IEnumerable<(string? FirstName, string? LastName, string? Email)> InvitedUsers)> Applications)> GetCompanyApplicationsDeclineData(Guid companyUserId, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
     Task<(bool IsValidApplicationId, Guid CompanyId, bool IsSubmitted)> GetCompanyIdSubmissionStatusForApplication(Guid applicationId);
     Task<(Guid CompanyId, string CompanyName, string? BusinessPartnerNumber, IEnumerable<string> IamIdpAliasse, CompanyApplicationTypeId ApplicationTypeId, Guid? NetworkRegistrationProcessId)> GetCompanyAndApplicationDetailsForApprovalAsync(Guid applicationId);

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplication.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplication.cs
@@ -50,10 +50,10 @@ public class CompanyApplication : IAuditableV1, IBaseEntity
     public DateTimeOffset? DateLastChanged { get; set; }
 
     public CompanyApplicationStatusId ApplicationStatusId { get; set; }
-    public Guid CompanyId { get; private set; }
+    public Guid CompanyId { get; set; }
     public Guid? ChecklistProcessId { get; set; }
 
-    public CompanyApplicationTypeId CompanyApplicationTypeId { get; private set; }
+    public CompanyApplicationTypeId CompanyApplicationTypeId { get; set; }
 
     public Guid? OnboardingServiceProviderId { get; set; }
 

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplication.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplication.cs
@@ -50,10 +50,10 @@ public class CompanyApplication : IAuditableV1, IBaseEntity
     public DateTimeOffset? DateLastChanged { get; set; }
 
     public CompanyApplicationStatusId ApplicationStatusId { get; set; }
-    public Guid CompanyId { get; set; }
+    public Guid CompanyId { get; private set; }
     public Guid? ChecklistProcessId { get; set; }
 
-    public CompanyApplicationTypeId CompanyApplicationTypeId { get; set; }
+    public CompanyApplicationTypeId CompanyApplicationTypeId { get; private set; }
 
     public Guid? OnboardingServiceProviderId { get; set; }
 

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyApplicationStatusFilter.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyApplicationStatusFilter.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW Group AG
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -201,7 +201,7 @@ public class RegistrationBusinessLogic(
 
     public async Task<CompanyDetailData> GetCompanyDetailData(Guid applicationId)
     {
-        var result = await portalRepositories.GetInstance<IApplicationRepository>().GetCompanyApplicationDetailDataAsync(applicationId, _identityData.CompanyId).ConfigureAwait(ConfigureAwaitOptions.None);
+        var result = await portalRepositories.GetInstance<IApplicationRepository>().GetCompanyApplicationDetailDataAsync(applicationId, _identityData.CompanyId, null).ConfigureAwait(ConfigureAwaitOptions.None);
         if (result == null)
         {
             throw new NotFoundException($"CompanyApplication {applicationId} not found");

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -191,7 +191,6 @@ public class RegistrationBusinessLogicTest
     public async Task GetOspCompanyApplicationDetailsAsync_WithDefaultRequest_GetsExpectedEntries()
     {
         // Arrange
-        var companyAppStatus = new[] { CompanyApplicationStatusFilter.InReview, CompanyApplicationStatusFilter.Closed };
         var companyApplicationData = new AsyncEnumerableStub<CompanyApplication>(_fixture.Build<CompanyApplication>().With(x => x.CompanyId, CompanyId).With(x => x.CompanyApplicationTypeId, CompanyApplicationTypeId.EXTERNAL).CreateMany(3));
         A.CallTo(() => _applicationRepository.GetCompanyApplicationsFilteredQuery(A<string?>._, A<IEnumerable<CompanyApplicationStatusId>?>._))
             .Returns(companyApplicationData.AsQueryable());
@@ -207,7 +206,6 @@ public class RegistrationBusinessLogicTest
     public async Task GetOspCompanyApplicationDetailsAsync_WithInReviewRequest_GetsExpectedEntries()
     {
         // Arrange
-        var companyAppStatus = new[] { CompanyApplicationStatusFilter.InReview };
         var companyApplicationData = new AsyncEnumerableStub<CompanyApplication>(_fixture.Build<CompanyApplication>().With(x => x.CompanyId, CompanyId).With(x => x.CompanyApplicationTypeId, CompanyApplicationTypeId.EXTERNAL).CreateMany(3));
         A.CallTo(() => _applicationRepository.GetCompanyApplicationsFilteredQuery(A<string?>._, A<IEnumerable<CompanyApplicationStatusId>?>._))
             .Returns(companyApplicationData.AsQueryable());
@@ -223,7 +221,6 @@ public class RegistrationBusinessLogicTest
     public async Task GetOspCompanyApplicationDetailsAsync_WithClosedRequest_GetsExpectedEntries()
     {
         // Arrange
-        var companyAppStatus = new[] { CompanyApplicationStatusFilter.Closed };
         var companyApplicationData = new AsyncEnumerableStub<CompanyApplication>(_fixture.Build<CompanyApplication>().With(x => x.CompanyId, CompanyId).With(x => x.CompanyApplicationTypeId, CompanyApplicationTypeId.EXTERNAL).CreateMany(3));
         A.CallTo(() => _applicationRepository.GetCompanyApplicationsFilteredQuery(A<string?>._, A<IEnumerable<CompanyApplicationStatusId>?>._))
             .Returns(companyApplicationData.AsQueryable());

--- a/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
@@ -72,6 +72,23 @@ public class RegistrationControllerTest
     }
 
     [Fact]
+    public async Task GetOspCompanyApplicationDetailsAsync_ReturnsCompanyApplicationDetails()
+    {
+        //Arrange
+        var paginationResponse = new Pagination.Response<CompanyDetailsOspOnboarding>(new Pagination.Metadata(15, 1, 1, 15), _fixture.CreateMany<CompanyDetailsOspOnboarding>(5));
+        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(0, 15, null, null))
+                  .Returns(paginationResponse);
+
+        //Act
+        var result = await _controller.GetOspCompanyDetailsAsync(0, 15, null, null);
+
+        //Assert
+        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(0, 15, null, null)).MustHaveHappenedOnceExactly();
+        Assert.IsType<Pagination.Response<CompanyDetailsOspOnboarding>>(result);
+        result.Content.Should().HaveCount(5);
+    }
+
+    [Fact]
     public async Task GetCompanyWithAddressAsync_ReturnsExpectedResult()
     {
         //Arrange


### PR DESCRIPTION
## Description

      GET endpoint should be accessible at /api/administration/registration/network/companies.
      Paginated response with max 20 records per page along with sorting, filtering and authorisation is required.


## Why

Need this api  to retrieve a list of all Onboarded OSP (Onboarding Service Provider) companies along with their current ### status

## Issue

#808

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
