### PR TITLE
feat(serviceAccount): adjust error messages

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
@@ -29,7 +29,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLog
 public interface IServiceAccountBusinessLogic
 {
     Task<IEnumerable<ServiceAccountDetails>> CreateOwnCompanyServiceAccountAsync(ServiceAccountCreationInfo serviceAccountCreationInfos);
-    Task<int> DeleteOwnCompanyServiceAccountAsync(Guid serviceAccountId);
+    Task DeleteOwnCompanyServiceAccountAsync(Guid serviceAccountId);
     Task<ServiceAccountConnectorOfferData> GetOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId);
     Task<ServiceAccountDetails> UpdateOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId, ServiceAccountEditableDetails serviceAccountDetails);
     Task<ServiceAccountDetails> ResetOwnCompanyServiceAccountSecretAsync(Guid serviceAccountId);

--- a/src/administration/Administration.Service/ErrorHandling/AdministrationServiceAccountErrorMessageContainer.cs
+++ b/src/administration/Administration.Service/ErrorHandling/AdministrationServiceAccountErrorMessageContainer.cs
@@ -26,20 +26,22 @@ public class AdministrationServiceAccountErrorMessageContainer : IErrorMessageCo
 {
     private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<AdministrationServiceAccountErrors, string> {
                 { AdministrationServiceAccountErrors.SERVICE_AUTH_SECRET_ARGUMENT, "other authenticationType values than SECRET are not supported yet , {authenticationType}" },
-                { AdministrationServiceAccountErrors.SERVICE_NAME_EMPTY_ARGUMENT, "name must not be empty, {name}"},
-                { AdministrationServiceAccountErrors.SERVICE_COMPANY_NOT_EXIST_CONFLICT, "company {companyId} does not exist"},
-                { AdministrationServiceAccountErrors.SERVICE_BPN_NOT_SET_CONFLICT, "bpn not set for company {companyId}"},
-                { AdministrationServiceAccountErrors.SERVICE_ROLES_NOT_ASSIGN_ARGUMENT, "The roles {unassignable} are not assignable to a service account, {userRoleIds}"},
-                { AdministrationServiceAccountErrors.SERVICE_ACCOUNT_NOT_FOUND, "serviceAccount {serviceAccountId} not found for company {companyId}"},
-                { AdministrationServiceAccountErrors.SERVICE_USERID_ACTIVATION_PENDING_CONFLICT, "Technical User is linked to an active connector. Change the link or deactivate the connector to delete the technical user."},
-                { AdministrationServiceAccountErrors.SERVICE_USERID_ACTIVATION_ACTIVE_CONFLICT, "Technical User is linked to an active subscription. Deactivate the subscription to delete the technical user."},
-                { AdministrationServiceAccountErrors.SERVICE_UNDEFINED_CLIENTID_CONFLICT, "undefined clientId for serviceAccount {serviceAccountId}"},
-                { AdministrationServiceAccountErrors.SERVICE_ID_PATH_NOT_MATCH_ARGUMENT, "serviceAccountId {serviceAccountId} from path does not match the one in body {serviceAccountDetailsServiceAccountId}"},
-                { AdministrationServiceAccountErrors.SERVICE_INACTIVE_CONFLICT, "serviceAccount {serviceAccountId} is already INACTIVE"},
-                { AdministrationServiceAccountErrors.SERVICE_CLIENTID_NOT_NULL_CONFLICT, "clientClientId of serviceAccount {serviceAccountId} should not be null"},
+                { AdministrationServiceAccountErrors.SERVICE_NAME_EMPTY_ARGUMENT, "name must not be empty, {name}" },
+                { AdministrationServiceAccountErrors.SERVICE_COMPANY_NOT_EXIST_CONFLICT, "company {companyId} does not exist" },
+                { AdministrationServiceAccountErrors.SERVICE_BPN_NOT_SET_CONFLICT, "bpn not set for company {companyId}" },
+                { AdministrationServiceAccountErrors.SERVICE_ROLES_NOT_ASSIGN_ARGUMENT, "The roles {unassignable} are not assignable to a service account, {userRoleIds}" },
+                { AdministrationServiceAccountErrors.SERVICE_ACCOUNT_NOT_FOUND, "serviceAccount {serviceAccountId} does not exist" },
+                { AdministrationServiceAccountErrors.SERVICE_USERID_ACTIVATION_PENDING_CONFLICT, "Technical User is linked to an active connector. Change the link or deactivate the connector to delete the technical user." },
+                { AdministrationServiceAccountErrors.SERVICE_USERID_ACTIVATION_ACTIVE_CONFLICT, "Technical User is linked to an active subscription. Deactivate the subscription to delete the technical user." },
+                { AdministrationServiceAccountErrors.SERVICE_UNDEFINED_CLIENTID_CONFLICT, "undefined clientId for serviceAccount {serviceAccountId}" },
+                { AdministrationServiceAccountErrors.SERVICE_ID_PATH_NOT_MATCH_ARGUMENT, "serviceAccountId {serviceAccountId} from path does not match the one in body {serviceAccountDetailsServiceAccountId}" },
+                { AdministrationServiceAccountErrors.SERVICE_INACTIVE_CONFLICT, "serviceAccount {serviceAccountId} is already INACTIVE" },
+                { AdministrationServiceAccountErrors.SERVICE_CLIENTID_NOT_NULL_CONFLICT, "clientClientId of serviceAccount {serviceAccountId} should not be null" },
                 { AdministrationServiceAccountErrors.SERVICE_ACCOUNT_NOT_LINKED_TO_PROCESS, "Service Account {serviceAccountId} is not linked to a process" },
-                { AdministrationServiceAccountErrors.SERVICE_ACCOUNT_PENDING_PROCESS_STEPS, "Service Account {serviceAccountId} has pending process steps {processStepTypeIds}"},
-                { AdministrationServiceAccountErrors.TECHNICAL_USER_CREATION_IN_PROGRESS, "Technical user can't be deleted because the creation progress is still running"}
+                { AdministrationServiceAccountErrors.SERVICE_ACCOUNT_PENDING_PROCESS_STEPS, "Service Account {serviceAccountId} has pending process steps {processStepTypeIds}" },
+                { AdministrationServiceAccountErrors.SERVICE_ACCOUNT_NOT_ACTIVE, "Service Account {serviceAccountId} is not status active" },
+                { AdministrationServiceAccountErrors.SERVICE_ACCOUNT_NO_PROVIDER_OR_OWNER, "Only provider or owner of the service account are allowed to delete it" },
+                { AdministrationServiceAccountErrors.TECHNICAL_USER_CREATION_IN_PROGRESS, "Technical user can't be deleted because the creation progress is still running" }
             }.ToImmutableDictionary(x => (int)x.Key, x => x.Value);
 
     public Type Type { get => typeof(AdministrationServiceAccountErrors); }
@@ -62,5 +64,7 @@ public enum AdministrationServiceAccountErrors
     SERVICE_CLIENTID_NOT_NULL_CONFLICT,
     SERVICE_ACCOUNT_NOT_LINKED_TO_PROCESS,
     SERVICE_ACCOUNT_PENDING_PROCESS_STEPS,
-    TECHNICAL_USER_CREATION_IN_PROGRESS
+    TECHNICAL_USER_CREATION_IN_PROGRESS,
+    SERVICE_ACCOUNT_NOT_ACTIVE,
+    SERVICE_ACCOUNT_NO_PROVIDER_OR_OWNER
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OwnServiceAccountData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OwnServiceAccountData.cs
@@ -24,6 +24,8 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 public record OwnServiceAccountData(
     IEnumerable<Guid> UserRoleIds,
     Guid ServiceAccountId,
+    UserStatusId ServiceAccountStatus,
+    bool IsOwnerOrProvider,
     Guid ServiceAccountVersion,
     Guid? ConnectorId,
     string? ClientClientId,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -97,12 +97,12 @@ public class ServiceAccountRepository(PortalDbContext portalDbContext) : IServic
     public Task<OwnServiceAccountData?> GetOwnCompanyServiceAccountWithIamServiceAccountRolesAsync(Guid serviceAccountId, Guid companyId, IEnumerable<ProcessStepTypeId> processStepsToFilter) =>
         portalDbContext.CompanyServiceAccounts
             .Where(serviceAccount =>
-                serviceAccount.Id == serviceAccountId &&
-                serviceAccount.Identity!.UserStatusId == UserStatusId.ACTIVE &&
-                (serviceAccount.CompaniesLinkedServiceAccount!.Owners == companyId || serviceAccount.CompaniesLinkedServiceAccount!.Provider == companyId))
+                serviceAccount.Id == serviceAccountId)
             .Select(sa => new OwnServiceAccountData(
                 sa.Identity!.IdentityAssignedRoles.Select(r => r.UserRoleId),
                 sa.Id,
+                sa.Identity!.UserStatusId,
+                sa.CompaniesLinkedServiceAccount!.Owners == companyId || sa.CompaniesLinkedServiceAccount!.Provider == companyId,
                 sa.Version,
                 sa.Connector!.Id,
                 sa.ClientClientId,


### PR DESCRIPTION
## Description

Adjust the error messages for `DELETE: api/administration/serviceaccount/owncompany/serviceaccounts/{serviceAccountId}`

## Why

To give a more specific error message

## Issue

Refs: #986

## Assets PR

https://github.com/eclipse-tractusx/portal-assets/pull/399

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
