### PR TITLE
fix(serviceAccount): adjust response for get serviceaccount detail

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -187,8 +187,7 @@ public class ServiceAccountBusinessLogic(
             result.ConnectorData,
             result.OfferSubscriptionData,
             result.CompanyLastEditorData!.Name,
-            result.CompanyLastEditorData.CompanyName,
-            result.SubscriptionId);
+            result.CompanyLastEditorData.CompanyName);
     }
 
     public async Task<ServiceAccountDetails> ResetOwnCompanyServiceAccountSecretAsync(Guid serviceAccountId)
@@ -215,8 +214,7 @@ public class ServiceAccountBusinessLogic(
             authData.IamClientAuthMethod,
             result.UserRoleDatas,
             result.CompanyServiceAccountTypeId,
-            authData.Secret,
-            result.SubscriptionId);
+            authData.Secret);
     }
 
     public async Task<ServiceAccountDetails> UpdateOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId, ServiceAccountEditableDetails serviceAccountDetails)

--- a/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
+++ b/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
@@ -38,6 +38,5 @@ public record ServiceAccountConnectorOfferData(
     [property: JsonPropertyName("connector")] ConnectorResponseData? Connector,
     [property: JsonPropertyName("offer")] OfferResponseData? Offer,
     [property: JsonPropertyName("LastEditorName")] string? LastName,
-    [property: JsonPropertyName("LastEditorCompanyName")] string? CompanyName,
-    [property: JsonPropertyName("subscriptionId")] Guid? SubscriptionId = null
+    [property: JsonPropertyName("LastEditorCompanyName")] string? CompanyName
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
@@ -30,7 +30,6 @@ public record CompanyServiceAccountDetailedData(
     UserStatusId Status,
     IEnumerable<UserRoleData> UserRoleDatas,
     CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
-    Guid? SubscriptionId,
     ConnectorResponseData? ConnectorData,
     OfferResponseData? OfferSubscriptionData,
     CompanyLastEditorData? CompanyLastEditorData,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -146,7 +146,6 @@ public class ServiceAccountRepository(PortalDbContext portalDbContext) : IServic
                         userRole.Offer!.AppInstances.First().IamClient!.ClientClientId,
                         userRole.UserRoleText)),
                 x.ServiceAccount.CompanyServiceAccountTypeId,
-                x.ServiceAccount.OfferSubscriptionId,
                 x.Connector == null
                     ? null
                     : new ConnectorResponseData(


### PR DESCRIPTION
## Description

* remove subscriptionId from response

## Why

The subscription Id is responded twice, it is already present in the offerData

## Issue

Refs: #897

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
