### PR TITLE
feat(app): adjust status query param for subscription-status

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -152,12 +152,11 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     }
 
     /// <inheritdoc />
-    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>>
-        GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId, string? name) =>
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId, string? name) =>
         _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(page, size, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE, statusId, name);
 
     /// <inheritdoc/>
-    public async Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName = null)
+    public async Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName)
     {
         if (!string.IsNullOrWhiteSpace(companyName) && !Company.IsMatch(companyName))
         {

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -152,8 +152,9 @@ public class AppsBusinessLogic : IAppsBusinessLogic
     }
 
     /// <inheritdoc />
-    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId) =>
-        _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(page, size, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE, statusId);
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>>
+        GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId, string? name) =>
+        _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(page, size, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE, statusId, name);
 
     /// <inheritdoc/>
     public async Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName = null)

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -78,9 +78,7 @@ public interface IAppsBusinessLogic
     /// <param name="statusId"></param>
     /// <param name="name"></param>
     /// <returns>Returns the details of the subscription status for App user</returns>
-    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>>
-        GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId,
-            string? name);
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId, string? name);
 
     /// <summary>
     /// Retrieves subscription statuses of provided apps of the provided user's company.
@@ -92,7 +90,7 @@ public interface IAppsBusinessLogic
     /// <param name="offerId"></param>
     /// <param name="companyName"></param>
     /// <returns>Async enumberable of user's company's provided apps' statuses.</returns>
-    public Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName = null);
+    public Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName);
 
     /// <summary>
     /// Adds a subscription relation between an application and a user's company.

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -76,8 +76,11 @@ public interface IAppsBusinessLogic
     /// <param name ="page">page</param>
     /// <param name ="size">size</param>
     /// <param name="statusId"></param>
+    /// <param name="name"></param>
     /// <returns>Returns the details of the subscription status for App user</returns>
-    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId);
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>>
+        GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId,
+            string? name);
 
     /// <summary>
     /// Retrieves subscription statuses of provided apps of the provided user's company.

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -158,7 +158,8 @@ public class AppsController : ControllerBase
     /// <remarks>Example: GET: /api/apps/subscribed/subscription-status</remarks>
     /// <param name="page">The page that should be displayed</param>
     /// <param name="size">The size per page of elements that should be returned</param>
-    /// <param name="statusId">Filter for the offer subscription status. If not set all elements will be returned</param>
+    /// <param name="status">Filter for the offer subscription status. If not set, all elements will be returned</param>
+    /// <param name="name">An optional search query for the name</param>
     /// <response code="200">Returns list of applicable apps subscription statuses.</response>
     /// <response code="400">If sub claim is empty/invalid or user does not exist.</response>
     [HttpGet]
@@ -167,8 +168,8 @@ public class AppsController : ControllerBase
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [ProducesResponseType(typeof(Pagination.Response<OfferSubscriptionStatusDetailData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync([FromQuery] int page = 0, [FromQuery] int size = 15, [FromQuery] OfferSubscriptionStatusId? statusId = null) =>
-        _appsBusinessLogic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(page, size, statusId);
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync([FromQuery] int page = 0, [FromQuery] int size = 15, [FromQuery] OfferSubscriptionStatusId? status = null, [FromQuery] string? name = null) =>
+        _appsBusinessLogic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(page, size, status, name);
 
     /// <summary>
     /// Retrieves subscription statuses of provided apps of the currently logged in user's company.

--- a/src/marketplace/Offers.Library/Service/IOfferService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferService.cs
@@ -242,9 +242,7 @@ public interface IOfferService
     /// <param name="statusId"></param>
     /// <param name="name"></param>
     /// <returns>Returns the details of the subscription status for user by OfferType</returns>
-    Task<Pagination.Response<OfferSubscriptionStatusDetailData>>
-        GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, OfferTypeId offerTypeId,
-            DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId, string? name);
+    Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, OfferTypeId offerTypeId, DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId, string? name);
 
     /// <summary>
     /// Gets the information for the subscription for the provider

--- a/src/marketplace/Offers.Library/Service/IOfferService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferService.cs
@@ -240,8 +240,11 @@ public interface IOfferService
     /// <param name="offerTypeId"></param>
     /// <param name="documentTypeId"></param>
     /// <param name="statusId"></param>
+    /// <param name="name"></param>
     /// <returns>Returns the details of the subscription status for user by OfferType</returns>
-    Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, OfferTypeId offerTypeId, DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId);
+    Task<Pagination.Response<OfferSubscriptionStatusDetailData>>
+        GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, OfferTypeId offerTypeId,
+            DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId, string? name);
 
     /// <summary>
     /// Gets the information for the subscription for the provider

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -889,8 +889,7 @@ public class OfferService : IOfferService
     }
 
     /// <inheritdoc/>
-    public async Task<Pagination.Response<OfferSubscriptionStatusDetailData>>
-        GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, OfferTypeId offerTypeId, DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId, string? name)
+    public async Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, OfferTypeId offerTypeId, DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId, string? name)
     {
         async Task<Pagination.Source<OfferSubscriptionStatusDetailData>?> GetCompanySubscribedOfferSubscriptionStatusesData(int skip, int take)
         {

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -889,12 +889,13 @@ public class OfferService : IOfferService
     }
 
     /// <inheritdoc/>
-    public async Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, OfferTypeId offerTypeId, DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId)
+    public async Task<Pagination.Response<OfferSubscriptionStatusDetailData>>
+        GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, OfferTypeId offerTypeId, DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId, string? name)
     {
         async Task<Pagination.Source<OfferSubscriptionStatusDetailData>?> GetCompanySubscribedOfferSubscriptionStatusesData(int skip, int take)
         {
             var offerCompanySubscriptionResponse = await _portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
-                .GetOwnCompanySubscribedOfferSubscriptionStatusAsync(_identityData.CompanyId, offerTypeId, documentTypeId, statusId)(skip, take).ConfigureAwait(ConfigureAwaitOptions.None);
+                .GetOwnCompanySubscribedOfferSubscriptionStatusAsync(_identityData.CompanyId, offerTypeId, documentTypeId, statusId, name)(skip, take).ConfigureAwait(ConfigureAwaitOptions.None);
 
             return offerCompanySubscriptionResponse == null
                 ? null

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
@@ -134,7 +134,7 @@ public interface IServiceBusinessLogic
     /// <param name ="size">size</param>
     /// <param name="statusId"></param>
     /// <returns>Returns the details of the subscription status for Service user</returns>
-    Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId);
+    Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId, string? name);
 
     /// <summary>
     /// Starts the auto setup process.

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -219,8 +219,8 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
         _offerService.GetSubscriptionDetailsForSubscriberAsync(serviceId, subscriptionId, OfferTypeId.SERVICE, _settings.SalesManagerRoles);
 
     /// <inheritdoc />
-    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId) =>
-        _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(page, size, OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE, statusId);
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId, string? name) =>
+        _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(page, size, OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE, statusId, name);
 
     /// <inheritdoc />
     public Task StartAutoSetupAsync(OfferAutoSetupData data) =>

--- a/src/marketplace/Services.Service/Controllers/ServicesController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServicesController.cs
@@ -297,7 +297,8 @@ public class ServicesController : ControllerBase
     /// <remarks>Example: GET: /api/services/subscribed/subscription-status</remarks>
     /// <param name="page">The page that should be displayed</param>
     /// <param name="size">The size per page of elements that should be returned</param>
-    /// <param name="statusId">Filter for the offer subscription status. If not set all elements will be returned</param>
+    /// <param name="status">Filter for the offer subscription status. If not set, all elements will be returned</param>
+    /// <param name="name">Optional search query to filter for the name</param>
     /// <response code="200">Returns list of applicable service subscription statuses.</response>
     /// <response code="400">If sub claim is empty/invalid or user does not exist.</response>
     [HttpGet]
@@ -306,8 +307,8 @@ public class ServicesController : ControllerBase
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [ProducesResponseType(typeof(Pagination.Response<OfferSubscriptionStatusDetailData>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync([FromQuery] int page = 0, [FromQuery] int size = 15, [FromQuery] OfferSubscriptionStatusId? statusId = null) =>
-        _serviceBusinessLogic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(page, size, statusId);
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync([FromQuery] int page = 0, [FromQuery] int size = 15, [FromQuery] OfferSubscriptionStatusId? status = null, [FromQuery] string? name = null) =>
+        _serviceBusinessLogic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(page, size, status, name);
 
     /// <summary>
     /// Unsubscribes an service from the current user's company's subscriptions.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -141,10 +141,11 @@ public interface IOfferSubscriptionsRepository
     /// <param name="offerTypeId">Id of the offer type</param>
     /// <param name="documentTypeId">Id of the document type</param>
     /// <param name="statusId"></param>
+    /// <param name="name"></param>
     /// <returns>Returns a func with skip, take and the pagination of the source</returns>
     Func<int, int, Task<Pagination.Source<OfferSubscriptionStatusData>?>>
         GetOwnCompanySubscribedOfferSubscriptionStatusAsync(Guid userCompanyId, OfferTypeId offerTypeId,
-            DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId);
+            DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId, string? name);
 
     /// <summary>
     /// 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -309,7 +309,8 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
 
     /// <inheritdoc />
     public Func<int, int, Task<Pagination.Source<OfferSubscriptionStatusData>?>>
-        GetOwnCompanySubscribedOfferSubscriptionStatusAsync(Guid userCompanyId, OfferTypeId offerTypeId, DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId) =>
+        GetOwnCompanySubscribedOfferSubscriptionStatusAsync(Guid userCompanyId, OfferTypeId offerTypeId,
+            DocumentTypeId documentTypeId, OfferSubscriptionStatusId? statusId, string? name) =>
         (skip, take) => Pagination.CreateSourceQueryAsync(
                 skip,
                 take,
@@ -318,7 +319,8 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                     .Where(os =>
                         os.Offer!.OfferTypeId == offerTypeId &&
                         os.CompanyId == userCompanyId &&
-                        (statusId == null || os.OfferSubscriptionStatusId == statusId))
+                        (statusId == null || os.OfferSubscriptionStatusId == statusId) &&
+                        (name == null || (os.Offer.Name != null && EF.Functions.ILike(os.Offer!.Name, $"%{name.EscapeForILike()}%"))))
                     .GroupBy(os => os.CompanyId),
                 null,
                 os => new OfferSubscriptionStatusData(

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
@@ -471,18 +471,18 @@ public class AppBusinessLogicTests
         // Arrange
         var data = _fixture.CreateMany<OfferSubscriptionStatusDetailData>(5).ToImmutableArray();
         var pagination = new Pagination.Response<OfferSubscriptionStatusDetailData>(new Pagination.Metadata(data.Length, 1, 0, data.Length), data);
-        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<OfferTypeId>._, A<DocumentTypeId>._, A<OfferSubscriptionStatusId?>._))
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<OfferTypeId>._, A<DocumentTypeId>._, A<OfferSubscriptionStatusId?>._, A<string?>._))
             .Returns(pagination);
 
         var sut = new AppsBusinessLogic(_portalRepositories, null!, _offerService, null!, _fixture.Create<IOptions<AppsSettings>>(), _identityService);
 
         // Act
-        var result = await sut.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(0, 10, null);
+        var result = await sut.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(0, 10, null, null);
 
         // Assert
         result.Meta.NumberOfElements.Should().Be(5);
         result.Content.Should().HaveCount(5);
-        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE, null)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE, null, null)).MustHaveHappenedOnceExactly();
     }
 
     #endregion

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
@@ -160,14 +160,14 @@ public class AppsControllerTests
         //Arrange
         var data = _fixture.CreateMany<OfferSubscriptionStatusDetailData>(3).ToImmutableArray();
         var pagination = new Pagination.Response<OfferSubscriptionStatusDetailData>(new Pagination.Metadata(data.Length, 1, 0, data.Length), data);
-        A.CallTo(() => _logic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<OfferSubscriptionStatusId?>._))
+        A.CallTo(() => _logic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<OfferSubscriptionStatusId?>._, A<string?>._))
             .Returns(pagination);
 
         //Act
         var result = await _controller.GetCompanySubscribedAppSubscriptionStatusesForUserAsync();
 
         //Assert
-        A.CallTo(() => _logic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(0, 15, null)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(0, 15, null, null)).MustHaveHappenedOnceExactly();
         result.Content.Should().HaveCount(3).And.ContainInOrder(data);
     }
 

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -2442,11 +2442,11 @@ public class OfferServiceTests
     {
         // Arrange
         var data = _fixture.CreateMany<OfferSubscriptionStatusData>(5).ToImmutableArray();
-        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(A<Guid>._, A<OfferTypeId>._, A<DocumentTypeId>._, A<OfferSubscriptionStatusId?>._))
+        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(A<Guid>._, A<OfferTypeId>._, A<DocumentTypeId>._, A<OfferSubscriptionStatusId?>._, A<string?>._))
             .Returns((skip, take) => Task.FromResult(new Pagination.Source<OfferSubscriptionStatusData>(data.Length, data.Skip(skip).Take(take)))!);
 
         // Act
-        var result = await _sut.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, offerTypeId, documentTypeId, null);
+        var result = await _sut.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, offerTypeId, documentTypeId, null, null);
 
         // Assert
         result.Meta.NumberOfElements.Should().Be(5);
@@ -2457,7 +2457,7 @@ public class OfferServiceTests
             x => x.OfferId == data[3].OfferId && x.OfferName == data[3].OfferName && x.Provider == data[3].Provider && x.OfferSubscriptionStatusId == data[3].OfferSubscriptionStatusId && x.OfferSubscriptionId == data[3].OfferSubscriptionId && x.DocumentId == data[3].DocumentId,
             x => x.OfferId == data[4].OfferId && x.OfferName == data[4].OfferName && x.Provider == data[4].Provider && x.OfferSubscriptionStatusId == data[4].OfferSubscriptionStatusId && x.OfferSubscriptionId == data[4].OfferSubscriptionId && x.DocumentId == data[4].DocumentId
         );
-        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(_companyId, offerTypeId, documentTypeId, null))
+        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(_companyId, offerTypeId, documentTypeId, null, null))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -2467,16 +2467,16 @@ public class OfferServiceTests
     public async Task GetCompanySubscribedOfferSubscriptionStatusesForUserAsync_WithQueryNullResult_ReturnsExpected(OfferTypeId offerTypeId, DocumentTypeId documentTypeId)
     {
         // Arrange
-        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(A<Guid>._, A<OfferTypeId>._, A<DocumentTypeId>._, A<OfferSubscriptionStatusId?>._))
+        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(A<Guid>._, A<OfferTypeId>._, A<DocumentTypeId>._, A<OfferSubscriptionStatusId?>._, A<string?>._))
             .Returns((skip, take) => Task.FromResult<Pagination.Source<OfferSubscriptionStatusData>?>(null));
 
         // Act
-        var result = await _sut.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, offerTypeId, documentTypeId, null);
+        var result = await _sut.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, offerTypeId, documentTypeId, null, null);
 
         // Assert
         result.Meta.NumberOfElements.Should().Be(0);
         result.Content.Should().BeEmpty();
-        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(_companyId, offerTypeId, documentTypeId, null))
+        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(_companyId, offerTypeId, documentTypeId, null, null))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
@@ -584,18 +584,18 @@ public class ServiceBusinessLogicTests
         // Arrange
         var data = _fixture.CreateMany<OfferSubscriptionStatusDetailData>(5).ToImmutableArray();
         var paginationResponse = new Pagination.Response<OfferSubscriptionStatusDetailData>(new Pagination.Metadata(data.Length, 1, 0, data.Length), data);
-        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<OfferTypeId>._, A<DocumentTypeId>._, A<OfferSubscriptionStatusId?>._))
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<OfferTypeId>._, A<DocumentTypeId>._, A<OfferSubscriptionStatusId?>._, A<string?>._))
             .Returns(paginationResponse);
 
         var sut = new ServiceBusinessLogic(null!, _offerService, null!, null!, _identityService, Options.Create(new ServiceSettings()));
 
         // Act
-        var result = await sut.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(0, 10, null);
+        var result = await sut.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(0, 10, null, null);
 
         // Assert
         result.Meta.NumberOfElements.Should().Be(5);
         result.Content.Should().HaveCount(5);
-        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE, null))
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE, null, null))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
@@ -306,14 +306,14 @@ public class ServiceControllerTest
         //Arrange
         var data = _fixture.CreateMany<OfferSubscriptionStatusDetailData>(3).ToImmutableArray();
         var pagination = new Pagination.Response<OfferSubscriptionStatusDetailData>(new Pagination.Metadata(data.Length, 1, 0, data.Length), data);
-        A.CallTo(() => _logic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<OfferSubscriptionStatusId?>._))
+        A.CallTo(() => _logic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<OfferSubscriptionStatusId?>._, A<string?>._))
             .Returns(pagination);
 
         //Act
         var result = await _controller.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync();
 
         //Assert
-        A.CallTo(() => _logic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(0, 15, null)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(0, 15, null, null)).MustHaveHappenedOnceExactly();
         result.Content.Should().HaveCount(3).And.ContainInOrder(data);
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -858,7 +858,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(companyId, offerTypeId, documentTypeId, null)(0, 15);
+        var result = await sut.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(companyId, offerTypeId, documentTypeId, null, null)(0, 15);
 
         // Assert
         switch (offerTypeId)
@@ -912,7 +912,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"), OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE, OfferSubscriptionStatusId.ACTIVE)(0, 15);
+        var result = await sut.GetOwnCompanySubscribedOfferSubscriptionStatusAsync(new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"), OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE, OfferSubscriptionStatusId.ACTIVE, null)(0, 15);
 
         // Assert
         result.Should().NotBeNull();


### PR DESCRIPTION
## Description

* added query param `name` to endpoint `GET: /api/apps/subscribed/subscription-status` to filter for app names
* added query param `name` to endpoint `GET: /api/services/subscribed/subscription-status` to filter for service names
* changed query param `statusId` to `status` of endpoint `GET: /api/apps/subscribed/subscription-status`

## Why

To be able to search for specific apps

## Issue

Refs: #592

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
