### PR TITLE
fix(bpdm): allow null values for geographic coordinate altitude

### DIFF
--- a/src/externalsystems/Bpdm.Library/Models/BpdmAddressDto.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmAddressDto.cs
@@ -92,7 +92,7 @@ public record BpdmPostalDeliveryPointDto(
 );
 
 public record BpdmGeographicCoordinatesDto(
-    double Longitude,
-    double Latitude,
-    double Altitude
+    double? Longitude,
+    double? Latitude,
+    double? Altitude
 );

--- a/src/externalsystems/Bpdm.Library/Models/BpdmAddressDto.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmAddressDto.cs
@@ -92,7 +92,7 @@ public record BpdmPostalDeliveryPointDto(
 );
 
 public record BpdmGeographicCoordinatesDto(
-    double? Longitude,
-    double? Latitude,
+    double Longitude,
+    double Latitude,
     double? Altitude
 );

--- a/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityData.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityData.cs
@@ -34,8 +34,8 @@ public record BpdmState(
 );
 
 public record BpdmGeographicCoordinates(
-    double? Longitude,
-    double? Latitude,
+    double Longitude,
+    double Latitude,
     double? Altitude
 );
 

--- a/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityData.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityData.cs
@@ -34,9 +34,9 @@ public record BpdmState(
 );
 
 public record BpdmGeographicCoordinates(
-    double Longitude,
-    double Latitude,
-    double Altitude
+    double? Longitude,
+    double? Latitude,
+    double? Altitude
 );
 
 public record BpdmPutStreet(

--- a/tests/externalsystems/Bpdm.Library/BPNAccessTest.cs
+++ b/tests/externalsystems/Bpdm.Library/BPNAccessTest.cs
@@ -136,7 +136,7 @@ public class BPNAccessTest
                     ""geographicCoordinates"": {
                         ""longitude"": 0.0,
                         ""latitude"": 0.0,
-                        ""altitude"": 0.0
+                        ""altitude"": null
                     },
                     ""country"": {
                         ""technicalKey"": ""DE"",

--- a/tests/externalsystems/Bpdm.Library/BpdmServiceTests.cs
+++ b/tests/externalsystems/Bpdm.Library/BpdmServiceTests.cs
@@ -361,7 +361,7 @@ public class BpdmServiceTests
                         ""geographicCoordinates"": {
                             ""longitude"": 0,
                             ""latitude"": 0,
-                            ""altitude"": 0
+                            ""altitude"": null
                         },
                         ""country"": ""UNDEFINED"",
                         ""administrativeAreaLevel1"": ""string"",


### PR DESCRIPTION
## Description

Nullable double for altitude in coordinates allowed. Test case adjusted.

As per BPDM specification.

## Why

Null altitude breaks onboarding. Altitude is rarely set.

## Issue

Refs: #881

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
