### PR TITLE
fix(appManagement): not getting Emails on the Rejection of App Release Request

### DIFF
--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -560,8 +560,6 @@ public class OfferService(
         await notificationService.CreateNotifications(notificationRecipients, _identityData.IdentityId, content, declineData.CompanyId.Value).AwaitAll().ConfigureAwait(false);
         await notificationService.SetNotificationsForOfferToDone(catenaAdminRoles, submitOfferNotificationTypeIds, offerId).ConfigureAwait(ConfigureAwaitOptions.None);
 
-        await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
-
         await mailingProcessCreation.RoleBaseSendMail(
             notificationRecipients,
             new[]
@@ -576,6 +574,8 @@ public class OfferService(
                 $"{offerType.ToString().ToLower()}-request-decline"
             },
             declineData.CompanyId.Value).ConfigureAwait(ConfigureAwaitOptions.None);
+
+        await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
     }
 
     private async Task CheckLanguageCodesExist(IEnumerable<string> languageCodes)

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -485,23 +485,21 @@ public class OfferService(
         await notificationService.CreateNotifications(approveOfferRoles, _identityData.IdentityId, content, offerDetails.ProviderCompanyId.Value).AwaitAll().ConfigureAwait(false);
         await notificationService.SetNotificationsForOfferToDone(catenaAdminRoles, submitOfferNotificationTypeIds, offerId).ConfigureAwait(ConfigureAwaitOptions.None);
 
-        await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
-
         await mailingProcessCreation.RoleBaseSendMail(
             notificationRecipients,
-            new[]
-            {
+            [
                 ("offerName", offerDetails.OfferName),
                 ("offerSubscriptionUrl", mailParams.SubscriptionUrl),
                 ("offerDetailUrl", $"{mailParams.DetailUrl}/{offerId}"),
                 (offerTypeId == OfferTypeId.APP ? "appId" : "serviceId", offerId.ToString())
-            },
+            ],
             ("offerProviderName", "User"),
-            new[]
-            {
+            [
                 $"{offerTypeId.ToString().ToLower()}-release-activation"
-            },
+            ],
             offerDetails.ProviderCompanyId.Value).ConfigureAwait(ConfigureAwaitOptions.None);
+
+        await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
     }
 
     /// <inheritdoc />
@@ -562,17 +560,15 @@ public class OfferService(
 
         await mailingProcessCreation.RoleBaseSendMail(
             notificationRecipients,
-            new[]
-            {
+            [
                 ("offerName", declineData.OfferName),
                 ("url", basePortalAddress),
                 ("declineMessage", data.Message),
-            },
+            ],
             ("offerProviderName", "Service Manager"),
-            new[]
-            {
+            [
                 $"{offerType.ToString().ToLower()}-request-decline"
-            },
+            ],
             declineData.CompanyId.Value).ConfigureAwait(ConfigureAwaitOptions.None);
 
         await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);

--- a/src/marketplace/Offers.Library/Service/OfferSubscriptionService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSubscriptionService.cs
@@ -89,16 +89,14 @@ public class OfferSubscriptionService : IOfferSubscriptionService
 
         await _mailingProcessCreation.RoleBaseSendMail(
             notificationRecipients,
-            new[]
-            {
+            [
                 ("offerName", offerProviderDetails.OfferName!),
                 ("url", basePortalAddress)
-            },
+            ],
             ("offerProviderName", "User"),
-            new[]
-            {
+            [
                 $"{offerTypeId.ToString().ToLower()}-subscription-request"
-            },
+            ],
             offerProviderDetails.ProviderCompanyId.Value).ConfigureAwait(ConfigureAwaitOptions.None);
         await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
 


### PR DESCRIPTION
## Description

App Manager is not receiving the email notification upon approval or rejecting the app.

## Why

In the App Request Management section, users are not receiving email notifications when an App Release Request is approved or rejected. This error has been introduced with the refactoring of email-creation by process-worker. The dbcontext now must be saved after creating the email-processes. Before the refactoring email-creating did not involve the database.

## Issue

[Ref: 1015](https://github.com/eclipse-tractusx/portal-backend/issues/1015)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes