### PR TITLE
fix(schema): adjust did document schema validation

### DIFF
--- a/src/externalsystems/Dim.Library/Schemas/DidDocument.schema.json
+++ b/src/externalsystems/Dim.Library/Schemas/DidDocument.schema.json
@@ -8,10 +8,7 @@
       "type": "array",
       "items": {
         "type": "string"
-      },
-      "const": [
-        "https://www.w3.org/ns/did/v1"
-      ]
+      }
     },
     "id": {
       "type": "string"

--- a/tests/externalsystems/Dim.Library.Tests/DimBusinessLogicTests.cs
+++ b/tests/externalsystems/Dim.Library.Tests/DimBusinessLogicTests.cs
@@ -360,28 +360,35 @@ public class DimBusinessLogicTests
         const string jsonData = """
                                         {
                                             "@context": [
-                                                "https://www.w3.org/ns/did/v1"
+                                                "https://www.w3.org/ns/did/v1",
+                                                "https://w3id.org/security/suites/jws-2020/v1"
                                             ],
-                                            "id": "did:web:example.com:did:BPNL0000000000XX",
+                                            "id": "did:web:portal-backend.int.catena-x.net:api:administration:staticdata:did:BPNL000000006TCJ",
+                                            "service": [
+                                                {
+                                                    "type": "CredentialService",
+                                                    "serviceEndpoint": "https://dis-agent-prod.eu10.dim.cloud.sap/api/v1.0.0/iatp",
+                                                    "id": "did:web:portal-backend.int.catena-x.net:api:administration:staticdata:did:BPNL000000006TCJ#CredentialService"
+                                                }
+                                            ],
                                             "verificationMethod": [
                                                 {
-                                                    "id": "did:web:example.com:did:BPNL0000000000XX#key-0",
+                                                    "id": "did:web:portal-backend.int.catena-x.net:api:administration:staticdata:did:BPNL000000006TCJ#keys-1c1e0ef5-fa61-4030-9a32-6636f6dd1ea2",
                                                     "type": "JsonWebKey2020",
+                                                    "controller": "did:web:portal-backend.int.catena-x.net:api:administration:staticdata:did:BPNL000000006TCJ",
                                                     "publicKeyJwk": {
-                                                        "kty": "JsonWebKey2020",
-                                                        "crv": "Ed25519",
-                                                        "x": "3534354354353",
-                                                        "y": "123456"
+                                                        "kty": "EC",
+                                                        "crv": "secp256k1",
+                                                        "x": "RnrgNQgLvDooE7z7J1fMPFoHyJtnQ0FifgebMO7pEmk",
+                                                        "y": "Z45urmCvyQp7AJzX7_JaRFQSGO-0U8zutUTCrGA1XR8"
                                                     }
                                                 }
                                             ],
-                                            "service": [
-                                                {
-                                                    "id": "did:web:example.com:did:BPNL0000000000XX#key-0",
-                                                    "type": "CredentialStore",
-                                                    "serviceEndpoint": "https://example.com/svc"
-                                                }
-                                            ]
+                                            "authentication": [
+                                                "did:web:portal-backend.int.catena-x.net:api:administration:staticdata:did:BPNL000000006TCJ#keys-1c1e0ef5-fa61-4030-9a32-6636f6dd1ea2"
+                                            ],
+                                            "assertionMethod": [],
+                                            "keyAgreement": []
                                         }
                                 """;
         var didDocument = JsonDocument.Parse(jsonData);


### PR DESCRIPTION
## Description

Adjust the did document schema validation to allow multiple entries in the @context array

## Why

To fix the validation of the did document schema

## Issue

Refs: #1054

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
