### PR TITLE
fix(BPDM): fixed the request structure of BPDM api

### DIFF
--- a/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityData.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityData.cs
@@ -111,5 +111,5 @@ public record BpdmLegalEntityData(
     BpdmLegalEntity LegalEntity,
     BpdmSite? Site,
     BpdmAddress Address,
-    bool OwnCompanyData
+    bool IsOwnCompanyData
 );


### PR DESCRIPTION
## Description

Renamed the property `OwnCompanyData` to `IsOwnCompanyData` as per[ BPDM api specifications](https://eclipse-tractusx.github.io/docs-kits/next/kits/Business%20Partner%20Kit/Software%20Development%20View/Gate%20Api/upsert-business-partners-input)

## Why

BPDM was having issues as this flag `IsOwnCompanyData` was always false as Portal was sending wrong flag

## Issue

#927  

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing tests pass locally with my changes
