### PR TITLE
fix(processWorker): add default clientPrefix

### DIFF
--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -209,6 +209,7 @@
       "enabled": true,
       "emailVerified": true
     },
+    "ClientPrefix": "app",
     "ServiceAccountClientPrefix": "sa",
     "ServiceAccountClient": {
       "clientId": "",


### PR DESCRIPTION
## Description

default clientPrefix has been added to Process-workers appsettings.json

## Why

ProcessWorker would create new clients with pure numerical clientid without prefix

## Issue

#856

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have checked that new and existing tests pass locally with my changes
