### PR TITLE
fix: enhance subscription/provider endpoint with external Service data

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -234,7 +234,7 @@ public class AppsBusinessLogic : IAppsBusinessLogic
 
     /// <inheritdoc />
     public Task<AppProviderSubscriptionDetailData> GetSubscriptionDetailForProvider(Guid appId, Guid subscriptionId) =>
-        _offerService.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, _settings.CompanyAdminRoles);
+        _offerService.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, _settings.CompanyAdminRoles, new WalletConfigData(_settings.IssuerDid, _settings.BpnDidResolverUrl, _settings.DecentralIdentityManagementAuthUrl));
 
     /// <inheritdoc />
     public Task<SubscriberSubscriptionDetailData> GetSubscriptionDetailForSubscriber(Guid appId, Guid subscriptionId) =>

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
@@ -225,6 +225,15 @@ public class AppsSettings
     [Required]
     [DistinctValues("x => x.DocumentTypeId")]
     public IEnumerable<UploadDocumentConfig> UploadActiveAppDocumentTypeIds { get; set; } = null!;
+
+    [Required(AllowEmptyStrings = true)]
+    public string DecentralIdentityManagementAuthUrl { get; set; } = null!;
+
+    [Required(AllowEmptyStrings = true)]
+    public string IssuerDid { get; set; } = null!;
+
+    [Required(AllowEmptyStrings = true)]
+    public string BpnDidResolverUrl { get; set; } = null!;
 }
 
 /// <summary>

--- a/src/marketplace/Offers.Library/Models/WalletConfigData.cs
+++ b/src/marketplace/Offers.Library/Models/WalletConfigData.cs
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
+
+public record WalletConfigData(
+    string IssuerDid,
+    string BpnDidResolverUrl,
+    string DecentralIdentityManagementAuthUrl
+);

--- a/src/marketplace/Offers.Library/Service/IOfferService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferService.cs
@@ -248,8 +248,9 @@ public interface IOfferService
     /// <param name="subscriptionId">Id of the subscription</param>
     /// <param name="offerTypeId">Offer type</param>
     /// <param name="contactUserRoles">The roles of the users that will be listed as contact</param>
+    /// <param name="walletData">The information for the external service data</param>
     /// <returns>Returns the details of the subscription</returns>
-    Task<AppProviderSubscriptionDetailData> GetAppSubscriptionDetailsForProviderAsync(Guid offerId, Guid subscriptionId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> contactUserRoles);
+    Task<AppProviderSubscriptionDetailData> GetAppSubscriptionDetailsForProviderAsync(Guid offerId, Guid subscriptionId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> contactUserRoles, WalletConfigData walletData);
 
     /// <summary>
     /// Unsubscribe the Offer subscription by subscriptionId

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -828,6 +828,7 @@ public class OfferService : IOfferService
     {
         var data = await GetOfferSubscriptionDetailsInternal(offerId, subscriptionId, offerTypeId, contactUserRoles, OfferCompanyRole.Provider, _portalRepositories.GetInstance<IOfferSubscriptionsRepository>().GetAppSubscriptionDetailsForProviderAsync)
             .ConfigureAwait(ConfigureAwaitOptions.None);
+
         return new AppProviderSubscriptionDetailData(
             data.Id,
             data.OfferSubscriptionStatus,
@@ -843,7 +844,7 @@ public class OfferService : IOfferService
             new SubscriptionExternalServiceData(
                 walletData.IssuerDid,
                 data.ExternalServiceData?.ParticipantId,
-                data.ExternalServiceData?.TrustedIssuer == null || data.ExternalServiceData.TrustedIssuer.EndsWith(":holder-iatp") ? data.ExternalServiceData?.TrustedIssuer : $"{data.ExternalServiceData.TrustedIssuer}:holder-iatp",
+                data.ExternalServiceData == null || data.ExternalServiceData.TrustedIssuer.EndsWith(":holder-iatp") ? data.ExternalServiceData?.TrustedIssuer : $"{data.ExternalServiceData.TrustedIssuer}:holder-iatp",
                 walletData.BpnDidResolverUrl,
                 walletData.DecentralIdentityManagementAuthUrl,
                 data.ExternalServiceData?.DecentralIdentityManagementServiceUrl));

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -824,11 +824,29 @@ public class OfferService : IOfferService
         GetOfferSubscriptionDetailsInternal(offerId, subscriptionId, offerTypeId, contactUserRoles, OfferCompanyRole.Provider, _portalRepositories.GetInstance<IOfferSubscriptionsRepository>().GetSubscriptionDetailsForProviderAsync);
 
     /// <inheritdoc />
-    public async Task<AppProviderSubscriptionDetailData> GetAppSubscriptionDetailsForProviderAsync(Guid offerId, Guid subscriptionId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> contactUserRoles)
+    public async Task<AppProviderSubscriptionDetailData> GetAppSubscriptionDetailsForProviderAsync(Guid offerId, Guid subscriptionId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> contactUserRoles, WalletConfigData walletData)
     {
         var data = await GetOfferSubscriptionDetailsInternal(offerId, subscriptionId, offerTypeId, contactUserRoles, OfferCompanyRole.Provider, _portalRepositories.GetInstance<IOfferSubscriptionsRepository>().GetAppSubscriptionDetailsForProviderAsync)
             .ConfigureAwait(ConfigureAwaitOptions.None);
-        return new AppProviderSubscriptionDetailData(data.Id, data.OfferSubscriptionStatus, data.Name, data.Customer, data.Bpn, data.Contact, data.TechnicalUserData, data.TenantUrl, data.AppInstanceId, data.ProcessSteps.GetProcessStepTypeId(data.Id, _logger));
+        return new AppProviderSubscriptionDetailData(
+            data.Id,
+            data.OfferSubscriptionStatus,
+            data.Name,
+            data.Customer,
+            data.Bpn,
+            data.Contact,
+            data.TechnicalUserData,
+            data.ConnectorData,
+            data.TenantUrl,
+            data.AppInstanceId,
+            data.ProcessSteps.GetProcessStepTypeId(data.Id, _logger),
+            new SubscriptionExternalServiceData(
+                walletData.IssuerDid,
+                data.ExternalServiceData?.ParticipantId,
+                data.ExternalServiceData?.TrustedIssuer == null || data.ExternalServiceData.TrustedIssuer.EndsWith(":holder-iatp") ? data.ExternalServiceData?.TrustedIssuer : $"{data.ExternalServiceData.TrustedIssuer}:holder-iatp",
+                walletData.BpnDidResolverUrl,
+                walletData.DecentralIdentityManagementAuthUrl,
+                data.ExternalServiceData?.DecentralIdentityManagementServiceUrl));
     }
 
     /// <inheritdoc />

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionDetailData.cs
@@ -69,9 +69,20 @@ public record AppProviderSubscriptionDetailData(
     string? Bpn,
     IEnumerable<string> Contact,
     IEnumerable<SubscriptionTechnicalUserData> TechnicalUserData,
+    IEnumerable<SubscriptionAssignedConnectorData> ConnectorData,
     string? TenantUrl,
     string AppInstanceId,
-    ProcessStepTypeId? ProcessStepTypeId
+    ProcessStepTypeId? ProcessStepTypeId,
+    SubscriptionExternalServiceData ExternalService
+);
+
+public record SubscriptionExternalServiceData(
+    [property: JsonPropertyName("trusted_issuer")] string TrustedIssuer,
+    [property: JsonPropertyName("participant_id")] string? ParticipantId,
+    [property: JsonPropertyName("iatp_id")] string? IatpId,
+    [property: JsonPropertyName("did_resolver")] string DidResolver,
+    [property: JsonPropertyName("decentralIdentityManagementAuthUrl")] string DecentralIdentityManagementAuthUrl,
+    [property: JsonPropertyName("decentralIdentityManagementServiceUrl")] string? DecentralIdentityManagementServiceUrl
 );
 
 /// <summary>
@@ -126,5 +137,13 @@ public record AppProviderSubscriptionDetail(
     IEnumerable<SubscriptionTechnicalUserData> TechnicalUserData,
     string? TenantUrl,
     string AppInstanceId,
-    IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId)> ProcessSteps
+    IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId)> ProcessSteps,
+    IEnumerable<SubscriptionAssignedConnectorData> ConnectorData,
+    ExternalServiceData? ExternalServiceData
+);
+
+public record ExternalServiceData(
+    [property: JsonPropertyName("trusted_issuer")] string TrustedIssuer,
+    [property: JsonPropertyName("participant_id")] string? ParticipantId,
+    [property: JsonPropertyName("decentralIdentityManagementServiceUrl")] string DecentralIdentityManagementServiceUrl
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -244,7 +244,9 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                             .Select(ps => new ValueTuple<ProcessStepTypeId, ProcessStepStatusId>(
                                 ps.ProcessStepTypeId,
                                 ps.ProcessStepStatusId))
-                            .Distinct())
+                            .Distinct(),
+                        x.Subscription.ConnectorAssignedOfferSubscriptions.Select(c => new SubscriptionAssignedConnectorData(c.ConnectorId, c.Connector!.Name, c.Connector.ConnectorUrl)),
+                        x.Company.CompanyWalletData == null ? null : new ExternalServiceData(x.Company.CompanyWalletData!.Did, x.Company.BusinessPartnerNumber, x.Company.CompanyWalletData.AuthenticationServiceUrl))
                     : null))
             .SingleOrDefaultAsync();
 

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
@@ -507,7 +507,7 @@ public class AppBusinessLogicTests
                 new UserRoleConfig("ClientTest", new[] {"Test"})
             }
         };
-        A.CallTo(() => _offerService.GetAppSubscriptionDetailsForProviderAsync(A<Guid>._, A<Guid>._, A<OfferTypeId>._, A<IEnumerable<UserRoleConfig>>._))
+        A.CallTo(() => _offerService.GetAppSubscriptionDetailsForProviderAsync(A<Guid>._, A<Guid>._, A<OfferTypeId>._, A<IEnumerable<UserRoleConfig>>._, A<WalletConfigData>._))
             .Returns(data);
         var sut = new AppsBusinessLogic(null!, null!, _offerService, null!, Options.Create(settings), _identityService, _logger);
 
@@ -516,7 +516,7 @@ public class AppBusinessLogicTests
 
         // Assert
         result.Should().Be(data);
-        A.CallTo(() => _offerService.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, A<IEnumerable<UserRoleConfig>>._))
+        A.CallTo(() => _offerService.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, A<IEnumerable<UserRoleConfig>>._, A<WalletConfigData>._))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/marketplace/Apps.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/marketplace/Apps.Service.Tests/appsettings.IntegrationTests.json
@@ -234,7 +234,10 @@
       }
     ],
     "OfferSubscriptionAddress": "https://test.de",
-    "OfferDetailAddress": "https://detail.de"
+    "OfferDetailAddress": "https://detail.de",
+    "DecentralIdentityManagementAuthUrl": "https://test.org/auth",
+    "IssuerDid": "did:web:example.org:test123",
+    "BpnDidResolverUrl": "https://test.org/bpn-did"
   },
   "Provisioning": {
     "CentralRealm": "CX-Central",

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -2218,11 +2218,12 @@ public class OfferServiceTests
         var offerId = Guid.NewGuid();
         var subscriptionId = Guid.NewGuid();
         var companyAdminRoles = _fixture.CreateMany<UserRoleConfig>().ToImmutableArray();
+        var walletData = _fixture.Create<WalletConfigData>();
 
         SetupGetSubscriptionDetailForProvider();
 
         // Act
-        async Task Act() => await _sut.GetAppSubscriptionDetailsForProviderAsync(offerId, subscriptionId, OfferTypeId.APP, companyAdminRoles);
+        async Task Act() => await _sut.GetAppSubscriptionDetailsForProviderAsync(offerId, subscriptionId, OfferTypeId.APP, companyAdminRoles, walletData);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConfigurationException>(Act);
@@ -2243,13 +2244,14 @@ public class OfferServiceTests
         {
             new UserRoleConfig("ClientTest", new[] {"Test"})
         };
+        var walletData = _fixture.Create<WalletConfigData>();
         SetupGetSubscriptionDetailForProvider();
 
         A.CallTo(() => _offerSubscriptionsRepository.GetAppSubscriptionDetailsForProviderAsync(A<Guid>._, A<Guid>._, A<Guid>._, A<OfferTypeId>._, A<IEnumerable<Guid>>._))
             .Returns<(bool, bool, AppProviderSubscriptionDetail?)>(default);
 
         // Act
-        async Task Act() => await _sut.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, companyAdminRoles);
+        async Task Act() => await _sut.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, companyAdminRoles, walletData);
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
@@ -2270,13 +2272,14 @@ public class OfferServiceTests
         {
             new UserRoleConfig("ClientTest", new[] {"Test"})
         };
+        var walletData = _fixture.Create<WalletConfigData>();
         SetupGetSubscriptionDetailForProvider();
 
         A.CallTo(() => _offerSubscriptionsRepository.GetAppSubscriptionDetailsForProviderAsync(A<Guid>._, A<Guid>._, A<Guid>._, A<OfferTypeId>._, A<IEnumerable<Guid>>._))
             .Returns((true, false, _fixture.Create<AppProviderSubscriptionDetail>()));
 
         // Act
-        async Task Act() => await _sut.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, companyAdminRoles);
+        async Task Act() => await _sut.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, companyAdminRoles, walletData);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
@@ -2297,6 +2300,7 @@ public class OfferServiceTests
         {
             new UserRoleConfig("ClientTest", new[] {"Test"})
         };
+        var walletData = _fixture.Create<WalletConfigData>();
         SetupGetSubscriptionDetailForProvider();
 
         var data = _fixture.Create<AppProviderSubscriptionDetail>();
@@ -2305,7 +2309,7 @@ public class OfferServiceTests
             .Returns((true, true, data));
 
         // Act
-        var result = await _sut.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, companyAdminRoles);
+        var result = await _sut.GetAppSubscriptionDetailsForProviderAsync(appId, subscriptionId, OfferTypeId.APP, companyAdminRoles, walletData);
 
         // Assert
         result.Id.Should().Be(data.Id);


### PR DESCRIPTION
## Description

Enhance endpoint GET /api/apps/{appId}/subscription/{subscriptionId}/provider to also return external service for the edc

## Why

To provide useful information for the edc connection

## Issue

Rest: #841

## Corresponding CD PR:

https://github.com/eclipse-tractusx/portal/pull/385

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
