### PR TITLE
fix(connector): create connector with correct state

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -216,7 +216,7 @@ public class ConnectorsBusinessLogic(
                 connector.HostId = host;
                 connector.TypeId = type;
                 connector.DateLastChanged = DateTimeOffset.UtcNow;
-                connector.StatusId = _settings.ClearinghouseConnectDisabled ? ConnectorStatusId.ACTIVE : ConnectorStatusId.PENDING;
+                connector.StatusId = _settings.ClearinghouseConnectDisabled ? ConnectorStatusId.PENDING : ConnectorStatusId.ACTIVE;
                 if (technicalUserId != null)
                 {
                     connector.CompanyServiceAccountId = technicalUserId;

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -161,7 +161,7 @@ public class ConnectorsBusinessLogicTests
 
         // Assert
         result.Should().NotBeEmpty();
-        _connectors.Should().HaveCount(1);
+        _connectors.Should().ContainSingle().Which.StatusId.Should().Be(clearingHouseDisabled ? ConnectorStatusId.PENDING : ConnectorStatusId.ACTIVE);
         A.CallTo(() => _connectorsRepository.CreateConnectorAssignedSubscriptions(A<Guid>._, A<Guid>._)).MustNotHaveHappened();
         A.CallTo(() => _sdFactoryBusinessLogic.RegisterConnectorAsync(A<Guid>._, A<string>._, A<string>._, A<CancellationToken>._)).MustHaveHappened(clearingHouseDisabled ? 0 : 1, Times.Exactly);
     }
@@ -201,33 +201,6 @@ public class ConnectorsBusinessLogicTests
         // Assert
         result.Should().NotBeEmpty();
         _connectors.Should().HaveCount(1);
-    }
-
-    [Fact]
-    public async Task CreateConnectorAsync_WithoutSelfDescriptionDocumentAndSdConnectionDisabled_CallsExpected()
-    {
-        // Arrange
-        var sut = new ConnectorsBusinessLogic(_portalRepositories, Options.Create(new ConnectorsSettings
-        {
-            MaxPageSize = 15,
-            ValidCertificationContentTypes = new[]
-            {
-                "application/x-pem-file",
-                "application/x-x509-ca-cert",
-                "application/pkix-cert"
-            },
-            ClearinghouseConnectDisabled = true
-        }), _sdFactoryBusinessLogic, _identityService, A.Fake<ILogger<ConnectorsBusinessLogic>>());
-
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", "de", null);
-        A.CallTo(() => _identity.CompanyId).Returns(CompanyIdWithoutSdDocument);
-
-        // Act
-        await sut.CreateConnectorAsync(connectorInput, CancellationToken.None);
-
-        // Assert
-        A.CallTo(() => _connectorsRepository.CreateConnector(A<string>._, A<string>._, A<string>._, A<Action<Connector>>._)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _sdFactoryBusinessLogic.RegisterConnectorAsync(A<Guid>._, A<string>._, A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
     }
 
     [Fact]
@@ -318,7 +291,8 @@ public class ConnectorsBusinessLogicTests
 
         // Assert
         result.Should().NotBeEmpty();
-        _connectors.Should().HaveCount(1);
+        _connectors.Should().ContainSingle().Which.StatusId.Should().Be(clearingHouseDisabled ? ConnectorStatusId.PENDING : ConnectorStatusId.ACTIVE);
+
         A.CallTo(() => _connectorsRepository.CreateConnectorAssignedSubscriptions(A<Guid>._, _validOfferSubscriptionId)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _sdFactoryBusinessLogic.RegisterConnectorAsync(A<Guid>._, A<string>._, A<string>._, A<CancellationToken>._)).MustHaveHappened(clearingHouseDisabled ? 0 : 1, Times.Exactly);
     }


### PR DESCRIPTION
## Description

When creating a connector the correct connector status is set

## Why

Currently the wrong state is set

## Issue

Refs: #918

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
