### PR TITLE
fix(connectors): add company connectors type filter to get connectors

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -46,7 +46,9 @@ public class ConnectorsRepository : IConnectorsRepository
             skip,
             take,
             _context.Connectors.AsNoTracking()
-                .Where(x => x.ProviderId == companyId && x.StatusId != ConnectorStatusId.INACTIVE)
+                .Where(x => x.ProviderId == companyId &&
+                       x.StatusId != ConnectorStatusId.INACTIVE &&
+                       x.TypeId == ConnectorTypeId.COMPANY_CONNECTOR)
                 .GroupBy(c => c.ProviderId),
             connector => connector.OrderByDescending(connector => connector.Name),
             con => new ConnectorData(

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -133,6 +133,30 @@ public class ConnectorsBusinessLogicTests
         result.Content.Should().HaveCount(resultPageSize);
     }
 
+    [Theory]
+    [InlineData(0, 10, 5, 1, 0, 5)]
+    public async Task GetAllCompanyConnectorDatasWithCheckTypeCompanyConnector_WithValidData_ReturnsExpected(int page, int size, int numberOfElements, int numberOfPages, int resultPage, int resultPageSize)
+    {
+        var data = _fixture.Build<ConnectorData>()
+            .With(x => x.Type, ConnectorTypeId.COMPANY_CONNECTOR)
+            .CreateMany(numberOfElements).ToImmutableArray();
+
+        A.CallTo(() => _connectorsRepository.GetAllCompanyConnectorsForCompanyId(A<Guid>._))
+            .Returns((int skip, int take) => Task.FromResult<Pagination.Source<ConnectorData>?>(new(data.Length, data.Skip(skip).Take(take))));
+
+        // Act
+        var result = await _logic.GetAllCompanyConnectorDatas(page, size);
+
+        // Assert
+        A.CallTo(() => _connectorsRepository.GetAllCompanyConnectorsForCompanyId(_identity.CompanyId)).MustHaveHappenedOnceExactly();
+        result.Should().NotBeNull();
+        result.Meta.NumberOfElements.Should().Be(numberOfElements);
+        result.Meta.NumberOfPages.Should().Be(numberOfPages);
+        result.Meta.Page.Should().Be(resultPage);
+        result.Meta.PageSize.Should().Be(resultPageSize);
+        result.Content.Should().HaveCount(resultPageSize);
+        result.Content.Should().Contain(x => x.Type == ConnectorTypeId.COMPANY_CONNECTOR);
+    }
     #endregion
 
     #region Create Connector

--- a/tests/administration/Administration.Service.Tests/IntegrationTests/ConnectorsControllerIntegrationTests.cs
+++ b/tests/administration/Administration.Service.Tests/IntegrationTests/ConnectorsControllerIntegrationTests.cs
@@ -50,6 +50,6 @@ public class ConnectorsControllerIntegrationTests : IClassFixture<IntegrationTes
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var pagination = await response.GetResultFromContent<Pagination.Response<ConnectorData>>();
-        pagination.Content.Should().HaveCount(2);
+        pagination.Content.Should().HaveCount(1);
     }
 }


### PR DESCRIPTION
## Description

When requesting connectors via GET: /api/administration/connectors with existing managed connectors, the managed connectors are also getting with own need to change the filter

## Why

The endpoint should only return connectors of type COMPANY_CONNECTOR so that own type can get only there types connectors and managed will get there type.

## Issue

#945 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
