### PR TITLE
fix(sdDoc): set process step to skipped if ClearinghouseConnectDisabed is true

### DIFF
--- a/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
+++ b/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
@@ -52,7 +52,7 @@ public class SdFactoryBusinessLogic(
         if (_settings.ClearinghouseConnectDisabled)
         {
             return new IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult(
-                ProcessStepStatusId.DONE,
+                ProcessStepStatusId.SKIPPED,
                 entry => entry.ApplicationChecklistEntryStatusId = ApplicationChecklistEntryStatusId.DONE,
                 new[] { ProcessStepTypeId.ACTIVATE_APPLICATION },
                 null,


### PR DESCRIPTION
## Description

set process step to skipped if ClearinghouseConnectDisabed is true

## Why

The process step was set to done before, but should be set to skipped

## Issue

Refs: #792

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
