### PR TITLE
fix: add external services to workflows

### DIFF
--- a/.github/workflows/marketplace-app-service.yml
+++ b/.github/workflows/marketplace-app-service.yml
@@ -25,6 +25,7 @@ on:
       # service and transitive paths
       - 'src/marketplace/Apps.Service/**'
       - 'src/marketplace/Offers.Library/**'
+      - 'src/externalsystems/**'
       - 'src/framework/**'
       - 'src/keycloak/**'
       - 'src/mailing/**'

--- a/.github/workflows/registration-service.yml
+++ b/.github/workflows/registration-service.yml
@@ -24,6 +24,7 @@ on:
     paths:
       # service and transitive paths
       - 'src/framework/**'
+      - 'src/externalsystems/**'
       - 'src/registration/**'
       - 'src/keycloak/**'
       - 'src/mailing/**'

--- a/.github/workflows/services-service.yml
+++ b/.github/workflows/services-service.yml
@@ -23,6 +23,7 @@ on:
   push:
     paths:
       # service and transitive paths
+      - 'src/externalsystems/**'
       - 'src/framework/**'
       - 'src/marketplace/Services.Service/**'
       - 'src/marketplace/Offers.Library/**'


### PR DESCRIPTION
## Description

* add externalService to the build of registration, marketplace and services service

## Why

To build images of the named services when and external service changes

## Issue

Refs: #1056

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
