### PR TITLE
feat(osp): add externalID and datecreated in registration network companies api

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -32,7 +32,7 @@ public interface IRegistrationBusinessLogic
 {
     Task<CompanyWithAddressData> GetCompanyWithAddressAsync(Guid applicationId);
     Task<Pagination.Response<CompanyApplicationDetails>> GetCompanyApplicationDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName);
-    Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName, string? externalId);
+    Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName, string? externalId, DateCreatedOrderFilter? dateCreatedOrderFilter);
     Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName);
     Task UpdateCompanyBpn(Guid applicationId, string bpn);
 

--- a/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -32,7 +32,7 @@ public interface IRegistrationBusinessLogic
 {
     Task<CompanyWithAddressData> GetCompanyWithAddressAsync(Guid applicationId);
     Task<Pagination.Response<CompanyApplicationDetails>> GetCompanyApplicationDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName);
-    Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName);
+    Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName, string? externalId);
     Task<Pagination.Response<CompanyApplicationWithCompanyUserDetails>> GetAllCompanyApplicationsDetailsAsync(int page, int size, string? companyName);
     Task UpdateCompanyBpn(Guid applicationId, string bpn);
 

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -162,26 +162,28 @@ public sealed class RegistrationBusinessLogic(
                     .AsAsyncEnumerable()));
     }
 
-    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName, string? externalId)
+    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName, string? externalId, DateCreatedOrderFilter? dateCreatedOrderFilter)
     {
         if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
         {
             throw new ControllerArgumentException("CompanyName length must be 3-40 characters and *+=#%\\s not used as one of the first three characters in the company name", nameof(companyName));
         }
-        var applications = portalRepositories.GetInstance<IApplicationRepository>()
+        var applicationsQuery = portalRepositories.GetInstance<IApplicationRepository>()
             .GetExternalCompanyApplicationsFilteredQuery(_identityData.CompanyId,
                 companyName?.Length >= 3 ? companyName : null, externalId,
                 GetCompanyApplicationStatusIds(companyApplicationStatusFilter));
+
+        var orderedQuery = dateCreatedOrderFilter == null || dateCreatedOrderFilter.Value == DateCreatedOrderFilter.DESC
+            ? applicationsQuery.AsSplitQuery().OrderByDescending(application => application.DateCreated)
+            : applicationsQuery.AsSplitQuery().OrderBy(application => application.DateCreated);
 
         return Pagination.CreateResponseAsync(
             page,
             size,
             _settings.ApplicationsMaxPageSize,
             (skip, take) => new Pagination.AsyncSource<CompanyDetailsOspOnboarding>(
-                applications.CountAsync(),
-                applications
-                    .AsSplitQuery()
-                    .OrderByDescending(application => application.DateCreated)
+                applicationsQuery.CountAsync(),
+                orderedQuery
                     .Skip(skip)
                     .Take(take)
                     .Select(application => new CompanyDetailsOspOnboarding(

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -162,7 +162,7 @@ public sealed class RegistrationBusinessLogic(
                     .AsAsyncEnumerable()));
     }
 
-    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName)
+    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync(int page, int size, CompanyApplicationStatusFilter? companyApplicationStatusFilter, string? companyName, string? externalId)
     {
         if (!string.IsNullOrEmpty(companyName) && !Company.IsMatch(companyName))
         {
@@ -170,7 +170,7 @@ public sealed class RegistrationBusinessLogic(
         }
         var applications = portalRepositories.GetInstance<IApplicationRepository>()
             .GetExternalCompanyApplicationsFilteredQuery(_identityData.CompanyId,
-                companyName?.Length >= 3 ? companyName : null,
+                companyName?.Length >= 3 ? companyName : null, externalId,
                 GetCompanyApplicationStatusIds(companyApplicationStatusFilter));
 
         return Pagination.CreateResponseAsync(
@@ -186,9 +186,11 @@ public sealed class RegistrationBusinessLogic(
                     .Take(take)
                     .Select(application => new CompanyDetailsOspOnboarding(
                         application.CompanyId,
+                        application.NetworkRegistration!.ExternalId,
                         application.Id,
                         application.ApplicationStatusId,
                         application.DateCreated,
+                        application.Company!.DateCreated,
                         application.DateLastChanged,
                         application.Company!.Name,
                         application.Company.CompanyAssignedRoles.Select(companyAssignedRoles => companyAssignedRoles.CompanyRoleId),
@@ -211,7 +213,7 @@ public sealed class RegistrationBusinessLogic(
             _settings.ApplicationsMaxPageSize,
             (skip, take) => new Pagination.AsyncSource<CompanyApplicationWithCompanyUserDetails>(
                 applications.CountAsync(),
-                applications.OrderByDescending(application => application.DateCreated)
+                applications.OrderByDescending(application => application.Company!.DateCreated)
                     .Skip(skip)
                     .Take(take)
                     .Select(application => new

--- a/src/administration/Administration.Service/Controllers/RegistrationController.cs
+++ b/src/administration/Administration.Service/Controllers/RegistrationController.cs
@@ -568,6 +568,7 @@ public class RegistrationController : ControllerBase
     /// <param name="size">size to get number of records</param>
     /// <param name="companyApplicationStatusFilter">Search by company applicationstatus</param>
     /// <param name="companyName">search by company name</param>
+    /// <param name="externalId">search by external Id</param>
     /// <returns>OSp Company Application Details</returns>
     /// <remarks>
     /// Example: GET: api/administration/registration/network/companies?companyName=Car&amp;page=0&amp;size=4&amp;companyApplicationStatus=Closed <br />
@@ -579,6 +580,8 @@ public class RegistrationController : ControllerBase
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("network/companies")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyDetailsOspOnboarding>), StatusCodes.Status200OK)]
-    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync([FromQuery] int page, [FromQuery] int size, [FromQuery] CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, [FromQuery] string? companyName = null) =>
-        _logic.GetOspCompanyDetailsAsync(page, size, companyApplicationStatusFilter, companyName);
+    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync([FromQuery] int page, [FromQuery] int size, [FromQuery] CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, [FromQuery] string? companyName = null, [FromQuery] string? externalId = null) =>
+        _logic.GetOspCompanyDetailsAsync(page, size, companyApplicationStatusFilter, companyName, externalId);
 }
+
+

--- a/src/administration/Administration.Service/Controllers/RegistrationController.cs
+++ b/src/administration/Administration.Service/Controllers/RegistrationController.cs
@@ -584,4 +584,3 @@ public class RegistrationController : ControllerBase
         _logic.GetOspCompanyDetailsAsync(page, size, companyApplicationStatusFilter, companyName, externalId);
 }
 
-

--- a/src/administration/Administration.Service/Controllers/RegistrationController.cs
+++ b/src/administration/Administration.Service/Controllers/RegistrationController.cs
@@ -569,6 +569,7 @@ public class RegistrationController : ControllerBase
     /// <param name="companyApplicationStatusFilter">Search by company applicationstatus</param>
     /// <param name="companyName">search by company name</param>
     /// <param name="externalId">search by external Id</param>
+    /// <param name="dateCreatedOrderFilter">sort result by dateCreated ascending or descending</param>
     /// <returns>OSp Company Application Details</returns>
     /// <remarks>
     /// Example: GET: api/administration/registration/network/companies?companyName=Car&amp;page=0&amp;size=4&amp;companyApplicationStatus=Closed <br />
@@ -580,7 +581,7 @@ public class RegistrationController : ControllerBase
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("network/companies")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyDetailsOspOnboarding>), StatusCodes.Status200OK)]
-    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync([FromQuery] int page, [FromQuery] int size, [FromQuery] CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, [FromQuery] string? companyName = null, [FromQuery] string? externalId = null) =>
-        _logic.GetOspCompanyDetailsAsync(page, size, companyApplicationStatusFilter, companyName, externalId);
+    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync([FromQuery] int page, [FromQuery] int size, [FromQuery] CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, [FromQuery] string? companyName = null, [FromQuery] string? externalId = null, [FromQuery] DateCreatedOrderFilter? dateCreatedOrderFilter = null) =>
+        _logic.GetOspCompanyDetailsAsync(page, size, companyApplicationStatusFilter, companyName, externalId, dateCreatedOrderFilter);
 }
 

--- a/src/administration/Administration.Service/Models/CompanyApplicationStatusFilter.cs
+++ b/src/administration/Administration.Service/Models/CompanyApplicationStatusFilter.cs
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 
 /// <summary>
 /// Filter operations for the CompanyApplicationStatus

--- a/src/administration/Administration.Service/Models/CompanyDetailsOspOnboarding.cs
+++ b/src/administration/Administration.Service/Models/CompanyDetailsOspOnboarding.cs
@@ -25,7 +25,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 public record CompanyDetailsOspOnboarding(
 
     [property: JsonPropertyName("companyId")] Guid CompanyId,
-    [property: JsonPropertyName("externalId")] string ExternalId,
+    [property: JsonPropertyName("externalId")] string? ExternalId,
     [property: JsonPropertyName("applicationId")] Guid ApplicationId,
     [property: JsonPropertyName("applicationStatus")] CompanyApplicationStatusId CompanyApplicationStatusId,
     [property: JsonPropertyName("applicationDateCreated")] DateTimeOffset ApplicationDateCreated,

--- a/src/administration/Administration.Service/Models/CompanyDetailsOspOnboarding.cs
+++ b/src/administration/Administration.Service/Models/CompanyDetailsOspOnboarding.cs
@@ -25,9 +25,11 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 public record CompanyDetailsOspOnboarding(
 
     [property: JsonPropertyName("companyId")] Guid CompanyId,
+    [property: JsonPropertyName("externalId")] string ExternalId,
     [property: JsonPropertyName("applicationId")] Guid ApplicationId,
     [property: JsonPropertyName("applicationStatus")] CompanyApplicationStatusId CompanyApplicationStatusId,
-    [property: JsonPropertyName("applicationDateCreated")] DateTimeOffset DateCreated,
+    [property: JsonPropertyName("applicationDateCreated")] DateTimeOffset ApplicationDateCreated,
+    [property: JsonPropertyName("dateCreated")] DateTimeOffset DateCreated,
     [property: JsonPropertyName("lastChangedDate")] DateTimeOffset? DateLastChanged,
     [property: JsonPropertyName("companyName")] string CompanyName,
     [property: JsonPropertyName("companyRoles")] IEnumerable<CompanyRoleId> CompanyRoles,

--- a/src/administration/Administration.Service/Models/DateCreatedOrderFilter.cs
+++ b/src/administration/Administration.Service/Models/DateCreatedOrderFilter.cs
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+
+public enum DateCreatedOrderFilter
+{
+    ASC,
+    DESC
+}

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -134,12 +134,13 @@ public class ApplicationRepository(PortalDbContext portalDbContext)
                 (companyName == null || EF.Functions.ILike(application.Company!.Name, $"{companyName.EscapeForILike()}%")) &&
                 (applicationStatusIds == null || applicationStatusIds.Contains(application.ApplicationStatusId)));
 
-    public IQueryable<CompanyApplication> GetExternalCompanyApplicationsFilteredQuery(Guid onboardingServiceProviderId, string? companyName, IEnumerable<CompanyApplicationStatusId> applicationStatusIds) =>
+    public IQueryable<CompanyApplication> GetExternalCompanyApplicationsFilteredQuery(Guid onboardingServiceProviderId, string? companyName, string? externalId, IEnumerable<CompanyApplicationStatusId> applicationStatusIds) =>
         portalDbContext.CompanyApplications.AsNoTracking()
             .Where(application =>
                 application.CompanyApplicationTypeId == CompanyApplicationTypeId.EXTERNAL &&
                 application.OnboardingServiceProviderId == onboardingServiceProviderId &&
                 (companyName == null || EF.Functions.ILike(application.Company!.Name, $"{companyName.EscapeForILike()}%")) &&
+                (externalId == null || EF.Functions.ILike(application.NetworkRegistration!.ExternalId, $"{externalId.EscapeForILike()}%")) &&
                 applicationStatusIds.Contains(application.ApplicationStatusId));
 
     public Task<CompanyApplicationDetailData?> GetCompanyApplicationDetailDataAsync(Guid applicationId, Guid userCompanyId, Guid? companyId) =>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -140,7 +140,7 @@ public class ApplicationRepository(PortalDbContext portalDbContext)
                 application.CompanyApplicationTypeId == CompanyApplicationTypeId.EXTERNAL &&
                 application.OnboardingServiceProviderId == onboardingServiceProviderId &&
                 (companyName == null || EF.Functions.ILike(application.Company!.Name, $"{companyName.EscapeForILike()}%")) &&
-                (externalId == null || EF.Functions.ILike(application.NetworkRegistration!.ExternalId, $"{externalId.EscapeForILike()}%")) &&
+                (externalId == null || application.NetworkRegistration!.ExternalId == externalId) &&
                 applicationStatusIds.Contains(application.ApplicationStatusId));
 
     public Task<CompanyApplicationDetailData?> GetCompanyApplicationDetailDataAsync(Guid applicationId, Guid userCompanyId, Guid? companyId) =>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -34,7 +34,7 @@ public interface IApplicationRepository
     Task<(bool Exists, bool IsUserOfCompany, CompanyApplicationStatusId ApplicationStatus)> GetOwnCompanyApplicationStatusUserDataUntrackedAsync(Guid applicationId, Guid companyId);
     Task<CompanyApplicationUserEmailData?> GetOwnCompanyApplicationUserEmailDataAsync(Guid applicationId, Guid companyUserId, IEnumerable<DocumentTypeId> submitDocumentTypeIds);
     IQueryable<CompanyApplication> GetCompanyApplicationsFilteredQuery(string? companyName, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
-    IQueryable<CompanyApplication> GetExternalCompanyApplicationsFilteredQuery(Guid onboardingServiceProviderId, string? companyName, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
+    IQueryable<CompanyApplication> GetExternalCompanyApplicationsFilteredQuery(Guid onboardingServiceProviderId, string? companyName, string? externalId, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
     Task<CompanyApplicationDetailData?> GetCompanyApplicationDetailDataAsync(Guid applicationId, Guid userCompanyId, Guid? companyId);
     Task<(string CompanyName, string? FirstName, string? LastName, string? Email, IEnumerable<(Guid ApplicationId, CompanyApplicationStatusId ApplicationStatusId, IEnumerable<(string? FirstName, string? LastName, string? Email)> InvitedUsers)> Applications)> GetCompanyApplicationsDeclineData(Guid companyUserId, IEnumerable<CompanyApplicationStatusId> applicationStatusIds);
     Task<(bool IsValidApplicationId, Guid CompanyId, bool IsSubmitted)> GetCompanyIdSubmissionStatusForApplication(Guid applicationId);

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplication.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplication.cs
@@ -66,7 +66,7 @@ public class CompanyApplication : IAuditableV1, IBaseEntity
     public virtual Process? ChecklistProcess { get; set; }
     public virtual CompanyApplicationType? CompanyApplicationType { get; set; }
     public virtual Company? OnboardingServiceProvider { get; set; }
-    public virtual NetworkRegistration? NetworkRegistration { get; private set; }
+    public virtual NetworkRegistration? NetworkRegistration { get; set; }
     public virtual Identity? LastEditor { get; private set; }
     public virtual CompanyInvitation? CompanyInvitation { get; private set; }
     public virtual ICollection<Invitation> Invitations { get; private set; }

--- a/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
@@ -75,14 +75,14 @@ public class RegistrationControllerTest
     {
         //Arrange
         var paginationResponse = new Pagination.Response<CompanyDetailsOspOnboarding>(new Pagination.Metadata(15, 1, 1, 15), _fixture.CreateMany<CompanyDetailsOspOnboarding>(5));
-        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(0, 15, null, null))
+        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(0, 15, null, null, null))
                   .Returns(paginationResponse);
 
         //Act
         var result = await _controller.GetOspCompanyDetailsAsync(0, 15, null, null);
 
         //Assert
-        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(0, 15, null, null)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(0, 15, null, null, null)).MustHaveHappenedOnceExactly();
         Assert.IsType<Pagination.Response<CompanyDetailsOspOnboarding>>(result);
         result.Content.Should().HaveCount(5);
     }

--- a/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
@@ -74,15 +74,22 @@ public class RegistrationControllerTest
     public async Task GetOspCompanyApplicationDetailsAsync_ReturnsCompanyApplicationDetails()
     {
         //Arrange
+        var page = _fixture.Create<int>();
+        var size = _fixture.Create<int>();
+        var companyApplicationStatusFilter = _fixture.Create<CompanyApplicationStatusFilter>();
+        var companyName = _fixture.Create<string>();
+        var externalId = _fixture.Create<string>();
+        var dateCreatedOrderFilter = _fixture.Create<DateCreatedOrderFilter>();
+
         var paginationResponse = new Pagination.Response<CompanyDetailsOspOnboarding>(new Pagination.Metadata(15, 1, 1, 15), _fixture.CreateMany<CompanyDetailsOspOnboarding>(5));
-        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(0, 15, null, null, null))
+        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(A<int>._, A<int>._, A<CompanyApplicationStatusFilter>._, A<string>._, A<string>._, A<DateCreatedOrderFilter>._))
                   .Returns(paginationResponse);
 
         //Act
-        var result = await _controller.GetOspCompanyDetailsAsync(0, 15, null, null);
+        var result = await _controller.GetOspCompanyDetailsAsync(page, size, companyApplicationStatusFilter, companyName, externalId, dateCreatedOrderFilter);
 
         //Assert
-        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(0, 15, null, null, null)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetOspCompanyDetailsAsync(page, size, companyApplicationStatusFilter, companyName, externalId, dateCreatedOrderFilter)).MustHaveHappenedOnceExactly();
         Assert.IsType<Pagination.Response<CompanyDetailsOspOnboarding>>(result);
         result.Content.Should().HaveCount(5);
     }


### PR DESCRIPTION
## Description

Change endpoint GET /api/administration/registration/network/companies
- Add externalID field to the response body to represent the external identifier of the company.
- Add dateCreated field to the response body to represent the creation date of the company record.
- Add new (optional) query-parameter externalID to facilitate lookup using external identifiers.
- Add new (optional) query parameter dateCreatedOrderFilter (values ASC, DESC) to specify order of result.
- Implement sorting by dateCreated in both ascending (ASC) and descending (DESC) order.

## Why

The response body should include the new fields externalID and dateCreated.
The API should support query parameters for searching by companyName and externalID.
The API should support query parameters for sorting by dateCreated in both ASC and DESC order.

## Issue

#850 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
