### PR TITLE
fix(connectors): allowing registration of connectors with pending status technical users

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -218,7 +218,7 @@ public class ServiceAccountRepository(PortalDbContext portalDbContext) : IServic
         portalDbContext.CompanyServiceAccounts
             .Where(sa =>
                 sa.Id == technicalUserId &&
-                sa.Identity!.UserStatusId == UserStatusId.ACTIVE &&
+                (sa.Identity!.UserStatusId == UserStatusId.ACTIVE || sa.Identity!.UserStatusId == UserStatusId.PENDING) &&
                 sa.Identity.CompanyId == companyId)
             .AnyAsync();
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_service_accounts.test.json
@@ -86,5 +86,14 @@
     "company_service_account_kind_id": 2,
     "offer_subscription_id": "ed4de48d-fd4b-4384-a72f-ecae3c6cc5ba",
     "client_client_id": "sa-os-external"
+  },
+  {
+    "id": "4ce1b774-3d00-4e07-9a53-ae1f64193394",
+    "name": "sa-pending-0",
+    "description": "pending service account",
+    "company_service_account_type_id": 2,
+    "company_service_account_kind_id": 1,
+    "offer_subscription_id": null,
+    "client_client_id": "sa-x-4"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/identities.test.json
@@ -185,5 +185,14 @@
     "user_entity_id": null,
     "identity_type_id": 2,
     "last_editor_id":"8b42e6de-7b59-4217-a63c-198e83d93777"
+  },
+  {
+    "id": "4ce1b774-3d00-4e07-9a53-ae1f64193394",
+    "date_created": "2024-08-08 18:01:33.439000 +00:00",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "user_status_id": 4,
+    "user_entity_id": null,
+    "identity_type_id": 2,
+    "last_editor_id":"8b42e6de-7b59-4217-a63c-198e83d93777"
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -439,6 +439,32 @@ public class ServiceAccountRepositoryTests : IAssemblyFixture<TestDbFixture>
         result.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task CheckActiveServiceAccountExistsForCompanyAsyncForPendingStatus_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.CheckActiveServiceAccountExistsForCompanyAsync(new Guid("4ce1b774-3d00-4e07-9a53-ae1f64193394"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckActiveServiceAccountExistsForCompanyAsyncForInactiveStatus_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.CheckActiveServiceAccountExistsForCompanyAsync(new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94d"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
     #endregion
 
     #region CreateDimCompanyServiceAccount


### PR DESCRIPTION
## Description

Update the backend logic for /api/administration/Connectors to allow the registration of connectors with technical users in the "PENDING" status.
Update the backend logic for /api/administration/Connectors/managed to allow the registration of connectors with technical users in the "PENDING" status.

## Why

This change is temporary change till long term solution still in discussion as mentioned in ticket for allowing registration of connectors with technical users status as "PENDING".

## Issue

#843 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
