### PR TITLE
chore(dependabot): change grouping pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,10 +33,9 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
+      default:
+        patterns:
+          - "*"
 
   # Github Actions
   -


### PR DESCRIPTION
## Description

to capture all dependencies without creating multiple custom groups

## Why

grouping into production and development dependencies appears to not be working, example logs: "Skipping update group for 'production-dependencies' as it does not match any allowed dependencies."
no pull requests get created

## Issue

n/a

relates to https://github.com/eclipse-tractusx/portal/issues/300

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
