### PR TITLE
feat(technicaluser): usertype parameter added in get service account data

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
@@ -27,6 +27,7 @@ public record CompanyServiceAccountData(
     [property: JsonPropertyName("serviceAccountId")] Guid ServiceAccountId,
     [property: JsonPropertyName("clientId")] string? ClientId,
     [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("userType")] CompanyServiceAccountKindId CompanyServiceAccountKindId,
     [property: JsonPropertyName("serviceAccountType")] CompanyServiceAccountTypeId CompanyServiceAccountTypeId,
     [property: JsonPropertyName("status")] UserStatusId UserStatusId,
     [property: JsonPropertyName("isOwner")] bool IsOwner,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -199,6 +199,7 @@ public class ServiceAccountRepository(PortalDbContext portalDbContext) : IServic
                 x.ServiceAccount.Id,
                 x.ServiceAccount.ClientClientId,
                 x.ServiceAccount.Name,
+                x.ServiceAccount.CompanyServiceAccountKindId,
                 x.ServiceAccount.CompanyServiceAccountTypeId,
                 x.ServiceAccount.Identity!.UserStatusId,
                 x.IsOwner,


### PR DESCRIPTION
## Description

Add Parameter usertype should display internal or external in api mentioned below:
GET: api/administration/serviceaccount/owncompany/serviceaccounts

## Why

usertype parameter with respective mentioned api need to add to check internal or external type of user

## Issue

#976 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
