### PR TITLE
feat(tech user): add internal invitation tech user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,7 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 * **Invitation**
   * enabled creation of application and company on invite to remove the delay of the company application after invite [#960](https://github.com/eclipse-tractusx/portal-backend/pull/960)
   * allowed access to invitation endpoint to technical user [#933](https://github.com/eclipse-tractusx/portal-backend/pull/933)
-* **Technical User**
-  * new parameters for api expansion for technical user data [#997](https://github.com/eclipse-tractusx/portal-backend/pull/997)
-  * add Registration Internal as Operator technical user for invite API [#1002](https://github.com/eclipse-tractusx/portal-backend/pull/1002)
+* **Technical User**: new parameters for api expansion for technical user data [#997](https://github.com/eclipse-tractusx/portal-backend/pull/997)
 * **Administration**: introduced validating og bpn before adding to company user [#902](https://github.com/eclipse-tractusx/portal-backend/pull/902)
 * **Business Partner Data Management**: add sharing state ready toggle [#905](https://github.com/eclipse-tractusx/portal-backend/pull/905)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X Portal Backend.
 
+## Unreleased
+
+## Feature
+
+* **Technical User**
+  * add Registration Internal as Operator technical user for invite API [#1002](https://github.com/eclipse-tractusx/portal-backend/pull/1002)
+
 ## 2.3.0-alpha.1
 
 ## Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
 * **Invitation**
   * enabled creation of application and company on invite to remove the delay of the company application after invite [#960](https://github.com/eclipse-tractusx/portal-backend/pull/960)
   * allowed access to invitation endpoint to technical user [#933](https://github.com/eclipse-tractusx/portal-backend/pull/933)
-* **Technical User**: new parameters for api expansion for technical user data [#997](https://github.com/eclipse-tractusx/portal-backend/pull/997)
+* **Technical User**
+  * new parameters for api expansion for technical user data [#997](https://github.com/eclipse-tractusx/portal-backend/pull/997)
+  * add Registration Internal as Operator technical user for invite API [#1002](https://github.com/eclipse-tractusx/portal-backend/pull/1002)
 * **Administration**: introduced validating og bpn before adding to company user [#902](https://github.com/eclipse-tractusx/portal-backend/pull/902)
 * **Business Partner Data Management**: add sharing state ready toggle [#905](https://github.com/eclipse-tractusx/portal-backend/pull/905)
 

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_assigned_collections.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_assigned_collections.json
@@ -32,6 +32,10 @@
     "user_role_collection_id": "1a24eca5-901f-4191-84a7-4ef09a894575"
   },
   {
+    "user_role_id": "34c42896-a003-4653-af8f-ba06ca595754",
+    "user_role_collection_id": "1a24eca5-901f-4191-84a7-4ef09a894575"
+  },
+  {
     "user_role_id": "58f897ec-0aad-4588-8ffa-5f45d6638633",
     "user_role_collection_id": "8cb12ea2-aed4-4d75-b041-ba297df3d2f2"
   },

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_descriptions.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_descriptions.json
@@ -258,5 +258,15 @@
     "user_role_id": "c01818be-4978-41f4-bf63-fa6d2de53267",
     "language_short_name": "en",
     "description": "BPDM Pool Sharing Consumer"
+  },
+  {
+    "user_role_id": "34c42896-a003-4653-af8f-ba06ca595754",
+    "language_short_name": "de",
+    "description": "Technischer User für die Invitation API zur Integration von Drittanbieter-Software."
+  },
+  {
+    "user_role_id": "34c42896-a003-4653-af8f-ba06ca595754",
+    "language_short_name": "en",
+    "description": "Technical user enabling the invitation API to integrate 3rd party software."
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_roles.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_roles.json
@@ -164,7 +164,7 @@
   {
     "id": "34c42896-a003-4653-af8f-ba06ca595754",
     "user_role": "Registration Internal",
-    "offer_id": "9b957704-3505-4445-822c-d7ef80f27fcd",
+    "offer_id": "0ffcb416-1101-4ba6-8d4a-a9dfa31745a4",
     "last_editor_id": null
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_roles.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_roles.json
@@ -160,5 +160,11 @@
     "user_role": "BPDM Pool Sharing Consumer",
     "offer_id": "0ffcb416-1101-4ba6-8d4a-a9dfa31745a4",
     "last_editor_id": null
+  },
+  {
+    "id": "34c42896-a003-4653-af8f-ba06ca595754",
+    "user_role": "Registration Internal",
+    "offer_id": "9b957704-3505-4445-822c-d7ef80f27fcd",
+    "last_editor_id": null
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -688,7 +688,7 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result.Should().NotBe(default);
         result.Bpn.Should().Be("BPNL00000003CRHK");
-        result.TechnicalUserRoleIds.Should().HaveCount(13).And.OnlyHaveUniqueItems();
+        result.TechnicalUserRoleIds.Should().HaveCount(14).And.OnlyHaveUniqueItems();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRoleCollectionRolesViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRoleCollectionRolesViewTests.cs
@@ -45,7 +45,7 @@ public class CompanyRoleCollectionRolesViewTests : IAssemblyFixture<TestDbFixtur
 
         // Act
         var result = await sut.CompanyRoleCollectionRolesView.ToListAsync();
-        result.Should().HaveCount(56);
+        result.Should().HaveCount(57);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -137,7 +137,7 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         data.Should().HaveCount(14);
         data.Should().OnlyHaveUniqueItems();
-        data.Where(x => x.RoleType == UserRoleType.Internal).Should().HaveCount(12);
+        data.Where(x => x.RoleType == UserRoleType.Internal).Should().HaveCount(13);
         data.Where(x => x.RoleType == UserRoleType.External).Should().ContainSingle();
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -57,7 +57,7 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         var data = await sut.GetCoreOfferRolesAsync(_validCompanyId, "en", ClientId).ToListAsync();
 
         // Assert
-        data.Should().HaveCount(13);
+        data.Should().HaveCount(14);
     }
 
     #endregion
@@ -135,7 +135,7 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         var data = await sut.GetServiceAccountRolesAsync(_validCompanyId, ClientId, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1), Constants.DefaultLanguage).ToListAsync();
 
         // Assert
-        data.Should().HaveCount(13);
+        data.Should().HaveCount(14);
         data.Should().OnlyHaveUniqueItems();
         data.Where(x => x.RoleType == UserRoleType.Internal).Should().HaveCount(12);
         data.Where(x => x.RoleType == UserRoleType.External).Should().ContainSingle();


### PR DESCRIPTION
## Description

Add `Registration Internal` as new technical user that can be created in portal.

New `technical_roles_management` composite role with name `Registration Internal` with:
- `invite_new_partner`
- `view_submitted_applications`

is also being added as new client role in eclipse-tractusx/portal-iam#189

## Why

Operator company wants to integrate 3rd party service to send out invites. Allows inviting and reviewing status via API.

## Issue

Refs: eclipse-tractusx/portal-backend#932
Related: eclipse-tractusx/portal-iam#189

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
