### PR TITLE
fix(Registration): added agreement table in update seeder

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchUpdateSeeder.cs
@@ -158,6 +158,16 @@ public class BatchUpdateSeeder : ICustomSeeder
                 dbEntry.ChecklistProcessId = entry.ChecklistProcessId;
             }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 
+        await SeedTable<Agreement>("agreements",
+            x => x.Id,
+            x => x.dataEntity.Name != x.dbEntity.Name || x.dataEntity.AgreementStatusId != x.dbEntity.AgreementStatusId,
+            (dbEntry, entry) =>
+            {
+                dbEntry.Name = entry.Name;
+                dbEntry.AgreementStatusId = entry.AgreementStatusId;
+                dbEntry.DateLastChanged = DateTimeOffset.UtcNow;
+            }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+
         await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
         _logger.LogInformation("Finished BaseEntityBatch Seeder");
     }


### PR DESCRIPTION
## Description

Added the 'agreements' table in update seeder

## Why

It is quite possible that operator company may want different name of agreement or enable/disable them.
Currently this table is missing from BatchUpdateSeeder.cs so even if operator company overwrite the seeder file ,agreement data won't get updated.

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
