### PR TITLE
feat(bpdm): add sharing state ready toggle

### DIFF
--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -295,7 +295,9 @@
       "ClientSecret": "",
       "Scope": "",
       "TokenAddress": "",
-      "BaseAddress": ""
+      "BaseAddress": "",
+      "UseDimWallet": false,
+      "TriggerSharingState": false
     },
     "Clearinghouse": {
       "Username": "",

--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -297,7 +297,7 @@
       "TokenAddress": "",
       "BaseAddress": "",
       "UseDimWallet": false,
-      "TriggerSharingState": false
+      "StartSharingStateAsReady": false
     },
     "Clearinghouse": {
       "Username": "",

--- a/src/externalsystems/Bpdm.Library/BpdmServiceSettings.cs
+++ b/src/externalsystems/Bpdm.Library/BpdmServiceSettings.cs
@@ -32,4 +32,6 @@ public class BpdmServiceSettings : KeyVaultAuthSettings
     public string BaseAddress { get; set; } = null!;
 
     public bool UseDimWallet { get; set; }
+
+    public bool StartAsReady { get; set; }
 }

--- a/src/externalsystems/Bpdm.Library/BpdmServiceSettings.cs
+++ b/src/externalsystems/Bpdm.Library/BpdmServiceSettings.cs
@@ -33,5 +33,5 @@ public class BpdmServiceSettings : KeyVaultAuthSettings
 
     public bool UseDimWallet { get; set; }
 
-    public bool StartAsReady { get; set; }
+    public bool StartSharingStateAsReady { get; set; }
 }

--- a/src/externalsystems/Bpdm.Library/BusinessLogic/BpdmBusinessLogic.cs
+++ b/src/externalsystems/Bpdm.Library/BusinessLogic/BpdmBusinessLogic.cs
@@ -84,7 +84,7 @@ public class BpdmBusinessLogic(
             data.Identifiers);
 
         await bpdmService.PutInputLegalEntity(bpdmTransferData, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
-        if (!_settings.StartAsReady)
+        if (!_settings.StartSharingStateAsReady)
         {
             await bpdmService.SetSharingStateToReady(context.ApplicationId.ToString(), cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
         }

--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -322,7 +322,7 @@
       "TokenAddress": "",
       "BaseAddress": "",
       "UseDimWallet": false,
-      "TriggerSharingState": false
+      "StartSharingStateAsReady": false
     },
     "SdFactory":{
       "Username": "",

--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -321,7 +321,8 @@
       "Scope": "",
       "TokenAddress": "",
       "BaseAddress": "",
-      "UseDimWallet": false
+      "UseDimWallet": false,
+      "TriggerSharingState": false
     },
     "SdFactory":{
       "Username": "",

--- a/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
@@ -303,7 +303,9 @@
       "ClientSecret": "test",
       "Scope": "test",
       "TokenAddress": "test",
-      "BaseAddress": "test"
+      "BaseAddress": "test",
+      "UseDimWallet": false,
+      "TriggerSharingState": false
     },
     "Clearinghouse": {
       "Username": "test",

--- a/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
@@ -305,7 +305,7 @@
       "TokenAddress": "test",
       "BaseAddress": "test",
       "UseDimWallet": false,
-      "TriggerSharingState": false
+      "StartSharingStateAsReady": false
     },
     "Clearinghouse": {
       "Username": "test",

--- a/tests/externalsystems/Bpdm.Library/BpdmBusinessLogicTests.cs
+++ b/tests/externalsystems/Bpdm.Library/BpdmBusinessLogicTests.cs
@@ -50,6 +50,7 @@ public class BpdmBusinessLogicTests
     private readonly IBpdmService _bpdmService;
     private readonly BpdmBusinessLogic _logic;
     private readonly IPortalRepositories _portalRepositories;
+    private readonly IOptions<BpdmServiceSettings> _options;
 
     public BpdmBusinessLogicTests()
     {
@@ -62,12 +63,12 @@ public class BpdmBusinessLogicTests
         _applicationRepository = A.Fake<IApplicationRepository>();
         _companyRepository = A.Fake<ICompanyRepository>();
         _bpdmService = A.Fake<IBpdmService>();
-        var options = A.Fake<IOptions<BpdmServiceSettings>>();
+        _options = A.Fake<IOptions<BpdmServiceSettings>>();
 
         A.CallTo(() => _portalRepositories.GetInstance<IApplicationRepository>()).Returns(_applicationRepository);
         A.CallTo(() => _portalRepositories.GetInstance<ICompanyRepository>()).Returns(_companyRepository);
 
-        _logic = new BpdmBusinessLogic(_portalRepositories, _bpdmService, options);
+        _logic = new BpdmBusinessLogic(_portalRepositories, _bpdmService, _options);
     }
 
     #endregion
@@ -80,9 +81,9 @@ public class BpdmBusinessLogicTests
         // Arrange
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
-                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO },
+                { ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -104,9 +105,9 @@ public class BpdmBusinessLogicTests
         var applicationId = Guid.NewGuid();
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
-                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO },
+                { ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(applicationId, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -126,9 +127,9 @@ public class BpdmBusinessLogicTests
         // Arrange
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
-                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO },
+                { ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithoutZipCode, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -149,9 +150,9 @@ public class BpdmBusinessLogicTests
         // Arrange
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
-                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO },
+                { ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithoutZipCode, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -172,9 +173,9 @@ public class BpdmBusinessLogicTests
         // Arrange
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
-                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO },
+                { ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithoutZipCode, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -195,9 +196,9 @@ public class BpdmBusinessLogicTests
         // Arrange
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
-                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO },
+                { ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithoutZipCode, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -212,23 +213,39 @@ public class BpdmBusinessLogicTests
         ex.Message.Should().Be("StreetName must not be empty");
     }
 
-    [Fact]
-    public async Task PushLegalEntity_WithValidData_CallsExpected()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task PushLegalEntity_WithValidData_CallsExpected(bool startAsReady)
     {
         // Arrange
         var entry = new ApplicationChecklistEntry(IdWithBpn, ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO, DateTimeOffset.UtcNow);
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
-                {ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO },
+                { ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
         SetupFakesForTrigger();
+        A.CallTo(() => _options.Value).Returns(new BpdmServiceSettings
+        {
+            Password = "test",
+            Username = "test",
+            Scope = "test",
+            BaseAddress = "test",
+            ClientId = "cl1",
+            ClientSecret = "test",
+            GrantType = "test",
+            TokenAddress = "https://example.org/token",
+            UseDimWallet = false,
+            StartAsReady = startAsReady
+        });
+        var logic = new BpdmBusinessLogic(_portalRepositories, _bpdmService, _options);
 
         // Act
-        var result = await _logic.PushLegalEntity(context, CancellationToken.None);
+        var result = await logic.PushLegalEntity(context, CancellationToken.None);
 
         // Assert
         result.Modified.Should().BeTrue();
@@ -238,6 +255,8 @@ public class BpdmBusinessLogicTests
                 A<BpdmTransferData>.That.Matches(x => x.ZipCode == "50668" && x.CompanyName == ValidCompanyName),
                 A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _bpdmService.SetSharingStateToReady(A<string>._, A<CancellationToken>._))
+            .MustHaveHappened(startAsReady ? 0 : 1, Times.Exactly);
     }
 
     #endregion
@@ -251,8 +270,8 @@ public class BpdmBusinessLogicTests
         var applicationId = Guid.NewGuid();
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(applicationId, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -272,8 +291,8 @@ public class BpdmBusinessLogicTests
         // Arrange
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithStateCreated, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -284,7 +303,7 @@ public class BpdmBusinessLogicTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ServiceException>(Act);
-        ex.Message.Should().Be($"not found");
+        ex.Message.Should().Be("not found");
     }
 
     [Fact]
@@ -293,8 +312,8 @@ public class BpdmBusinessLogicTests
         // Arrange
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithoutZipCode, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -320,8 +339,8 @@ public class BpdmBusinessLogicTests
         };
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithSharingError, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -332,7 +351,7 @@ public class BpdmBusinessLogicTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ServiceException>(Act);
-        ex.Message.Should().Be($"ErrorCode: Code 43, ErrorMessage: This is a test sharing state error");
+        ex.Message.Should().Be("ErrorCode: Code 43, ErrorMessage: This is a test sharing state error");
     }
 
     [Fact]
@@ -348,8 +367,8 @@ public class BpdmBusinessLogicTests
             .Create();
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithoutSharingProcessStarted, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -380,8 +399,8 @@ public class BpdmBusinessLogicTests
                 ApplicationChecklistEntryStatusId.TO_DO).Create();
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithSharingPending, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -417,8 +436,8 @@ public class BpdmBusinessLogicTests
             ApplicationChecklistEntryStatusId.TO_DO).Create();
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
@@ -449,8 +468,8 @@ public class BpdmBusinessLogicTests
                 ApplicationChecklistEntryStatusId.TO_DO).Create();
         var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
             {
-                {ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.FAILED},
-                {ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO},
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.FAILED },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.TO_DO }
             }
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithBpn, default, checklist, Enumerable.Empty<ProcessStepTypeId>());

--- a/tests/externalsystems/Bpdm.Library/BpdmBusinessLogicTests.cs
+++ b/tests/externalsystems/Bpdm.Library/BpdmBusinessLogicTests.cs
@@ -240,7 +240,7 @@ public class BpdmBusinessLogicTests
             GrantType = "test",
             TokenAddress = "https://example.org/token",
             UseDimWallet = false,
-            StartAsReady = startAsReady
+            StartSharingStateAsReady = startAsReady
         });
         var logic = new BpdmBusinessLogic(_portalRepositories, _bpdmService, _options);
 


### PR DESCRIPTION
## Description

add toggle to disable the set sharing state ready call of the bpdm service

## Why

Bpdm has a toggle to set the sharing state automatically to ready, for that purpose its useful to have a toggle on the portal side as well.

## Issue

Refs: #845

## Corresponding CD PR

https://github.com/eclipse-tractusx/portal/pull/403

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
