### PR TITLE
fix(decline): removed active flag to get the name

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -202,11 +202,16 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
                     {
                         Application = application,
                         CompanyUser = application.Invitations.Select(invitation => invitation.CompanyUser)
-                    .FirstOrDefault(companyUser =>
-                         companyUser!.Firstname != null
-                        && companyUser.Lastname != null
-                        && companyUser.Email != null
-                    )
+                                .FirstOrDefault(companyUser =>
+                                    companyUser!.Identity!.UserStatusId == UserStatusId.ACTIVE
+                                    && companyUser!.Firstname != null
+                                    && companyUser.Lastname != null
+                                    && companyUser.Email != null)
+                            ?? application.Invitations.Select(invitation => invitation.CompanyUser)
+                                .FirstOrDefault(companyUser =>
+                                    companyUser!.Firstname != null
+                                    && companyUser.Lastname != null
+                                    && companyUser.Email != null)
                     })
                     .Select(s => new CompanyApplicationWithCompanyUserDetails(
                         s.Application.Id,

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -201,14 +201,17 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
                     .Select(application => new
                     {
                         Application = application,
-                        CompanyUser = application.Invitations.Select(invitation => invitation.CompanyUser)
-                                .FirstOrDefault(companyUser =>
+                        CompanyUsers = application.Invitations.Select(invitation => invitation.CompanyUser)
+                    })
+                    .Select(x => new
+                    {
+                        x.Application,
+                        CompanyUser = x.CompanyUsers.FirstOrDefault(companyUser =>
                                     companyUser!.Identity!.UserStatusId == UserStatusId.ACTIVE
                                     && companyUser!.Firstname != null
                                     && companyUser.Lastname != null
                                     && companyUser.Email != null)
-                            ?? application.Invitations.Select(invitation => invitation.CompanyUser)
-                                .FirstOrDefault(companyUser =>
+                            ?? x.CompanyUsers.FirstOrDefault(companyUser =>
                                     companyUser!.Firstname != null
                                     && companyUser.Lastname != null
                                     && companyUser.Email != null)

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -203,8 +203,7 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
                         Application = application,
                         CompanyUser = application.Invitations.Select(invitation => invitation.CompanyUser)
                     .FirstOrDefault(companyUser =>
-                        companyUser!.Identity!.UserStatusId == UserStatusId.ACTIVE
-                        && companyUser.Firstname != null
+                         companyUser!.Firstname != null
                         && companyUser.Lastname != null
                         && companyUser.Email != null
                     )


### PR DESCRIPTION
## Description

Removed active flag to get the user details in case of declined application
fixes #871 closes #871 

## Why

Currently in portal ‘Invite a new partner’ page shows blank in Full name if user declines the registration.
Because user is no longer active in DB so this code just returns null .

## Issue

[Issue 871](https://github.com/eclipse-tractusx/portal-backend/issues/871)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
