### PR TITLE
feat(Invite): added company and application in invite api response

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/IInvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IInvitationBusinessLogic.cs
@@ -23,7 +23,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLog
 {
     public interface IInvitationBusinessLogic
     {
-        Task ExecuteInvitation(CompanyInvitationData invitationData);
+        Task<CompanyInvitationResponse> ExecuteInvitation(CompanyInvitationData invitationData);
         Task RetriggerCreateCentralIdp(Guid processId);
         Task RetriggerCreateSharedIdpServiceAccount(Guid processId);
         Task RetriggerUpdateCentralIdpUrls(Guid processId);

--- a/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
@@ -42,7 +42,7 @@ public class InvitationBusinessLogic : IInvitationBusinessLogic
         _portalRepositories = portalRepositories;
     }
 
-    public Task ExecuteInvitation(CompanyInvitationData invitationData)
+    public Task<CompanyInvitationResponse> ExecuteInvitation(CompanyInvitationData invitationData)
     {
         if (string.IsNullOrWhiteSpace(invitationData.Email))
         {
@@ -57,7 +57,7 @@ public class InvitationBusinessLogic : IInvitationBusinessLogic
         return ExecuteInvitationInternalAsync(invitationData);
     }
 
-    private async Task ExecuteInvitationInternalAsync(CompanyInvitationData invitationData)
+    private async Task<CompanyInvitationResponse> ExecuteInvitationInternalAsync(CompanyInvitationData invitationData)
     {
         var (userName, firstName, lastName, email, organisationName) = invitationData;
         var processStepRepository = _portalRepositories.GetInstance<IProcessStepRepository>();
@@ -78,6 +78,7 @@ public class InvitationBusinessLogic : IInvitationBusinessLogic
         });
 
         await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+        return new CompanyInvitationResponse(applicationId, company.Id);
     }
 
     public Task RetriggerCreateCentralIdp(Guid processId) => ProcessStepTypeId.RETRIGGER_INVITATION_CREATE_CENTRAL_IDP.TriggerProcessStep(processId, _portalRepositories);

--- a/src/administration/Administration.Service/Controllers/InvitationController.cs
+++ b/src/administration/Administration.Service/Controllers/InvitationController.cs
@@ -63,12 +63,12 @@ public class InvitationController : ControllerBase
     [HttpPost]
     [Authorize(Roles = "invite_new_partner")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CompanyInvitationResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status502BadGateway)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
-    public Task ExecuteInvitation([FromBody] CompanyInvitationData invitationData) =>
+    public Task<CompanyInvitationResponse> ExecuteInvitation([FromBody] CompanyInvitationData invitationData) =>
         _logic.ExecuteInvitation(invitationData);
 
     /// <summary>

--- a/src/administration/Administration.Service/Models/CompanyInvitationResponse.cs
+++ b/src/administration/Administration.Service/Models/CompanyInvitationResponse.cs
@@ -1,0 +1,22 @@
+/********************************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+
+public record CompanyInvitationResponse(Guid ApplicationId, Guid CompanyId);

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -97,13 +97,14 @@ public class InvitationBusinessLogicTests
             .WithEmailPattern(x => x.Email)
             .Create();
 
-        await _sut.ExecuteInvitation(invitationData);
+        var result = await _sut.ExecuteInvitation(invitationData);
 
         processes.Should().ContainSingle().And.Satisfy(x => x.ProcessTypeId == ProcessTypeId.INVITATION);
         processSteps.Should().ContainSingle().And.Satisfy(x => x.ProcessStepTypeId == ProcessStepTypeId.INVITATION_CREATE_CENTRAL_IDP && x.ProcessStepStatusId == ProcessStepStatusId.TODO);
         invitations.Should().ContainSingle().And.Satisfy(x => x.ProcessId == processes.Single().Id && x.UserName == "testUserName" && x.ApplicationId == ApplicationId);
         A.CallTo(() => _companyRepository.CreateCompany(A<string>._, null)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _applicationRepository.CreateCompanyApplication(CompanyId, CompanyApplicationStatusId.CREATED, CompanyApplicationTypeId.INTERNAL, null)).MustHaveHappenedOnceExactly();
+        result.Should().Be(new CompanyInvitationResponse(ApplicationId, CompanyId));
     }
 
     [Theory]

--- a/tests/administration/Administration.Service.Tests/Controllers/InvitationControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/InvitationControllerTests.cs
@@ -41,12 +41,15 @@ public class InvitationControllerTests
     {
         // Arrange
         var data = _fixture.Create<CompanyInvitationData>();
+        var expectedResponse = new CompanyInvitationResponse(Guid.NewGuid(), Guid.NewGuid());
+        A.CallTo(() => _logic.ExecuteInvitation(A<CompanyInvitationData>._)).Returns(expectedResponse);
 
         // Act
-        await _controller.ExecuteInvitation(data);
+        var result = await _controller.ExecuteInvitation(data);
 
         // Assert
         A.CallTo(() => _logic.ExecuteInvitation(data)).MustHaveHappenedOnceExactly();
+        result.Should().Be(expectedResponse);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Added the company id and application id in Invite api return response

## Why
However these changes were already merged in #963 but somehow got removed so creating the new PR 
In automation and CRM communication there was no reference id to track the Invitation .
So now by this change they can track the invitation by company id and application id.

## Issue

NA


## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
