### PR TITLE
test(api-hub): change to raw.githubusercontent for openApiSpecs

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -19,8 +19,8 @@
 
 leadingRepository: "https://github.com/eclipse-tractusx/portal"
 openApiSpecs:
-- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Administration.Service.yaml"
-- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Apps.Service.yaml"
-- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Notifications.Service.yaml"
-- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Registration.Service.yaml"
-- "https://github.com/eclipse-tractusx/portal-backend/tree/feature/1021-api-hub/docs/api/Org.Eclipse.TractusX.Portal.Backend.Services.Service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Administration.Service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Apps.Service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Notifications.Service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Registration.Service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Services.Service.yaml"


### PR DESCRIPTION
## Description

change to raw.githubusercontent for openApiSpecs

## Why

api-hub runs into error when collecting specification

## Issue

follow up to https://github.com/eclipse-tractusx/portal-backend/pull/1032
https://github.com/eclipse-tractusx/portal-backend/issues/1021

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
