### PR TITLE
feat(invitation): added invitation id and api for invitation details

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IInvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IInvitationBusinessLogic.cs
@@ -23,7 +23,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLog
 {
     public interface IInvitationBusinessLogic
     {
-        Task ExecuteInvitation(CompanyInvitationData invitationData);
+        Task<Guid> ExecuteInvitation(CompanyInvitationData invitationData);
         Task RetriggerCreateCentralIdp(Guid processId);
         Task RetriggerCreateSharedIdpServiceAccount(Guid processId);
         Task RetriggerUpdateCentralIdpUrls(Guid processId);
@@ -32,5 +32,6 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLog
         Task RetriggerEnableCentralIdp(Guid processId);
         Task RetriggerCreateDatabaseIdp(Guid processId);
         Task RetriggerInvitationCreateUser(Guid processId);
+        Task<CompanyInvitationDetails> GetApplicationAndCompanyDetails(Guid invitationId);
     }
 }

--- a/src/administration/Administration.Service/Controllers/InvitationController.cs
+++ b/src/administration/Administration.Service/Controllers/InvitationController.cs
@@ -68,7 +68,7 @@ public class InvitationController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status502BadGateway)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
-    public Task ExecuteInvitation([FromBody] CompanyInvitationData invitationData) =>
+    public Task<Guid> ExecuteInvitation([FromBody] CompanyInvitationData invitationData) =>
         _logic.ExecuteInvitation(invitationData);
 
     /// <summary>
@@ -238,4 +238,21 @@ public class InvitationController : ControllerBase
         await _logic.RetriggerInvitationCreateUser(processId).ConfigureAwait(ConfigureAwaitOptions.None);
         return NoContent();
     }
+    /// <summary>
+    /// Get the application id and company id by using invitation id
+    /// </summary>
+    /// <param name="invitationId"></param>
+    /// <returns>application id and company id</returns>
+    /// Example: GET: api/administration/invitation/{invitationId}
+    [HttpGet]
+    [Authorize(Roles = "invite_new_partner")]
+    [Authorize(Policy = PolicyTypes.CompanyUser)]
+    [Route("{invitationId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status502BadGateway)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
+    public Task<CompanyInvitationDetails> GetApplicationAndCompanyDetails([FromRoute] Guid invitationId) =>
+        _logic.GetApplicationAndCompanyDetails(invitationId);
 }

--- a/src/administration/Administration.Service/Models/CompanyInvitationData.cs
+++ b/src/administration/Administration.Service/Models/CompanyInvitationData.cs
@@ -69,3 +69,5 @@ public class CompanyInvitationData
         organisationName = OrganisationName;
     }
 }
+
+public record CompanyInvitationDetails(Guid? ApplicationId, Guid? CompanyId);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyInvitationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyInvitationRepository.cs
@@ -104,4 +104,14 @@ public class CompanyInvitationRepository : ICompanyInvitationRepository
             .Where(x => x.Id == invitationId)
             .Select(x => x.ServiceAccountUserId)
             .SingleOrDefaultAsync();
+
+    public Task<(Guid? ApplicationId, Guid? CompanyId)> GetInvitationCompanyAndApplicationId(Guid invitationId) =>
+        _context.CompanyInvitations
+            .Where(x => x.Id == invitationId)
+            .Select(x => new ValueTuple<Guid?, Guid?>(
+
+                x.ApplicationId,
+                x.Application!.CompanyId
+            ))
+            .SingleOrDefaultAsync();
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyInvitationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyInvitationRepository.cs
@@ -33,4 +33,5 @@ public interface ICompanyInvitationRepository
     Task<string?> GetIdpNameForInvitationId(Guid invitationId);
     Task<(string OrgName, string? IdpName, string? ClientId, byte[]? ClientSecret, byte[]? InitializationVector, int? EncryptionMode)> GetUpdateCentralIdpUrlData(Guid invitationId);
     Task<string?> GetServiceAccountUserIdForInvitation(Guid invitationId);
+    Task<(Guid? ApplicationId, Guid? CompanyId)> GetInvitationCompanyAndApplicationId(Guid invitationId);
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -568,7 +568,6 @@ public class InvitationBusinessLogicTests
     public async Task GetApplicationAndCompanyDetails_ReturnResult()
     {
         // Arrange
-        var invitationId = Guid.NewGuid();
         var expectedResult = (Guid.NewGuid(), Guid.NewGuid());
         A.CallTo(() => _companyInvitationRepository.GetInvitationCompanyAndApplicationId(A<Guid>._)).Returns(expectedResult);
 

--- a/tests/administration/Administration.Service.Tests/Controllers/InvitationControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/InvitationControllerTests.cs
@@ -41,12 +41,15 @@ public class InvitationControllerTests
     {
         // Arrange
         var data = _fixture.Create<CompanyInvitationData>();
+        var invitationId = Guid.NewGuid();
+        A.CallTo(() => _logic.ExecuteInvitation(A<CompanyInvitationData>._)).Returns(invitationId);
 
         // Act
-        await _controller.ExecuteInvitation(data);
+        var result = await _controller.ExecuteInvitation(data);
 
         // Assert
         A.CallTo(() => _logic.ExecuteInvitation(data)).MustHaveHappenedOnceExactly();
+        result.Should().Be(invitationId);
     }
 
     [Fact]
@@ -151,6 +154,22 @@ public class InvitationControllerTests
         // Assert
         result.StatusCode.Should().Be(204);
         A.CallTo(() => _logic.RetriggerInvitationCreateUser(processId))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task GetApplicationAndCompanyDetails_ReturnsExpected()
+    {
+        // Arrange
+        var expectedResult = new CompanyInvitationDetails(Guid.NewGuid(), Guid.NewGuid());
+        var invitationId = Guid.NewGuid();
+        A.CallTo(() => _logic.GetApplicationAndCompanyDetails(A<Guid>._)).Returns(expectedResult);
+        // Act
+        var result = await _controller.GetApplicationAndCompanyDetails(invitationId);
+
+        // Assert
+        result.Should().Be(expectedResult);
+        A.CallTo(() => _logic.GetApplicationAndCompanyDetails(invitationId))
             .MustHaveHappenedOnceExactly();
     }
 }


### PR DESCRIPTION
## Description

1. Added Invitation Id in response of ExecuteInvitation api i.e `POST: api/administration/invitation`
2. Created a new api to get the application id and company id by using invitation id i.e 
   `GET: api/administration/invitation/{invitationId}`

## Why

In automation and CRM communication there was no reference id to track the Invitation .
So now by this invitation Id they can call the newly created api to get the Application id and Company Id

## Issue

#834 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
