### PR TITLE
feat(technicalUser): add internal external flag to profiles

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -338,7 +338,7 @@ public class ServiceAccountBusinessLogic(
                            userRoles,
                            languageShortName ?? Constants.DefaultLanguage))
         {
-            yield return userRole;
+            yield return new UserRoleWithDescription(userRole.UserRoleId, userRole.UserRoleText, userRole.RoleDescription, userRole.External ? UserRoleType.External : UserRoleType.Internal);
         }
     }
 

--- a/src/administration/Administration.Service/Models/UserRoleWithDescription.cs
+++ b/src/administration/Administration.Service/Models/UserRoleWithDescription.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW Group AG
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -18,21 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using System.Text.Json.Serialization;
 
-namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 
-public record TechnicalUserProfileInformation(
-    [property: JsonPropertyName("technicalUserProfileId")] Guid TechnicalUserProfileId,
-    [property: JsonPropertyName("userRoles")] IEnumerable<UserRoleInformation> UserRoles
+/// <summary>
+/// Basic model for user role data needed to display user roles with description.
+/// </summary>
+public record UserRoleWithDescription(
+    [property: JsonPropertyName("roleId")] Guid UserRoleId,
+    [property: JsonPropertyName("roleName")] string UserRoleText,
+    [property: JsonPropertyName("roleDescription")] string? RoleDescription,
+    [property: JsonPropertyName("roleType")] UserRoleType RoleType
 );
-
-public record TechnicalUserProfileInformationTransferData(
-    Guid TechnicalUserProfileId,
-    IEnumerable<UserRoleInformationTransferData> UserRoles
-);
-
-public record UserRoleInformationTransferData(
-    Guid UserRoleId,
-    string UserRoleText,
-    bool External);

--- a/src/marketplace/Apps.Service/Apps.Service.csproj
+++ b/src/marketplace/Apps.Service/Apps.Service.csproj
@@ -27,6 +27,7 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..\..</DockerfileContext>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   
   <Target Name="openapi" AfterTargets="Build">

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -527,7 +527,7 @@ public class AppReleaseBusinessLogic(
 
     /// <inheritdoc />
     public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId) =>
-        offerService.GetTechnicalUserProfilesForOffer(offerId, OfferTypeId.APP);
+        offerService.GetTechnicalUserProfilesForOffer(offerId, OfferTypeId.APP, _settings.DimUserRoles);
 
     /// <inheritdoc />
     public Task UpdateTechnicalUserProfiles(Guid appId, IEnumerable<TechnicalUserProfileData> data) =>

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
@@ -233,6 +233,10 @@ public class AppsSettings
 
     [Required(AllowEmptyStrings = true)]
     public string BpnDidResolverUrl { get; set; } = null!;
+
+    [Required]
+    [DistinctValues("x => x.ClientId")]
+    public IEnumerable<UserRoleConfig> DimUserRoles { get; set; } = null!;
 }
 
 /// <summary>

--- a/src/marketplace/Apps.Service/appsettings.json
+++ b/src/marketplace/Apps.Service/appsettings.json
@@ -76,7 +76,8 @@
     "DeleteDocumentTypeIds": [],
     "SubmitAppDocumentTypeIds": [],
     "OfferSubscriptionAddress": "",
-    "OfferDetailAddress": ""
+    "OfferDetailAddress": "",
+    "DimUserRoles": []
   },
   "Provisioning": {
     "CentralRealm": "",

--- a/src/marketplace/Offers.Library/Service/IOfferService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferService.cs
@@ -200,8 +200,9 @@ public interface IOfferService
     /// </summary>
     /// <param name="offerId">Id of the offer</param>
     /// <param name="offerTypeId">Id of the offer type</param>
+    /// <param name="externalUserRoles">The ExternalUserRoles</param>
     /// <returns>IEnumerable with the technical user profile information</returns>
-    Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId);
+    Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> externalUserRoles);
 
     /// <summary>
     /// Creates or updates the technical user profiles

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
@@ -257,7 +257,7 @@ public class ServiceReleaseBusinessLogic : IServiceReleaseBusinessLogic
 
     /// <inheritdoc />
     public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId) =>
-        _offerService.GetTechnicalUserProfilesForOffer(offerId, OfferTypeId.SERVICE);
+        _offerService.GetTechnicalUserProfilesForOffer(offerId, OfferTypeId.SERVICE, _settings.DimUserRoles);
 
     /// <inheritdoc />
     public Task UpdateTechnicalUserProfiles(Guid serviceId, IEnumerable<TechnicalUserProfileData> data) =>

--- a/src/marketplace/Services.Service/ServiceSettings.cs
+++ b/src/marketplace/Services.Service/ServiceSettings.cs
@@ -164,6 +164,10 @@ public class ServiceSettings
     /// </summary>
     [Required(AllowEmptyStrings = false)]
     public string OfferDetailAddress { get; init; } = null!;
+
+    [Required]
+    [DistinctValues("x => x.ClientId")]
+    public IEnumerable<UserRoleConfig> DimUserRoles { get; set; } = null!;
 }
 
 public static class ServiceSettingsExtension

--- a/src/marketplace/Services.Service/appsettings.json
+++ b/src/marketplace/Services.Service/appsettings.json
@@ -70,7 +70,8 @@
     "DeleteDocumentTypeIds": [],
     "TechnicalUserProfileClient": "",
     "OfferSubscriptionAddress": "",
-    "OfferDetailAddress": ""
+    "OfferDetailAddress": "",
+    "DimUserRoles": []
   },
   "Provisioning": {
     "CentralRealm": "",

--- a/src/portalbackend/PortalBackend.DBAccess/Models/TechnicalUserProfileInformation.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/TechnicalUserProfileInformation.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW Group AG
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
@@ -32,16 +32,17 @@ public record UserRoleData(
 /// <summary>
 /// Basic model for user role data needed to display user roles with description.
 /// </summary>
-public record UserRoleWithDescription(
-        [property: JsonPropertyName("roleId")] Guid UserRoleId,
-        [property: JsonPropertyName("roleName")] string UserRoleText,
-        [property: JsonPropertyName("roleDescription")] string? RoleDescription,
-        [property: JsonPropertyName("roleType")] UserRoleType RoleType
-    );
+public record UserRoleWithDescriptionTransferData(
+        Guid UserRoleId,
+        string UserRoleText,
+        string? RoleDescription,
+        bool External
+);
 
 public record UserRoleInformation(
     [property: JsonPropertyName("roleId")] Guid UserRoleId,
-    [property: JsonPropertyName("roleName")] string UserRoleText);
+    [property: JsonPropertyName("roleName")] string UserRoleText,
+    [property: JsonPropertyName("type")] UserRoleType RoleType);
 
 public enum UserRoleType
 {

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserProfileRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserProfileRepository.cs
@@ -18,6 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
@@ -67,6 +68,7 @@ public interface ITechnicalUserProfileRepository
     /// <param name="offerId">Id of the offer</param>
     /// <param name="usersCompanyId"></param>
     /// <param name="offerTypeId">Id of the offertype</param>
+    /// <param name="externalUserRoles">The external user roles</param>
     /// <returns>List of the technical user profile information</returns>
-    Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformation> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId);
+    Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformationTransferData> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId, IEnumerable<Guid> externalUserRoles);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
@@ -48,7 +48,7 @@ public interface IUserRolesRepository
     IAsyncEnumerable<OfferRoleInfo> GetAppRolesAsync(Guid offerId, Guid companyId, string languageShortName);
     IAsyncEnumerable<string> GetClientRolesCompositeAsync(string keyCloakClientId);
 
-    IAsyncEnumerable<UserRoleWithDescription> GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName);
+    IAsyncEnumerable<UserRoleWithDescriptionTransferData> GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName);
 
     /// <summary>
     /// Gets all user role ids for the given offerId

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserProfileRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserProfileRepository.cs
@@ -20,6 +20,7 @@
 
 using Microsoft.EntityFrameworkCore;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
@@ -69,14 +70,17 @@ public class TechnicalUserProfileRepository : ITechnicalUserProfileRepository
     }
 
     /// <inheritdoc />
-    public Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformation> Information)>
-        GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId) =>
+    public Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformationTransferData> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId, IEnumerable<Guid> externalUserRoles) =>
             _context.Offers
                 .Where(x => x.Id == offerId && x.OfferTypeId == offerTypeId)
-                .Select(x => new ValueTuple<bool, IEnumerable<TechnicalUserProfileInformation>>(
+                .Select(x => new ValueTuple<bool, IEnumerable<TechnicalUserProfileInformationTransferData>>(
                     x.ProviderCompanyId == usersCompanyId,
-                    x.TechnicalUserProfiles.Select(tup => new TechnicalUserProfileInformation(
+                    x.TechnicalUserProfiles.Select(tup => new TechnicalUserProfileInformationTransferData(
                         tup.Id,
-                        tup.TechnicalUserProfileAssignedUserRoles.Select(ur => new UserRoleInformation(ur.UserRole!.Id, ur.UserRole.UserRoleText))))))
+                        tup.TechnicalUserProfileAssignedUserRoles
+                            .Select(ur => new UserRoleInformationTransferData(
+                                ur.UserRole!.Id,
+                                ur.UserRole.UserRoleText,
+                                externalUserRoles.Contains(ur.UserRoleId)))))))
                 .SingleOrDefaultAsync();
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserProfileRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserProfileRepository.cs
@@ -20,7 +20,6 @@
 
 using Microsoft.EntityFrameworkCore;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
@@ -71,16 +70,16 @@ public class TechnicalUserProfileRepository : ITechnicalUserProfileRepository
 
     /// <inheritdoc />
     public Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformationTransferData> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId, IEnumerable<Guid> externalUserRoles) =>
-            _context.Offers
-                .Where(x => x.Id == offerId && x.OfferTypeId == offerTypeId)
-                .Select(x => new ValueTuple<bool, IEnumerable<TechnicalUserProfileInformationTransferData>>(
-                    x.ProviderCompanyId == usersCompanyId,
-                    x.TechnicalUserProfiles.Select(tup => new TechnicalUserProfileInformationTransferData(
-                        tup.Id,
-                        tup.TechnicalUserProfileAssignedUserRoles
-                            .Select(ur => new UserRoleInformationTransferData(
-                                ur.UserRole!.Id,
-                                ur.UserRole.UserRoleText,
-                                externalUserRoles.Contains(ur.UserRoleId)))))))
-                .SingleOrDefaultAsync();
+        _context.Offers
+            .Where(x => x.Id == offerId && x.OfferTypeId == offerTypeId)
+            .Select(x => new ValueTuple<bool, IEnumerable<TechnicalUserProfileInformationTransferData>>(
+                x.ProviderCompanyId == usersCompanyId,
+                x.TechnicalUserProfiles.Select(tup => new TechnicalUserProfileInformationTransferData(
+                    tup.Id,
+                    tup.TechnicalUserProfileAssignedUserRoles
+                        .Select(ur => new UserRoleInformationTransferData(
+                            ur.UserRole!.Id,
+                            ur.UserRole.UserRoleText,
+                            externalUserRoles.Contains(ur.UserRoleId)))))))
+            .SingleOrDefaultAsync();
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
@@ -214,19 +214,19 @@ public class UserRolesRepository : IUserRolesRepository
             .Select(userRole => userRole.UserRoleText)
             .AsAsyncEnumerable();
 
-    IAsyncEnumerable<UserRoleWithDescription> IUserRolesRepository.GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName) =>
+    IAsyncEnumerable<UserRoleWithDescriptionTransferData> IUserRolesRepository.GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName) =>
         _dbContext.UserRoles
             .AsNoTracking()
             .Where(ur => ur.Offer!.AppInstances.Any(ai => ai.IamClient!.ClientClientId == clientId) &&
                 ur.UserRoleCollections.Any(urc =>
                     urc.CompanyRoleAssignedRoleCollection!.CompanyRole!.CompanyAssignedRoles.Any(car =>
                         car.CompanyId == companyId)))
-            .Select(userRole => new UserRoleWithDescription(
+            .Select(userRole => new UserRoleWithDescriptionTransferData(
                 userRole.Id,
                 userRole.UserRoleText,
                 userRole.UserRoleDescriptions.SingleOrDefault(desc =>
                     desc.LanguageShortName == languageShortName)!.Description,
-                externalRoleIds.Contains(userRole.Id) ? UserRoleType.External : UserRoleType.Internal))
+                externalRoleIds.Contains(userRole.Id)))
             .AsAsyncEnumerable();
 
     /// <inheritdoc />

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -656,7 +656,7 @@ public class ServiceAccountBusinessLogicTests
     public async Task GetServiceAccountRolesAsync_GetsExpectedData()
     {
         // Arrange
-        var data = _fixture.CreateMany<UserRoleWithDescription>(15);
+        var data = _fixture.CreateMany<UserRoleWithDescriptionTransferData>(15);
 
         A.CallTo(() => _userRolesRepository.GetServiceAccountRolesAsync(A<Guid>._, A<string>._, A<IEnumerable<Guid>>._, A<string>._))
             .Returns(data.ToAsyncEnumerable());
@@ -676,7 +676,8 @@ public class ServiceAccountBusinessLogicTests
         // Sonar fix -> Return value of pure method is not used
         result.Should().AllSatisfy(ur =>
         {
-            data.Contains(ur).Should().BeTrue();
+            var transferData = new UserRoleWithDescriptionTransferData(ur.UserRoleId, ur.UserRoleText, ur.RoleDescription, ur.RoleType == UserRoleType.External);
+            data.Contains(transferData).Should().BeTrue();
         });
     }
 

--- a/tests/endtoend/CreateAppScenario/CreateNewTestAppScenario.cs
+++ b/tests/endtoend/CreateAppScenario/CreateNewTestAppScenario.cs
@@ -18,6 +18,7 @@
  ********************************************************************************/
 
 using FluentAssertions;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Apps.Service.ViewModels;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Linq;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -1264,7 +1264,7 @@ public class AppReleaseBusinessLogicTest
     {
         // Arrange
         var appId = Guid.NewGuid();
-        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(appId, OfferTypeId.APP))
+        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(appId, OfferTypeId.APP, A<IEnumerable<UserRoleConfig>>._))
             .Returns(_fixture.CreateMany<TechnicalUserProfileInformation>(5));
         var sut = new AppReleaseBusinessLogic(null!, Options.Create(new AppsSettings()), _offerService, _offerDocumentService, null!, _identityService);
 

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -1823,16 +1823,16 @@ public class OfferServiceTests
     {
         // Arrange
         var offerId = _fixture.Create<Guid>();
-        var data = _fixture.CreateMany<TechnicalUserProfileInformation>(5);
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId))
+        var data = _fixture.CreateMany<TechnicalUserProfileInformationTransferData>(5);
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._))
             .Returns((true, data));
 
         // Act
-        var result = await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId);
+        var result = await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId, Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         result.Should().HaveCount(5);
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._)).MustHaveHappenedOnceExactly();
     }
 
     [Theory]
@@ -1842,16 +1842,16 @@ public class OfferServiceTests
     {
         // Arrange
         var offerId = _fixture.Create<Guid>();
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId))
-            .Returns<(bool, IEnumerable<TechnicalUserProfileInformation>)>(default);
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._))
+            .Returns<(bool, IEnumerable<TechnicalUserProfileInformationTransferData>)>(default);
 
         // Act
-        async Task Act() => await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId);
+        async Task Act() => await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId, Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
         ex.Message.Should().Be($"Offer {offerId} does not exist");
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._)).MustHaveHappenedOnceExactly();
     }
 
     [Theory]
@@ -1861,16 +1861,16 @@ public class OfferServiceTests
     {
         // Arrange
         var offerId = _fixture.Create<Guid>();
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId))
-            .Returns((false, Enumerable.Empty<TechnicalUserProfileInformation>()));
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._))
+            .Returns((false, Enumerable.Empty<TechnicalUserProfileInformationTransferData>()));
 
         // Act
-        async Task Act() => await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId);
+        async Task Act() => await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId, Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
         ex.Message.Should().Be($"Company {_companyId} is not the providing company");
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._)).MustHaveHappenedOnceExactly();
     }
 
     #endregion

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
@@ -585,7 +585,7 @@ public class ServiceReleaseBusinessLogicTest
     public async Task GetTechnicalUserProfilesForOffer_ReturnsExpected()
     {
         // Arrange
-        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(_existingServiceId, OfferTypeId.SERVICE))
+        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(_existingServiceId, OfferTypeId.SERVICE, A<IEnumerable<UserRoleConfig>>._))
             .Returns(_fixture.CreateMany<TechnicalUserProfileInformation>(5));
         var sut = new ServiceReleaseBusinessLogic(null!, _offerService, _offerDocumentService, _identityService, Options.Create(new ServiceSettings()));
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
@@ -18,7 +18,6 @@
  ********************************************************************************/
 
 using Microsoft.EntityFrameworkCore;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Tests.Setup;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
@@ -18,6 +18,7 @@
  ********************************************************************************/
 
 using Microsoft.EntityFrameworkCore;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Tests.Setup;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
@@ -251,12 +252,14 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.SERVICE);
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.SERVICE, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1));
 
         // Assert
         result.Should().NotBeNull();
         result.IsUserOfProvidingCompany.Should().BeTrue();
-        result.Information.Should().HaveCount(2);
+        result.Information.Should().HaveCount(2).And.Satisfy(
+            x => x.UserRoles.Count(x => !x.External) == 2,
+            x => x.UserRoles.Count(x => !x.External) == 1);
     }
 
     [Fact]
@@ -266,7 +269,7 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, Guid.NewGuid(), OfferTypeId.SERVICE);
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, Guid.NewGuid(), OfferTypeId.SERVICE, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1));
 
         // Assert
         result.Should().NotBeNull();
@@ -280,7 +283,7 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(Guid.NewGuid(), _validCompanyId, OfferTypeId.SERVICE);
+        var result = await sut.GetTechnicalUserProfileInformation(Guid.NewGuid(), _validCompanyId, OfferTypeId.SERVICE, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1));
 
         // Assert
         result.Should().Be(default);
@@ -293,7 +296,7 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.APP);
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.APP, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1));
 
         // Assert
         result.Should().Be(default);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -137,8 +137,8 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         data.Should().HaveCount(19);
         data.Should().OnlyHaveUniqueItems();
-        data.Where(x => x.RoleType == UserRoleType.Internal).Should().HaveCount(18);
-        data.Where(x => x.RoleType == UserRoleType.External).Should().ContainSingle();
+        data.Where(x => !x.External).Should().HaveCount(18);
+        data.Where(x => x.External).Should().ContainSingle();
     }
 
     #endregion


### PR DESCRIPTION
## Description

* add internal | external flag to the userRoles of an technicalUserProfile

## Why

To give the frontend the possibility to show the internal and external roles separately

## Issue

Refs: #1007

## Corresponding CD PR

https://github.com/eclipse-tractusx/portal/pull/440

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
