### PR TITLE
feat(connector): add duplicate check to connector creation

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -185,7 +185,7 @@ public class ConnectorsBusinessLogic(
         if (await portalRepositories.GetInstance<IConnectorsRepository>()
              .CheckConnectorExists(name, connectorUrl).ConfigureAwait(ConfigureAwaitOptions.None))
         {
-            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_DUPLICATE, new ErrorParameter[] { new("name", name), new("connectorUrl", connectorUrl) });
+            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_DUPLICATE, [new("name", name), new("connectorUrl", connectorUrl)]);
         }
     }
 

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -97,6 +97,7 @@ public class ConnectorsBusinessLogic(
     {
         var companyId = _identityData.CompanyId;
         var (name, connectorUrl, location, technicalUserId) = connectorInputModel;
+        await CheckDuplicateConnector(name, connectorUrl).ConfigureAwait(ConfigureAwaitOptions.None);
         await CheckLocationExists(location);
 
         var result = await portalRepositories
@@ -125,6 +126,7 @@ public class ConnectorsBusinessLogic(
     {
         var companyId = _identityData.CompanyId;
         var (name, connectorUrl, location, subscriptionId, technicalUserId) = connectorInputModel;
+        await CheckDuplicateConnector(name, connectorUrl).ConfigureAwait(ConfigureAwaitOptions.None);
         await CheckLocationExists(location).ConfigureAwait(ConfigureAwaitOptions.None);
 
         var result = await portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
@@ -175,6 +177,15 @@ public class ConnectorsBusinessLogic(
                 .CheckCountryExistsByAlpha2CodeAsync(location.ToUpper()).ConfigureAwait(ConfigureAwaitOptions.None))
         {
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_LOCATION_NOT_EXIST, new ErrorParameter[] { new("location", location) });
+        }
+    }
+
+    private async Task CheckDuplicateConnector(string name, string connectorUrl)
+    {
+        if (await portalRepositories.GetInstance<IConnectorsRepository>()
+             .CheckConnectorExists(name, connectorUrl).ConfigureAwait(ConfigureAwaitOptions.None))
+        {
+            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_DUPLICATE, new ErrorParameter[] { new("name", name), new("connectorUrl", connectorUrl) });
         }
     }
 

--- a/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
+++ b/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
@@ -26,24 +26,25 @@ public class AdministrationConnectorErrorMessageContainer : IErrorMessageContain
 {
     private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<AdministrationConnectorErrors, string> {
                 { AdministrationConnectorErrors.CONNECTOR_NOT_FOUND, "connector {connectorId} does not exist" },
-                { AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY,"company {companyId} is not provider of connector {connectorId}"},
+                { AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY,"company {companyId} is not provider of connector {connectorId}" },
                 { AdministrationConnectorErrors.CONNECTOR_UNEXPECTED_NO_BPN_ASSIGNED, "provider company {companyId} has no businessPartnerNumber assigned" },
-                { AdministrationConnectorErrors.CONNECTOR_NOT_OFFERSUBSCRIPTION_EXIST,"OfferSubscription {subscriptionId} does not exist"},
-                { AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY_OFFER,"Company is not the provider of the offer"},
-                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_OFFERSUBSCRIPTION_LINKED,"OfferSubscription is already linked to a connector"},
-                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_STATUS_ACTIVE_OR_PENDING,"The offer subscription must be either {offerSubscriptionStatusIdActive} or {offerSubscriptionStatusIdPending}"},
-                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_NO_DESCRIPTION,"provider company {CompanyId} has no self description document"},
-                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN,"The bpn of company {companyId} must be set"},
-                { AdministrationConnectorErrors.CONNECTOR_ARGUMENT_LOCATION_NOT_EXIST,"Location {location} does not exist"},
-                { AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_NOT_ACTIVE,"Technical User {technicalUserId} is not assigned to company {companyId} or is not active"},
-                { AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY_NOR_HOST,"company {companyId} is neither provider nor host-company of connector {connectorId}"},
-                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_DELETION_DECLINED,"Connector status does not match a deletion scenario. Deletion declined"},
-                { AdministrationConnectorErrors.CONNECTOR_DELETION_FAILED_OFFER_SUBSCRIPTION,"Deletion Failed. Connector {connectorId} connected to an active offer subscription, {activeConnectorOfferSubscription}"},
-                { AdministrationConnectorErrors.CONNECTOR_ARGUMENT_INCORRECT_BPN,"Incorrect BPN {bpns} attribute value"},
-                { AdministrationConnectorErrors.CONNECTOR_NOT_EXIST,"Connector {externalId} does not exist"},
-                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_ALREADY_ASSIGNED,"Connector {externalId} already has a document assigned"},
-                { AdministrationConnectorErrors.CONNECTOR_NOT_HOST_COMPANY,"Company {companyId} is not the connectors host company"},
-                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_INACTIVE_STATE,"Connector {connectorId} is in state {connectorStatusId}"}
+                { AdministrationConnectorErrors.CONNECTOR_NOT_OFFERSUBSCRIPTION_EXIST,"OfferSubscription {subscriptionId} does not exist" },
+                { AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY_OFFER,"Company is not the provider of the offer" },
+                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_OFFERSUBSCRIPTION_LINKED,"OfferSubscription is already linked to a connector" },
+                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_STATUS_ACTIVE_OR_PENDING,"The offer subscription must be either {offerSubscriptionStatusIdActive} or {offerSubscriptionStatusIdPending}" },
+                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_NO_DESCRIPTION,"provider company {CompanyId} has no self description document" },
+                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN,"The bpn of company {companyId} must be set" },
+                { AdministrationConnectorErrors.CONNECTOR_ARGUMENT_LOCATION_NOT_EXIST,"Location {location} does not exist" },
+                { AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_NOT_ACTIVE,"Technical User {technicalUserId} is not assigned to company {companyId} or is not active" },
+                { AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY_NOR_HOST,"company {companyId} is neither provider nor host-company of connector {connectorId}" },
+                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_DELETION_DECLINED,"Connector status does not match a deletion scenario. Deletion declined" },
+                { AdministrationConnectorErrors.CONNECTOR_DELETION_FAILED_OFFER_SUBSCRIPTION,"Deletion Failed. Connector {connectorId} connected to an active offer subscription, {activeConnectorOfferSubscription}" },
+                { AdministrationConnectorErrors.CONNECTOR_ARGUMENT_INCORRECT_BPN,"Incorrect BPN {bpns} attribute value" },
+                { AdministrationConnectorErrors.CONNECTOR_NOT_EXIST,"Connector {externalId} does not exist" },
+                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_ALREADY_ASSIGNED,"Connector {externalId} already has a document assigned" },
+                { AdministrationConnectorErrors.CONNECTOR_NOT_HOST_COMPANY,"Company {companyId} is not the connectors host company" },
+                { AdministrationConnectorErrors.CONNECTOR_CONFLICT_INACTIVE_STATE,"Connector {connectorId} is in state {connectorStatusId}" },
+                { AdministrationConnectorErrors.CONNECTOR_DUPLICATE,"Connector {name} does already exists for url {connectorUrl}" }
             }.ToImmutableDictionary(x => (int)x.Key, x => x.Value);
 
     public Type Type { get => typeof(AdministrationConnectorErrors); }
@@ -70,5 +71,6 @@ public enum AdministrationConnectorErrors
     CONNECTOR_NOT_EXIST,
     CONNECTOR_CONFLICT_ALREADY_ASSIGNED,
     CONNECTOR_NOT_HOST_COMPANY,
-    CONNECTOR_CONFLICT_INACTIVE_STATE
+    CONNECTOR_CONFLICT_INACTIVE_STATE,
+    CONNECTOR_DUPLICATE
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -234,7 +234,7 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
             .SingleOrDefaultAsync();
 
     public Task<bool> CheckConnectorExists(string name, string connectorUrl) =>
-        _context.Connectors.AnyAsync(x =>
+        dbContext.Connectors.AnyAsync(x =>
             x.Name == name &&
             x.ConnectorUrl == connectorUrl);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -232,4 +232,9 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
             .Where(c => c.SdCreationProcessId == processId)
             .Select(c => new ValueTuple<Guid, string?, Guid>(c.Id, c.Provider!.BusinessPartnerNumber, c.Provider.SelfDescriptionDocumentId!.Value))
             .SingleOrDefaultAsync();
+
+    public Task<bool> CheckConnectorExists(string name, string connectorUrl) =>
+        _context.Connectors.AnyAsync(x =>
+            x.Name == name &&
+            x.ConnectorUrl == connectorUrl);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
@@ -109,4 +109,5 @@ public interface IConnectorsRepository
     Func<int, int, Task<Pagination.Source<ConnectorMissingSdDocumentData>?>> GetConnectorsWithMissingSdDocument();
     IAsyncEnumerable<Guid> GetConnectorIdsWithMissingSelfDescription();
     Task<(Guid Id, string? BusinessPartnerNumber, Guid SelfDescriptionDocumentId)> GetConnectorForProcessId(Guid processId);
+    Task<bool> CheckConnectorExists(string name, string connectorUrl);
 }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -596,6 +596,36 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
+    #region CheckConnectorExists
+
+    [Fact]
+    public async Task CheckConnectorExists_WithExisting_ReturnsTrue()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.CheckConnectorExists("Test Connector 6", "www.google.de").ConfigureAwait(false);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckConnectorExists_WithoutExisting_ReturnsFalse()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.CheckConnectorExists("not existing", "www.google.de").ConfigureAwait(false);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
     private async Task<(ConnectorsRepository, PortalDbContext)> CreateSut()
     {
         var context = await _dbTestDbFixture.GetPortalDbContext();


### PR DESCRIPTION
## Description

Add check if a combination of name and url is already existing for a connector 

## Why

without the check the database throws an error which is unhandled.

## Issue

Refs: #917

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
