### PR TITLE
fix(connectordeletion): change GetConnectorDeleteDataAsync to splitquery

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -159,6 +159,7 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
     /// <inheritdoc />
     public Task<DeleteConnectorData?> GetConnectorDeleteDataAsync(Guid connectorId, Guid companyId, IEnumerable<ProcessStepTypeId> processStepsToFilter) =>
         dbContext.Connectors
+            .AsSplitQuery()
             .Where(x => x.Id == connectorId)
             .Select(connector => new DeleteConnectorData(
                 connector.ProviderId == companyId || connector.HostId == companyId,


### PR DESCRIPTION
## Description

change GetConnectorDeleteDataAsync to splitquery

## Why

this query returns 2 independent IEnumerables which is inefficient when not being executed as splitquery. This was forgotten in #968 

## Issue

#966 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [X] I have performed a self-review of my own code
- [X] I have checked that new and existing tests pass locally with my changes
