### PR TITLE
fix(registration): fix region mapping

### DIFF
--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -106,7 +106,7 @@ public class RegistrationBusinessLogic(
             legalEntity.LegalShortName ?? "",
             physicalPostalAddress?.City ?? "",
             physicalPostalAddress?.Street?.Name ?? "",
-            physicalPostalAddress?.AdministrativeAreaLevel1?.RegionCode,
+            physicalPostalAddress?.District,
             null,
             physicalPostalAddress?.Street?.HouseNumber,
             physicalPostalAddress?.PostalCode,

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -205,10 +205,9 @@ public class RegistrationBusinessLogicTest
             .With(x => x.Bpna, businessPartnerNumber)
             .With(x => x.PhysicalPostalAddress, _fixture.Build<BpdmPhysicalPostalAddress>()
                 .With(x => x.Country, _fixture.Build<BpdmCountry>().With(x => x.TechnicalKey, country).Create())
-                .With(x => x.AdministrativeAreaLevel1,
-                    _fixture.Build<BpdmAdministrativeAreaLevel>().With(x => x.RegionCode, region).Create())
                 .With(x => x.PostalCode, zipCode)
                 .With(x => x.City, city)
+                .With(x => x.District, region)
                 .With(x => x.Street,
                     _fixture.Build<BpdmStreet>().With(x => x.Name, streetName).With(x => x.HouseNumber, streetNumber)
                         .Create())


### PR DESCRIPTION
## Description

Changed the mapping of Region Field with District 

## Why

User is sending this data from FE which is sent via BE using District field to BPDM but when user try to fill it again from BPN search it becomes null as it is mapped with another field in BPDM

## Issue

#979 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
