### PR TITLE
feat(connector): adjust connector deletion

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IConnectorsBusinessLogic.cs
@@ -67,7 +67,8 @@ public interface IConnectorsBusinessLogic
     /// Remove a connector from persistence layer by id.
     /// </summary>
     /// <param name="connectorId">ID of the connector to be deleted.</param>
-    Task DeleteConnectorAsync(Guid connectorId);
+    /// <param name="deleteServiceAccount">if <c>true</c> the linked service account will be deleted, otherwise the connection to the connector will just be removed</param>
+    Task DeleteConnectorAsync(Guid connectorId, bool deleteServiceAccount);
 
     /// <summary>
     /// Retrieve connector end point along with bpns

--- a/src/administration/Administration.Service/BusinessLogic/IServiceAccountManagement.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IServiceAccountManagement.cs
@@ -17,19 +17,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
-namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 
-public record OwnServiceAccountData(
-    IEnumerable<Guid> UserRoleIds,
-    Guid ServiceAccountId,
-    Guid ServiceAccountVersion,
-    Guid? ConnectorId,
-    string? ClientClientId,
-    ConnectorStatusId? StatusId,
-    OfferSubscriptionStatusId? OfferStatusId,
-    bool IsDimServiceAccount,
-    bool CreationProcessInProgress,
-    Guid? ProcessId
-);
+public interface IServiceAccountManagement
+{
+    Task DeleteServiceAccount(Guid serviceAccountId, DeleteServiceAccountData result);
+}

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountManagement.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountManagement.cs
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Linq;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.Processes.Library;
+using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
+
+public class ServiceAccountManagement(IProvisioningManager provisioningManager, IPortalRepositories portalRepositories) : IServiceAccountManagement
+{
+    public async Task DeleteServiceAccount(Guid serviceAccountId, DeleteServiceAccountData result)
+    {
+        var userStatus = UserStatusId.DELETED;
+        switch (result)
+        {
+            case { IsDimServiceAccount: true, CreationProcessInProgress: false }:
+                userStatus = await CreateDeletionProcess(serviceAccountId, result.ProcessId).ConfigureAwait(ConfigureAwaitOptions.None);
+                break;
+            case { IsDimServiceAccount: true, CreationProcessInProgress: true }:
+                throw ConflictException.Create(AdministrationServiceAccountErrors.TECHNICAL_USER_CREATION_IN_PROGRESS);
+            default:
+                if (!string.IsNullOrWhiteSpace(result.ClientClientId))
+                {
+                    await provisioningManager.DeleteCentralClientAsync(result.ClientClientId).ConfigureAwait(ConfigureAwaitOptions.None);
+                }
+
+                break;
+        }
+
+        portalRepositories.GetInstance<IUserRepository>().AttachAndModifyIdentity(
+            serviceAccountId,
+            i =>
+            {
+                i.UserStatusId = UserStatusId.PENDING;
+            },
+            i =>
+            {
+                i.UserStatusId = userStatus;
+            });
+        portalRepositories.GetInstance<IUserRolesRepository>().DeleteCompanyUserAssignedRoles(result.UserRoleIds.Select(userRoleId => (serviceAccountId, userRoleId)));
+    }
+
+    private async Task<UserStatusId> CreateDeletionProcess(Guid serviceAccountId, Guid? processId)
+    {
+        if (processId == null)
+        {
+            throw ConflictException.Create(AdministrationServiceAccountErrors.SERVICE_ACCOUNT_NOT_LINKED_TO_PROCESS, [new ErrorParameter("serviceAccountId", serviceAccountId.ToString())]);
+        }
+
+        var processData = await portalRepositories.GetInstance<IProcessStepRepository>()
+            .GetProcessDataForServiceAccountDeletionCallback(processId.Value, null)
+            .ConfigureAwait(ConfigureAwaitOptions.None);
+
+        var context = processData.ProcessData.CreateManualProcessData(null,
+            portalRepositories, () => $"externalId {processId}");
+
+        context.ProcessSteps.Where(step => step.ProcessStepTypeId != ProcessStepTypeId.DELETE_DIM_TECHNICAL_USER).IfAny(pending =>
+            throw ConflictException.Create(AdministrationServiceAccountErrors.SERVICE_ACCOUNT_PENDING_PROCESS_STEPS, [new ErrorParameter("serviceAccountId", serviceAccountId.ToString()), new("processStepTypeIds", string.Join<ProcessStep>(",", pending))]));
+
+        if (context.ProcessSteps.Any(step => step.ProcessStepTypeId == ProcessStepTypeId.DELETE_DIM_TECHNICAL_USER))
+            return UserStatusId.DELETED;
+
+        context.ScheduleProcessSteps([ProcessStepTypeId.DELETE_DIM_TECHNICAL_USER]);
+        context.FinalizeProcessStep();
+        return UserStatusId.PENDING_DELETION;
+    }
+}

--- a/src/administration/Administration.Service/Controllers/ConnectorsController.cs
+++ b/src/administration/Administration.Service/Controllers/ConnectorsController.cs
@@ -150,7 +150,8 @@ public class ConnectorsController(IConnectorsBusinessLogic logic)
     /// Removes a connector from persistence layer by id.
     /// </summary>
     /// <param name="connectorId" example="5636F9B9-C3DE-4BA5-8027-00D17A2FECFB">ID of the connector to be deleted.</param>
-    /// <remarks>Example: DELETE: /api/administration/connectors/5636F9B9-C3DE-4BA5-8027-00D17A2FECFB</remarks>
+    /// <param name="deleteServiceAccount">if <c>true</c> the linked service account will be deleted, otherwise the connection to the connector will just be removed</param>
+    /// <remarks>Example: DELETE: /api/administration/connectors/{connectorId}?deleteServiceAccount=true</remarks>
     /// <response code="204">Empty response on success.</response>
     /// <response code="404">Record not found.</response>
     /// <response code="409">Connector status does not match a deletion scenario. Deletion declined.</response>
@@ -161,9 +162,9 @@ public class ConnectorsController(IConnectorsBusinessLogic logic)
     [ProducesResponseType(typeof(IActionResult), StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> DeleteConnectorAsync([FromRoute] Guid connectorId)
+    public async Task<IActionResult> DeleteConnectorAsync([FromRoute] Guid connectorId, [FromQuery] bool deleteServiceAccount = false)
     {
-        await logic.DeleteConnectorAsync(connectorId);
+        await logic.DeleteConnectorAsync(connectorId, deleteServiceAccount);
         return NoContent();
     }
 

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -84,6 +84,7 @@ await WebAppHelper
 
         builder.Services
             .AddTransient<ISubscriptionConfigurationBusinessLogic, SubscriptionConfigurationBusinessLogic>()
+            .AddTransient<IServiceAccountManagement, ServiceAccountManagement>()
             .AddPartnerRegistration(builder.Configuration)
             .AddNetworkRegistrationProcessHelper()
             .AddIssuerComponentService(builder.Configuration.GetSection("Issuer"));

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
@@ -74,7 +74,8 @@ public record DeleteConnectorData(
     ConnectorStatusId ConnectorStatus,
     IEnumerable<ConnectorOfferSubscription> ConnectorOfferSubscriptions,
     UserStatusId? UserStatusId,
-    Guid? ServiceAccountId
+    Guid? ServiceAccountId,
+    DeleteServiceAccountData DeleteServiceAccountData
 );
 public record ConnectorOfferSubscription(Guid AssignedOfferSubscriptionIds, OfferSubscriptionStatusId OfferSubscriptionStatus);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Models/DeleteServiceAccountData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/DeleteServiceAccountData.cs
@@ -17,18 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
-
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
-public record OwnServiceAccountData(
+public record DeleteServiceAccountData(
     IEnumerable<Guid> UserRoleIds,
-    Guid ServiceAccountId,
-    Guid ServiceAccountVersion,
-    Guid? ConnectorId,
     string? ClientClientId,
-    ConnectorStatusId? StatusId,
-    OfferSubscriptionStatusId? OfferStatusId,
     bool IsDimServiceAccount,
     bool CreationProcessInProgress,
     Guid? ProcessId

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -26,31 +26,20 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 
-/// Implementation of <see cref="IConnectorsRepository"/> accessing database with EF Core.
-public class ConnectorsRepository : IConnectorsRepository
+/// <inheritdoc />
+public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsRepository
 {
-    private readonly PortalDbContext _context;
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    /// <param name="portalDbContext">PortalDb context.</param>
-    public ConnectorsRepository(PortalDbContext portalDbContext)
-    {
-        _context = portalDbContext;
-    }
-
     /// <inheritdoc/>
     public Func<int, int, Task<Pagination.Source<ConnectorData>?>> GetAllCompanyConnectorsForCompanyId(Guid companyId) =>
         (skip, take) => Pagination.CreateSourceQueryAsync(
             skip,
             take,
-            _context.Connectors.AsNoTracking()
+            dbContext.Connectors.AsNoTracking()
                 .Where(x => x.ProviderId == companyId &&
                        x.StatusId != ConnectorStatusId.INACTIVE &&
                        x.TypeId == ConnectorTypeId.COMPANY_CONNECTOR)
                 .GroupBy(c => c.ProviderId),
-            connector => connector.OrderByDescending(connector => connector.Name),
+            connector => connector.OrderByDescending(c => c.Name),
             con => new ConnectorData(
                 con.Name,
                 con.Location!.Alpha2Code,
@@ -73,7 +62,7 @@ public class ConnectorsRepository : IConnectorsRepository
         (skip, take) => Pagination.CreateSourceQueryAsync(
             skip,
             take,
-            _context.Connectors.AsNoTracking()
+            dbContext.Connectors.AsNoTracking()
                 .Where(c => c.HostId == companyId &&
                             c.StatusId != ConnectorStatusId.INACTIVE &&
                             c.TypeId == ConnectorTypeId.CONNECTOR_AS_A_SERVICE)
@@ -96,7 +85,7 @@ public class ConnectorsRepository : IConnectorsRepository
         ).SingleOrDefaultAsync();
 
     public Task<(ConnectorData ConnectorData, bool IsProviderCompany)> GetConnectorByIdForCompany(Guid connectorId, Guid companyId) =>
-        _context.Connectors
+        dbContext.Connectors
             .AsNoTracking()
             .Where(connector => connector.Id == connectorId && connector.StatusId != ConnectorStatusId.INACTIVE)
             .Select(connector => new ValueTuple<ConnectorData, bool>(
@@ -120,7 +109,7 @@ public class ConnectorsRepository : IConnectorsRepository
             .SingleOrDefaultAsync();
 
     public Task<(ConnectorInformationData ConnectorInformationData, bool IsProviderUser)> GetConnectorInformationByIdForIamUser(Guid connectorId, Guid userCompanyId) =>
-        _context.Connectors
+        dbContext.Connectors
             .AsNoTracking()
             .Where(connector => connector.Id == connectorId && connector.StatusId != ConnectorStatusId.INACTIVE)
             .Select(connector => new ValueTuple<ConnectorInformationData, bool>(
@@ -134,12 +123,12 @@ public class ConnectorsRepository : IConnectorsRepository
     {
         var connector = new Connector(Guid.NewGuid(), name, location, connectorUrl);
         setupOptionalFields?.Invoke(connector);
-        return _context.Connectors.Add(connector).Entity;
+        return dbContext.Connectors.Add(connector).Entity;
     }
 
     /// <inheritdoc/>
     public IAsyncEnumerable<(string BusinessPartnerNumber, string ConnectorEndpoint)> GetConnectorEndPointDataAsync(IEnumerable<string> bpns) =>
-        _context.Connectors
+        dbContext.Connectors
             .AsNoTracking()
             .Where(connector => connector.StatusId == ConnectorStatusId.ACTIVE && (!bpns.Any() || bpns.Contains(connector.Provider!.BusinessPartnerNumber)))
             .OrderBy(connector => connector.ProviderId)
@@ -155,21 +144,21 @@ public class ConnectorsRepository : IConnectorsRepository
     {
         var connector = new Connector(connectorId, null!, null!, null!);
         initialize?.Invoke(connector);
-        _context.Attach(connector);
+        dbContext.Attach(connector);
         setOptionalParameters(connector);
         return connector;
     }
 
     /// <inheritdoc />
     public Task<(Guid ConnectorId, Guid? SelfDescriptionDocumentId)> GetConnectorDataById(Guid connectorId) =>
-        _context.Connectors
+        dbContext.Connectors
             .Where(x => x.Id == connectorId && x.StatusId != ConnectorStatusId.INACTIVE)
             .Select(x => new ValueTuple<Guid, Guid?>(x.Id, x.SelfDescriptionDocumentId))
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public Task<DeleteConnectorData?> GetConnectorDeleteDataAsync(Guid connectorId, Guid companyId) =>
-        _context.Connectors
+    public Task<DeleteConnectorData?> GetConnectorDeleteDataAsync(Guid connectorId, Guid companyId, IEnumerable<ProcessStepTypeId> processStepsToFilter) =>
+        dbContext.Connectors
             .Where(x => x.Id == connectorId)
             .Select(connector => new DeleteConnectorData(
                 connector.ProviderId == companyId || connector.HostId == companyId,
@@ -181,12 +170,21 @@ public class ConnectorsRepository : IConnectorsRepository
                     x.OfferSubscription!.OfferSubscriptionStatusId
                 )),
                 connector.CompanyServiceAccount!.Identity!.UserStatusId,
-                connector.CompanyServiceAccountId
+                connector.CompanyServiceAccountId,
+                new DeleteServiceAccountData(
+                    connector.CompanyServiceAccount!.Identity!.IdentityAssignedRoles.Select(r => r.UserRoleId),
+                    connector.CompanyServiceAccount.ClientClientId,
+                    connector.CompanyServiceAccount.CompanyServiceAccountKindId == CompanyServiceAccountKindId.EXTERNAL,
+                    connector.CompanyServiceAccount.DimUserCreationData!.Process!.ProcessSteps
+                        .Any(ps =>
+                            ps.ProcessStepStatusId == ProcessStepStatusId.TODO &&
+                            processStepsToFilter.Contains(ps.ProcessStepTypeId)),
+                    connector.CompanyServiceAccount.DimUserCreationData == null ? null : connector.CompanyServiceAccount.DimUserCreationData!.ProcessId)
             )).SingleOrDefaultAsync();
 
     /// <inheritdoc />
     public Task<ConnectorUpdateInformation?> GetConnectorUpdateInformation(Guid connectorId, Guid companyId) =>
-        _context.Connectors
+        dbContext.Connectors
             .Where(c => c.Id == connectorId)
             .Select(c => new ConnectorUpdateInformation(
                 c.StatusId,
@@ -198,21 +196,21 @@ public class ConnectorsRepository : IConnectorsRepository
             .SingleOrDefaultAsync();
 
     public void DeleteConnector(Guid connectorId) =>
-        _context.Connectors.Remove(new Connector(connectorId, null!, null!, null!));
+        dbContext.Connectors.Remove(new Connector(connectorId, null!, null!, null!));
 
     /// <inheritdoc />
     public ConnectorAssignedOfferSubscription CreateConnectorAssignedSubscriptions(Guid connectorId, Guid subscriptionId) =>
-        _context.ConnectorAssignedOfferSubscriptions.Add(new ConnectorAssignedOfferSubscription(connectorId, subscriptionId)).Entity;
+        dbContext.ConnectorAssignedOfferSubscriptions.Add(new ConnectorAssignedOfferSubscription(connectorId, subscriptionId)).Entity;
 
     /// <inheritdoc />
     public void DeleteConnectorAssignedSubscriptions(Guid connectorId, IEnumerable<Guid> assignedOfferSubscriptions) =>
-        _context.ConnectorAssignedOfferSubscriptions.RemoveRange(assignedOfferSubscriptions.Select(x => new ConnectorAssignedOfferSubscription(connectorId, x)));
+        dbContext.ConnectorAssignedOfferSubscriptions.RemoveRange(assignedOfferSubscriptions.Select(x => new ConnectorAssignedOfferSubscription(connectorId, x)));
 
     public Func<int, int, Task<Pagination.Source<ConnectorMissingSdDocumentData>?>> GetConnectorsWithMissingSdDocument() =>
         (skip, take) => Pagination.CreateSourceQueryAsync(
             skip,
             take,
-            _context.Connectors.AsNoTracking()
+            dbContext.Connectors.AsNoTracking()
                 .Where(x => x.StatusId == ConnectorStatusId.ACTIVE && x.SelfDescriptionDocumentId == null)
                 .GroupBy(c => c.StatusId),
             connector => connector.OrderByDescending(c => c.Name),
@@ -224,13 +222,13 @@ public class ConnectorsRepository : IConnectorsRepository
         ).SingleOrDefaultAsync();
 
     public IAsyncEnumerable<Guid> GetConnectorIdsWithMissingSelfDescription() =>
-        _context.Connectors
+        dbContext.Connectors
             .Where(c => c.StatusId == ConnectorStatusId.ACTIVE && c.SelfDescriptionDocumentId == null && c.Provider!.SelfDescriptionDocumentId != null)
             .Select(c => c.Id)
             .ToAsyncEnumerable();
 
     public Task<(Guid Id, string? BusinessPartnerNumber, Guid SelfDescriptionDocumentId)> GetConnectorForProcessId(Guid processId) =>
-        _context.Connectors
+        dbContext.Connectors
             .Where(c => c.SdCreationProcessId == processId)
             .Select(c => new ValueTuple<Guid, string?, Guid>(c.Id, c.Provider!.BusinessPartnerNumber, c.Provider.SelfDescriptionDocumentId!.Value))
             .SingleOrDefaultAsync();

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
@@ -20,6 +20,7 @@
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 
@@ -84,8 +85,9 @@ public interface IConnectorsRepository
     /// </summary>
     /// <param name="connectorId">Id of the connector</param>
     /// <param name="companyId">Id of the company</param>
+    /// <param name="processStepsToFilter"></param>
     /// <returns>returns SelfDescriptionDocument Data/c></returns>
-    Task<DeleteConnectorData?> GetConnectorDeleteDataAsync(Guid connectorId, Guid companyId);
+    Task<DeleteConnectorData?> GetConnectorDeleteDataAsync(Guid connectorId, Guid companyId, IEnumerable<ProcessStepTypeId> processStepsToFilter);
 
     /// <summary>
     /// Gets the data required for the connector update

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountManagementTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountManagementTests.cs
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountManagementTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountManagementTests.cs
@@ -1,0 +1,117 @@
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;
+using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.BusinessLogic;
+
+public class ServiceAccountManagementTests
+{
+    private const string ClientId = "Cl1-CX-Registration";
+    private static readonly Guid ValidServiceAccountId = Guid.NewGuid();
+    private readonly IEnumerable<Guid> _userRoleIds = Enumerable.Repeat(Guid.NewGuid(), 1);
+    private readonly IUserRepository _userRepository;
+    private readonly IUserRolesRepository _userRolesRepository;
+    private readonly IProcessStepRepository _processStepRepository;
+    private readonly IProvisioningManager _provisioningManager;
+    private readonly IFixture _fixture;
+    private readonly ServiceAccountManagement _sut;
+
+    public ServiceAccountManagementTests()
+    {
+        _fixture = new Fixture().Customize(new AutoFakeItEasyCustomization { ConfigureMembers = true });
+        _fixture.ConfigureFixture();
+
+        _provisioningManager = A.Fake<IProvisioningManager>();
+
+        _userRepository = A.Fake<IUserRepository>();
+        _userRolesRepository = A.Fake<IUserRolesRepository>();
+        _processStepRepository = A.Fake<IProcessStepRepository>();
+        var portalRepositories = A.Fake<IPortalRepositories>();
+        A.CallTo(() => portalRepositories.GetInstance<IUserRepository>()).Returns(_userRepository);
+        A.CallTo(() => portalRepositories.GetInstance<IUserRolesRepository>()).Returns(_userRolesRepository);
+        A.CallTo(() => portalRepositories.GetInstance<IProcessStepRepository>()).Returns(_processStepRepository);
+
+        _sut = new ServiceAccountManagement(_provisioningManager, portalRepositories);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public async Task DeleteOwnCompanyServiceAccountAsync_WithoutClient_CallsExpected(bool withClient, bool isDimServiceAccount)
+    {
+        // Arrange
+        var identity = _fixture.Build<Identity>()
+            .With(x => x.Id, ValidServiceAccountId)
+            .With(x => x.UserStatusId, UserStatusId.ACTIVE)
+            .Create();
+        var processId = Guid.NewGuid();
+        SetupDeleteOwnCompanyServiceAccount(isDimServiceAccount, identity);
+
+        // Act
+        await _sut.DeleteServiceAccount(ValidServiceAccountId, new DeleteServiceAccountData(_userRoleIds, withClient ? ClientId : null, isDimServiceAccount, false, processId));
+
+        // Assert
+        if (isDimServiceAccount)
+        {
+            A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)>>.That.Matches(x => x.Count() == 1 && x.First().ProcessStepTypeId == ProcessStepTypeId.DELETE_DIM_TECHNICAL_USER && x.First().ProcessStepStatusId == ProcessStepStatusId.TODO && x.First().ProcessId == processId))).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _userRepository.AttachAndModifyIdentity(A<Guid>._, A<Action<Identity>>._, A<Action<Identity>>._)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _provisioningManager.DeleteCentralClientAsync(A<string>._)).MustNotHaveHappened();
+            identity.UserStatusId.Should().Be(UserStatusId.PENDING_DELETION);
+        }
+        else if (withClient)
+        {
+            A.CallTo(() => _userRepository.AttachAndModifyIdentity(A<Guid>._, A<Action<Identity>>._, A<Action<Identity>>._)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId, ProcessStepStatusId, Guid)>>._)).MustNotHaveHappened();
+            A.CallTo(() => _provisioningManager.DeleteCentralClientAsync(ClientId)).MustHaveHappenedOnceExactly();
+            identity.UserStatusId.Should().Be(UserStatusId.DELETED);
+        }
+
+        var validServiceAccountUserRoleIds = _userRoleIds.Select(userRoleId => (ValidServiceAccountId, userRoleId));
+        A.CallTo(() => _userRolesRepository.DeleteCompanyUserAssignedRoles(A<IEnumerable<(Guid, Guid)>>.That.IsSameSequenceAs(validServiceAccountUserRoleIds))).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task DeleteServiceAccount_WithCreationProcessInProgress_ThrowsException()
+    {
+        // Arrange
+        Task Act() => _sut.DeleteServiceAccount(ValidServiceAccountId, new DeleteServiceAccountData(_userRoleIds, ClientId, true, true, Guid.NewGuid()));
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+
+        // Assert
+        ex.Message.Should().Be("TECHNICAL_USER_CREATION_IN_PROGRESS");
+    }
+
+    private void SetupDeleteOwnCompanyServiceAccount(bool isDimServiceAccount, Identity? identity = null)
+    {
+        if (isDimServiceAccount)
+        {
+            A.CallTo(() => _processStepRepository.GetProcessDataForServiceAccountDeletionCallback(A<Guid>._, A<IEnumerable<ProcessStepTypeId>>._))
+                .ReturnsLazily((Guid id, IEnumerable<ProcessStepTypeId>? processStepTypeIds) =>
+                    (
+                        ProcessTypeId.OFFER_SUBSCRIPTION,
+                        new VerifyProcessData(
+                            new Process(id, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
+                            processStepTypeIds?.Select(stepTypeId => new ProcessStep(Guid.NewGuid(), stepTypeId, ProcessStepStatusId.TODO, id, _fixture.Create<DateTimeOffset>())) ?? Enumerable.Empty<ProcessStep>()),
+                        Guid.NewGuid()));
+        }
+
+        if (identity != null)
+        {
+            A.CallTo(() => _userRepository.AttachAndModifyIdentity(ValidServiceAccountId, A<Action<Identity>>._, A<Action<Identity>>._))
+                .Invokes((Guid _, Action<Identity>? _, Action<Identity> modify) =>
+                {
+                    modify.Invoke(identity);
+                });
+        }
+    }
+}

--- a/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
@@ -154,7 +154,7 @@ public class ConnectorsControllerTests
         await _controller.DeleteConnectorAsync(connectorId);
 
         //Assert
-        A.CallTo(() => _logic.DeleteConnectorAsync(connectorId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.DeleteConnectorAsync(connectorId, false)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]

--- a/tests/administration/Administration.Service.Tests/EndpointSetup/ConnectorsEndpoints.cs
+++ b/tests/administration/Administration.Service.Tests/EndpointSetup/ConnectorsEndpoints.cs
@@ -19,7 +19,7 @@
 
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.IntegrationTests.EndpointSetup;
 
-namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.EnpointSetup;
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.EndpointSetup;
 
 public class ConnectorsEndpoints
 {

--- a/tests/administration/Administration.Service.Tests/IntegrationTests/ConnectorsControllerIntegrationTests.cs
+++ b/tests/administration/Administration.Service.Tests/IntegrationTests/ConnectorsControllerIntegrationTests.cs
@@ -18,7 +18,7 @@
  ********************************************************************************/
 
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Controllers;
-using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.EnpointSetup;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.EndpointSetup;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.IntegrationTests.Seeding;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;

--- a/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
@@ -44,7 +44,7 @@
     }
   },
   "Provisioning": {
-    "CentralRealm": "",
+    "CentralRealm": "test",
     "CentralRealmId": "",
     "IdpPrefix": "idp",
     "MappedBpnAttribute": "bpn",

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -36,6 +36,12 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 {
     private readonly TestDbFixture _dbTestDbFixture;
     private readonly Guid _userCompanyId = new("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87");
+    private readonly IEnumerable<ProcessStepTypeId> _processStepsToFilter = new[]
+    {
+        ProcessStepTypeId.CREATE_DIM_TECHNICAL_USER, ProcessStepTypeId.RETRIGGER_CREATE_DIM_TECHNICAL_USER,
+        ProcessStepTypeId.AWAIT_CREATE_DIM_TECHNICAL_USER_RESPONSE,
+        ProcessStepTypeId.RETRIGGER_AWAIT_CREATE_DIM_TECHNICAL_USER_RESPONSE
+    };
 
     public ConnectorRepositoryTests(TestDbFixture testDbFixture)
     {
@@ -286,7 +292,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetConnectorDeleteDataAsync(new Guid("7e86a0b8-6903-496b-96d1-0ef508206833"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+        var result = await sut.GetConnectorDeleteDataAsync(new Guid("7e86a0b8-6903-496b-96d1-0ef508206833"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"), _processStepsToFilter);
 
         // Assert
         result.Should().NotBeNull();
@@ -301,7 +307,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetConnectorDeleteDataAsync(new Guid("7e86a0b8-6903-496b-96d1-0ef508206839"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+        var result = await sut.GetConnectorDeleteDataAsync(new Guid("7e86a0b8-6903-496b-96d1-0ef508206839"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"), _processStepsToFilter);
 
         // Assert
         result.Should().NotBeNull();
@@ -317,7 +323,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetConnectorDeleteDataAsync(new Guid("7e86a0b8-6903-496b-96d1-0ef508206839"), Guid.NewGuid());
+        var result = await sut.GetConnectorDeleteDataAsync(new Guid("7e86a0b8-6903-496b-96d1-0ef508206839"), Guid.NewGuid(), _processStepsToFilter);
 
         // Assert
         result.Should().NotBeNull();
@@ -331,7 +337,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetConnectorDeleteDataAsync(new Guid(), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+        var result = await sut.GetConnectorDeleteDataAsync(new Guid(), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"), _processStepsToFilter);
 
         // Assert
         result.Should().BeNull();
@@ -344,7 +350,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetConnectorDeleteDataAsync(new Guid("4618c650-709c-4580-956a-85b76eecd4b8"), new Guid("41fd2ab8-71cd-4546-9bef-a388d91b2542"));
+        var result = await sut.GetConnectorDeleteDataAsync(new Guid("4618c650-709c-4580-956a-85b76eecd4b8"), new Guid("41fd2ab8-71cd-4546-9bef-a388d91b2542"), _processStepsToFilter);
 
         // Assert
         result.Should().NotBeNull();


### PR DESCRIPTION
## Description

* add flag to define whether a linked service account should be deleted
* adjust deletion logic for service accounts when deleting a connector

## Why

The deletion logic for connectors currently doesn't support the deletion process of external service accounts

## Issue

Refs: #966 #967

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
