### PR TITLE
test(api-hub): add api specifications from feature branch

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -18,3 +18,9 @@
 ###############################################################
 
 leadingRepository: "https://github.com/eclipse-tractusx/portal"
+openApiSpecs:
+- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Administration.Service.yaml"
+- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Apps.Service.yaml"
+- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Notifications.Service.yaml"
+- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Registration.Service.yaml"
+- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Services.Service.yaml"


### PR DESCRIPTION
## Description

add api specifications from feature branch
should only get merged once https://github.com/eclipse-tractusx/portal-backend/pull/1030 is ready for testing

## Why

to the api-hub as it only consider specification references within main branch

## Issue

https://github.com/eclipse-tractusx/portal-backend/issues/1021

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes