### PR TITLE
fix(subscriptionActivationEmail): null requester name

### DIFF
--- a/src/mailing/Mailing.Template/EmailTemplates/serviceprovider_subscription_activation.html
+++ b/src/mailing/Mailing.Template/EmailTemplates/serviceprovider_subscription_activation.html
@@ -111,7 +111,7 @@
                                   style="Margin:0;padding-top:20px;padding-bottom:20px;padding-left:30px;padding-right:30px;text-align: left;">
                                   <p
                                     style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                                    Dear {offerRequesterName}, <br>your Catena-X marketplace subscription request for
+                                    Dear {offerCustomerName}, <br>your Catena-X marketplace subscription request for
                                     {offerName} got accepted and is not active.</p>
                                   <p
                                     style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">


### PR DESCRIPTION
## Description

Requester name is null

## Why

Requester name is null when requester or subscriber receives the Subscription Activation email.

## Issue

[Ref: 973](https://github.com/eclipse-tractusx/portal-backend/issues/973)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
