### PR TITLE
build: adjust maintenance docker image

### DIFF
--- a/docker/Dockerfile-maintenance-service
+++ b/docker/Dockerfile-maintenance-service
@@ -23,14 +23,21 @@ COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/maintenance/Maintenance.App/ src/maintenance/Maintenance.App/
 COPY src/portalbackend/PortalBackend.DBAccess/ src/portalbackend/PortalBackend.DBAccess/
 COPY src/portalbackend/PortalBackend.PortalEntities/ src/portalbackend/PortalBackend.PortalEntities/
+COPY src/externalsystems/Clearinghouse.Library/ src/externalsystems/Clearinghouse.Library/
+COPY src/externalsystems/Custodian.Library/ src/externalsystems/Custodian.Library/
+COPY src/framework/Framework.Async/ src/framework/Framework.Async/
 COPY src/framework/Framework.DBAccess/ src/framework/Framework.DBAccess/
 COPY src/framework/Framework.Linq/ src/framework/Framework.Linq/
 COPY src/framework/Framework.Models/ src/framework/Framework.Models/
 COPY src/framework/Framework.Logging/ src/framework/Framework.Logging/
 COPY src/framework/Framework.Seeding/ src/framework/Framework.Seeding/
+COPY src/framework/Framework.IO/ src/framework/Framework.IO/
+COPY src/framework/Framework.Token/ src/framework/Framework.Token/
+COPY src/framework/Framework.HttpClientExtensions/ src/framework/Framework.HttpClientExtensions/
 COPY src/framework/Framework.ErrorHandling/ src/framework/Framework.ErrorHandling/
 COPY src/framework/Framework.DateTimeProvider/ src/framework/Framework.DateTimeProvider/
 COPY src/processes/Processes.ProcessIdentity/ src/processes/Processes.ProcessIdentity/
+COPY src/processes/ApplicationChecklist.Library/ src/processes/ApplicationChecklist.Library/
 RUN dotnet restore "src/maintenance/Maintenance.App/Maintenance.App.csproj"
 WORKDIR /src/maintenance/Maintenance.App
 RUN dotnet publish "Maintenance.App.csproj" -c Release -o /app/publish


### PR DESCRIPTION
## Description

Added missing references to maintenance service docker image

## Why

The docker image can't be build due to missing references

## Issue

Refs: #810

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x  I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
