### PR TITLE
test(swagger-hub): change to filename without .Service

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -19,8 +19,8 @@
 
 leadingRepository: "https://github.com/eclipse-tractusx/portal"
 openApiSpecs:
-- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Administration.Service.yaml"
-- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Apps.Service.yaml"
-- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Notifications.Service.yaml"
-- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Registration.Service.yaml"
-- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/752ee7abf52606402d4053fe6edb9b8a05a74b84/docs/api/Org.Eclipse.TractusX.Portal.Backend.Services.Service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/9f2b0e92eb28bd75f916acaae5a4d1f3f0ac610c/docs/api/administration-service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/9f2b0e92eb28bd75f916acaae5a4d1f3f0ac610c/docs/api/apps-service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/9f2b0e92eb28bd75f916acaae5a4d1f3f0ac610c/docs/api/notifications-service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/9f2b0e92eb28bd75f916acaae5a4d1f3f0ac610c/docs/api/registration-service.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/portal-backend/9f2b0e92eb28bd75f916acaae5a4d1f3f0ac610c/docs/api/services-service.yaml"


### PR DESCRIPTION
## Description

change to filename without .Service

## Why

leads to issues when filename is used to determine directory structure at api-hub

## Issue

follow up to https://github.com/eclipse-tractusx/portal-backend/pull/1032 and https://github.com/eclipse-tractusx/portal-backend/pull/1033
https://github.com/eclipse-tractusx/portal-backend/issues/1021

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes