### PR TITLE
feat(registration): new attribute type added in registration application endpoint

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -181,7 +181,8 @@ public sealed class RegistrationBusinessLogic : IRegistrationBusinessLogic
                                 && companyUser.Email != null)
                             .Select(companyUser => companyUser!.Email)
                             .FirstOrDefault(),
-                        application.Company.BusinessPartnerNumber))
+                        application.Company.BusinessPartnerNumber,
+                        application.CompanyApplicationTypeId))
                     .AsAsyncEnumerable()));
     }
 

--- a/src/administration/Administration.Service/Models/CompanyApplicationDetails.cs
+++ b/src/administration/Administration.Service/Models/CompanyApplicationDetails.cs
@@ -31,7 +31,9 @@ public record CompanyApplicationDetails(
     [property: JsonPropertyName("companyRoles")] IEnumerable<CompanyRoleId> CompanyRoles,
     [property: JsonPropertyName("applicationChecklist")] IEnumerable<ApplicationChecklistEntryDetails> ApplicationChecklist,
     [property: JsonPropertyName("email")] string? Email,
-    [property: JsonPropertyName("bpn")] string? BusinessPartnerNumber
+    [property: JsonPropertyName("bpn")] string? BusinessPartnerNumber,
+    [property: JsonPropertyName("type")] CompanyApplicationTypeId CompanyApplicationTypeId
+
 );
 
 public record ApplicationChecklistEntryDetails(


### PR DESCRIPTION
## Description

Enhance the /api/administration/registration/applications?size=10&page=0 endpoint by adding a new attribute "type" to the response, which indicates whether the application is "external" or "internal". This information is available at the application level in the database.

## Why

Retrieve the "type" information from the application-level data in the database.
Ensure the "type" attribute is properly mapped and included in the endpoint response.
Update the existing response structure to include the new "type" attribute for each application in the "content" array.

## Issue

#842 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
