### PR TITLE
feat(technicaluser): new parameters for api expansion for technical user data added 

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -162,10 +162,11 @@ public class ServiceAccountBusinessLogic(
 
         IamClientAuthMethod? iamClientAuthMethod;
         string? secret;
-        var AuthServiceUrl = (result.CompanyServiceAccountKindId == CompanyServiceAccountKindId.INTERNAL) ? _settings.AuthServiceUrl : result.DimServiceAccountData!.AuthenticationServiceUrl;
+        var authServiceUrl = _settings.AuthServiceUrl;
 
         if (result.DimServiceAccountData != null)
         {
+            authServiceUrl = result.DimServiceAccountData.AuthenticationServiceUrl;
             iamClientAuthMethod = IamClientAuthMethod.SECRET;
             var cryptoHelper = _settings.EncryptionConfigs.GetCryptoHelper(_settings.EncryptionConfigIndex);
             secret = cryptoHelper.Decrypt(
@@ -194,7 +195,7 @@ public class ServiceAccountBusinessLogic(
             result.UserRoleDatas,
             result.CompanyServiceAccountTypeId,
             result.CompanyServiceAccountKindId,
-            AuthServiceUrl,
+            authServiceUrl,
             result.Status,
             secret,
             result.ConnectorData,

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -192,6 +192,8 @@ public class ServiceAccountBusinessLogic(
             iamClientAuthMethod,
             result.UserRoleDatas,
             result.CompanyServiceAccountTypeId,
+            result.CompanyServiceAccountKindId,
+            result.DimServiceAccountData!.AuthenticationServiceUrl,
             result.Status,
             secret,
             result.ConnectorData,

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -162,6 +162,7 @@ public class ServiceAccountBusinessLogic(
 
         IamClientAuthMethod? iamClientAuthMethod;
         string? secret;
+        var AuthServiceUrl = (result.CompanyServiceAccountKindId == CompanyServiceAccountKindId.INTERNAL) ? _settings.AuthServiceUrl : result.DimServiceAccountData!.AuthenticationServiceUrl;
 
         if (result.DimServiceAccountData != null)
         {
@@ -193,7 +194,7 @@ public class ServiceAccountBusinessLogic(
             result.UserRoleDatas,
             result.CompanyServiceAccountTypeId,
             result.CompanyServiceAccountKindId,
-            result.DimServiceAccountData!.AuthenticationServiceUrl,
+            AuthServiceUrl,
             result.Status,
             secret,
             result.ConnectorData,

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountSettings.cs
@@ -40,6 +40,9 @@ public class ServiceAccountSettings
     [Required]
     [DistinctValues("x => x.Index")]
     public IEnumerable<EncryptionModeConfig> EncryptionConfigs { get; set; } = null!;
+
+    [Required]
+    public string AuthServiceUrl { get; set; } = null!;
 }
 
 public static class ServiceAccountSettingsExtensions

--- a/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
+++ b/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
@@ -33,10 +33,14 @@ public record ServiceAccountConnectorOfferData(
     [property: JsonPropertyName("authenticationType")] IamClientAuthMethod? IamClientAuthMethod,
     [property: JsonPropertyName("roles")] IEnumerable<UserRoleData> UserRoleDatas,
     [property: JsonPropertyName("companyServiceAccountTypeId")] CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
+    [property: JsonPropertyName("usertype")] CompanyServiceAccountKindId CompanyServiceAccountKindId,
+    [property: JsonPropertyName("authenticationServiceUrl")] string AuthenticationServiceUrl,
     [property: JsonPropertyName("status")] UserStatusId UserStatusId,
     [property: JsonPropertyName("secret")] string? Secret,
     [property: JsonPropertyName("connector")] ConnectorResponseData? Connector,
     [property: JsonPropertyName("offer")] OfferResponseData? Offer,
     [property: JsonPropertyName("LastEditorName")] string? LastName,
-    [property: JsonPropertyName("LastEditorCompanyName")] string? CompanyName
+    [property: JsonPropertyName("LastEditorCompanyName")] string? CompanyName,
+    [property: JsonPropertyName("subscriptionId")] Guid? SubscriptionId = null
+
 );

--- a/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
+++ b/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
@@ -40,7 +40,6 @@ public record ServiceAccountConnectorOfferData(
     [property: JsonPropertyName("connector")] ConnectorResponseData? Connector,
     [property: JsonPropertyName("offer")] OfferResponseData? Offer,
     [property: JsonPropertyName("LastEditorName")] string? LastName,
-    [property: JsonPropertyName("LastEditorCompanyName")] string? CompanyName,
-    [property: JsonPropertyName("subscriptionId")] Guid? SubscriptionId = null
+    [property: JsonPropertyName("LastEditorCompanyName")] string? CompanyName
 
 );

--- a/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
+++ b/src/administration/Administration.Service/Models/ServiceAccountConnectorOfferData.cs
@@ -41,5 +41,4 @@ public record ServiceAccountConnectorOfferData(
     [property: JsonPropertyName("offer")] OfferResponseData? Offer,
     [property: JsonPropertyName("LastEditorName")] string? LastName,
     [property: JsonPropertyName("LastEditorCompanyName")] string? CompanyName
-
 );

--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -248,7 +248,8 @@
   "ServiceAccount": {
     "ClientId": "",
     "EncryptionConfigIndex": 0,
-    "EncryptionConfigs": []
+    "EncryptionConfigs": [],
+    "AuthServiceUrl": ""
   },
   "Connectors": {
     "MaxPageSize": 20,

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
@@ -31,7 +31,6 @@ public record CompanyServiceAccountDetailedData(
     IEnumerable<UserRoleData> UserRoleDatas,
     CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
     CompanyServiceAccountKindId CompanyServiceAccountKindId,
-    Guid? SubscriptionId,
     ConnectorResponseData? ConnectorData,
     OfferResponseData? OfferSubscriptionData,
     CompanyLastEditorData? CompanyLastEditorData,

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
@@ -30,6 +30,8 @@ public record CompanyServiceAccountDetailedData(
     UserStatusId Status,
     IEnumerable<UserRoleData> UserRoleDatas,
     CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
+    CompanyServiceAccountKindId CompanyServiceAccountKindId,
+    Guid? SubscriptionId,
     ConnectorResponseData? ConnectorData,
     OfferResponseData? OfferSubscriptionData,
     CompanyLastEditorData? CompanyLastEditorData,
@@ -42,6 +44,7 @@ public record OfferResponseData(Guid Id, OfferTypeId Type, string? Name, Guid? S
 public record CompanyLastEditorData(string? Name, string CompanyName);
 
 public record DimServiceAccountData(
+    string AuthenticationServiceUrl,
     byte[] ClientSecret,
     byte[]? InitializationVector,
     int EncryptionMode

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -147,7 +147,6 @@ public class ServiceAccountRepository(PortalDbContext portalDbContext) : IServic
                         userRole.UserRoleText)),
                 x.ServiceAccount.CompanyServiceAccountTypeId,
                 x.ServiceAccount.CompanyServiceAccountKindId,
-                x.ServiceAccount.OfferSubscriptionId,
                 x.Connector == null
                     ? null
                     : new ConnectorResponseData(

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -146,6 +146,8 @@ public class ServiceAccountRepository(PortalDbContext portalDbContext) : IServic
                         userRole.Offer!.AppInstances.First().IamClient!.ClientClientId,
                         userRole.UserRoleText)),
                 x.ServiceAccount.CompanyServiceAccountTypeId,
+                x.ServiceAccount.CompanyServiceAccountKindId,
+                x.ServiceAccount.OfferSubscriptionId,
                 x.Connector == null
                     ? null
                     : new ConnectorResponseData(
@@ -168,6 +170,7 @@ public class ServiceAccountRepository(PortalDbContext portalDbContext) : IServic
                 x.ServiceAccount.DimCompanyServiceAccount == null
                     ? null
                     : new DimServiceAccountData(
+                        x.DimCompanyServiceAccount!.AuthenticationServiceUrl,
                         x.DimCompanyServiceAccount!.ClientSecret,
                         x.DimCompanyServiceAccount.InitializationVector,
                         x.DimCompanyServiceAccount.EncryptionMode)))

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -242,7 +242,7 @@ public class ServiceAccountBusinessLogicTests
     [Fact]
     public async Task GetOwnCompanyServiceAccountDetailsAsync_WithValidUserTypeInternal_AuthenticationUrl()
     {
-        // Arrange        
+        // Arrange
         SetupGetOwnComapnyServiceAccountInternalType();
         var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
@@ -839,8 +839,8 @@ public class ServiceAccountBusinessLogicTests
 
     private void SetupGetOwnCompanyServiceAccount()
     {
-        var cryptoConfig = _options.Value.EncryptionConfigs.Single(x => x.Index == _options.Value.EncryptionConfigIndex);
-        var (secret, initializationVector) = CryptoHelper.Encrypt("test", Convert.FromHexString(cryptoConfig.EncryptionKey), cryptoConfig.CipherMode, cryptoConfig.PaddingMode);
+        var cryptoHelper = _options.Value.EncryptionConfigs.GetCryptoHelper(_options.Value.EncryptionConfigIndex);
+        var (secret, initializationVector) = cryptoHelper.Encrypt("test");
 
         var dimServiceAccountData = new DimServiceAccountData("https://example.org/auth", secret, initializationVector, _options.Value.EncryptionConfigIndex);
         var dataWithDim = _fixture.Build<CompanyServiceAccountDetailedData>()
@@ -872,8 +872,8 @@ public class ServiceAccountBusinessLogicTests
 
     private void SetupGetOwnComapnyServiceAccountExternalType()
     {
-        var cryptoConfig = _options.Value.EncryptionConfigs.Single(x => x.Index == _options.Value.EncryptionConfigIndex);
-        var (secret, initializationVector) = CryptoHelper.Encrypt("test", Convert.FromHexString(cryptoConfig.EncryptionKey), cryptoConfig.CipherMode, cryptoConfig.PaddingMode);
+        var cryptoHelper = _options.Value.EncryptionConfigs.GetCryptoHelper(_options.Value.EncryptionConfigIndex);
+        var (secret, initializationVector) = cryptoHelper.Encrypt("test");
 
         var dimServiceAccountData = new DimServiceAccountData("https://test.org/auth", secret, initializationVector, _options.Value.EncryptionConfigIndex);
 
@@ -885,7 +885,6 @@ public class ServiceAccountBusinessLogicTests
 
         A.CallTo(() => _serviceAccountRepository.GetOwnCompanyServiceAccountDetailedDataUntrackedAsync(ValidServiceAccountId, ValidCompanyId))
         .Returns(externalData);
-
     }
 
     private void SetupDeleteOwnCompanyServiceAccount(Connector? connector = null, Identity? identity = null, Guid? processId = null)

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -100,7 +100,7 @@ public class ServiceAccountBusinessLogicTests
 
         _options = Options.Create(new ServiceAccountSettings
         {
-            AuthServiceUrl = "https://testcentralidp.int.testcatena-x.net/auth",
+            AuthServiceUrl = "https://auth.test/auth",
             ClientId = ClientId,
             EncryptionConfigIndex = 1,
             EncryptionConfigs = new[] { new EncryptionModeConfig() { Index = 1, EncryptionKey = Convert.ToHexString(encryptionKey), CipherMode = System.Security.Cryptography.CipherMode.CBC, PaddingMode = System.Security.Cryptography.PaddingMode.PKCS7 } },
@@ -255,7 +255,7 @@ public class ServiceAccountBusinessLogicTests
         // Assert
         result.Should().NotBeNull();
         result.CompanyServiceAccountKindId.Should().Be(CompanyServiceAccountKindId.INTERNAL);
-        result.AuthenticationServiceUrl.Should().Be("https://testcentralidp.int.testcatena-x.net/auth");
+        result.AuthenticationServiceUrl.Should().Be("https://auth.test/auth");
     }
 
     [Fact]
@@ -289,7 +289,7 @@ public class ServiceAccountBusinessLogicTests
         // Assert
         result.Should().NotBeNull();
         result.CompanyServiceAccountKindId.Should().NotBe(CompanyServiceAccountKindId.INTERNAL);
-        result.AuthenticationServiceUrl.Should().NotBe("https://testcentralidp.int.testcatena-x.net/auth");
+        result.AuthenticationServiceUrl.Should().NotBe("https://auth.test/auth");
     }
 
     [Fact]

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -100,6 +100,7 @@ public class ServiceAccountBusinessLogicTests
 
         _options = Options.Create(new ServiceAccountSettings
         {
+            AuthServiceUrl = "https://testcentralidp.int.testcatena-x.net/auth",
             ClientId = ClientId,
             EncryptionConfigIndex = 1,
             EncryptionConfigs = new[] { new EncryptionModeConfig() { Index = 1, EncryptionKey = Convert.ToHexString(encryptionKey), CipherMode = System.Security.Cryptography.CipherMode.CBC, PaddingMode = System.Security.Cryptography.PaddingMode.PKCS7 } },
@@ -254,7 +255,7 @@ public class ServiceAccountBusinessLogicTests
         // Assert
         result.Should().NotBeNull();
         result.CompanyServiceAccountKindId.Should().Be(CompanyServiceAccountKindId.INTERNAL);
-        result.AuthenticationServiceUrl.Should().Be("https://example.org/auth");
+        result.AuthenticationServiceUrl.Should().Be("https://testcentralidp.int.testcatena-x.net/auth");
     }
 
     [Fact]
@@ -272,6 +273,23 @@ public class ServiceAccountBusinessLogicTests
         result.Should().NotBeNull();
         result.CompanyServiceAccountKindId.Should().Be(CompanyServiceAccountKindId.EXTERNAL);
         result.AuthenticationServiceUrl.Should().Be("https://example.org/auth");
+    }
+
+    [Fact]
+    public async Task GetOwnCompanyServiceAccountDetailsAsync_WithInValidUserTypeInternal_AuthenticationUrl()
+    {
+        // Arrange       
+        SetupGetOwnCompanyServiceAccountDetails();
+        SetupGetOwnComapnyServiceAccountExternalType();
+        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+
+        // Act
+        var result = await sut.GetOwnCompanyServiceAccountDetailsAsync(ValidServiceAccountId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.CompanyServiceAccountKindId.Should().NotBe(CompanyServiceAccountKindId.INTERNAL);
+        result.AuthenticationServiceUrl.Should().NotBe("https://testcentralidp.int.testcatena-x.net/auth");
     }
 
     [Fact]

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -849,7 +849,7 @@ public class ServiceAccountBusinessLogicTests
 
     private void SetupGetOwnComapnyServiceAccountInternalType()
     {
-        var data = _fixture.Build<CompanyServiceAccountDetailedData>()
+        _fixture.Build<CompanyServiceAccountDetailedData>()
             .With(x => x.Status, UserStatusId.ACTIVE)
             .With(x => x.CompanyServiceAccountKindId, CompanyServiceAccountKindId.INTERNAL)
             .With(x => x.DimServiceAccountData, default(DimServiceAccountData?))
@@ -859,7 +859,7 @@ public class ServiceAccountBusinessLogicTests
 
     private void SetupGetOwnComapnyServiceAccountExternalType()
     {
-        var data = _fixture.Build<CompanyServiceAccountDetailedData>()
+        _fixture.Build<CompanyServiceAccountDetailedData>()
             .With(x => x.Status, UserStatusId.ACTIVE)
             .With(x => x.CompanyServiceAccountKindId, CompanyServiceAccountKindId.EXTERNAL)
             .With(x => x.DimServiceAccountData, default(DimServiceAccountData?))

--- a/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
+++ b/tests/administration/Administration.Service.Tests/appsettings.IntegrationTests.json
@@ -245,7 +245,8 @@
         "CipherMode": "CBC",
         "PaddingMode": "PKCS7"
       }
-    ]
+    ],
+    "AuthServiceUrl": "https://auth.test/auth"
   },
   "Connectors": {
     "MaxPageSize": 20,


### PR DESCRIPTION
## Description

Add Parameter usertype and authentication_service_url in below mentioned api
GET: api/administration/serviceaccount/owncompany/serviceaccounts/{GetServiceAccountId}

## Why

For checking user_type internal or external and valid authenticatio_service_url for specific technical user 

## Issue

#976 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
