### PR TITLE
feat(check): additional checks for OPERATOR and confirmed status added in document request endpoint

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -199,7 +199,7 @@ public class ConnectorsBusinessLogic(
         if (!await portalRepositories.GetInstance<ITechnicalUserRepository>()
                 .CheckActiveServiceAccountExistsForCompanyAsync(technicalUserId.Value, companyId).ConfigureAwait(ConfigureAwaitOptions.None))
         {
-           throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_NOT_ACTIVE, [new ErrorParameter("technicalUserId", technicalUserId.Value.ToString()), new ErrorParameter("companyId", companyId.ToString())]);
+            throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_NOT_ACTIVE, [new ErrorParameter("technicalUserId", technicalUserId.Value.ToString()), new ErrorParameter("companyId", companyId.ToString())]);
         }
     }
 

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -199,7 +199,7 @@ public class ConnectorsBusinessLogic(
         if (!await portalRepositories.GetInstance<ITechnicalUserRepository>()
                 .CheckActiveServiceAccountExistsForCompanyAsync(technicalUserId.Value, companyId).ConfigureAwait(ConfigureAwaitOptions.None))
         {
-            throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_NOT_ACTIVE, [new ErrorParameter("technicalUserId", technicalUserId.Value.ToString()), new ErrorParameter("companyId", companyId.ToString())]);
+           throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_NOT_ACTIVE, [new ErrorParameter("technicalUserId", technicalUserId.Value.ToString()), new ErrorParameter("companyId", companyId.ToString())]);
         }
     }
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/DocumentRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/DocumentRepository.cs
@@ -82,10 +82,10 @@ public class DocumentRepository(PortalDbContext dbContext) : IDocumentRepository
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public Task<(Guid DocumentId, bool IsSameUser)> GetDocumentIdWithCompanyUserCheckAsync(Guid documentId, Guid companyUserId) =>
+    public Task<(Guid DocumentId, bool IsSameUser, bool IsRoleOperator, bool IsStatusConfirmed)> GetDocumentIdWithCompanyUserCheckAsync(Guid documentId, Guid companyUserId) =>
         dbContext.Documents
             .Where(x => x.Id == documentId)
-            .Select(x => new ValueTuple<Guid, bool>(x.Id, x.CompanyUserId == companyUserId))
+            .Select(x => new ValueTuple<Guid, bool, bool, bool>(x.Id, x.CompanyUserId == companyUserId, x.CompanyUser!.Identity!.Company!.CompanyAssignedRoles.Any(x => x.CompanyRoleId == CompanyRoleId.OPERATOR), x.CompanyUser.Identity.Company.CompanyApplications.Any(x => x.ApplicationStatusId == CompanyApplicationStatusId.CONFIRMED)))
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IDocumentRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IDocumentRepository.cs
@@ -65,7 +65,7 @@ public interface IDocumentRepository
     /// <param name="documentId">id of the document the user id should be selected for</param>
     /// <param name="companyUserId"></param>
     /// <returns>Returns the user id if a document is found for the given id, otherwise null</returns>
-    Task<(Guid DocumentId, bool IsSameUser)> GetDocumentIdWithCompanyUserCheckAsync(Guid documentId, Guid companyUserId);
+    Task<(Guid DocumentId, bool IsSameUser, bool IsRoleOperator, bool IsStatusConfirmed)> GetDocumentIdWithCompanyUserCheckAsync(Guid documentId, Guid companyUserId);
 
     /// <summary>
     /// Get the document data and checks if the user 

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -173,7 +173,7 @@ public class RegistrationBusinessLogic(
             throw new ForbiddenException($"The user is not permitted to access document {documentId}.");
         }
 
-        if (!documentDetails.IsStatusConfirmed)
+        if (documentDetails.IsStatusConfirmed)
         {
             throw new ForbiddenException($"Documents not accessible as onboarding process finished {documentId}.");
         }

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -168,9 +168,14 @@ public class RegistrationBusinessLogic(
             throw new NotFoundException($"document {documentId} does not exist.");
         }
 
-        if (!documentDetails.IsSameUser)
+        if (!documentDetails.IsSameUser && !documentDetails.IsRoleOperator)
         {
             throw new ForbiddenException($"The user is not permitted to access document {documentId}.");
+        }
+
+        if (!documentDetails.IsStatusConfirmed)
+        {
+            throw new ForbiddenException($"Documents not accessible as onboarding process finished {documentId}.");
         }
 
         var document = await documentRepository.GetDocumentByIdAsync(documentId).ConfigureAwait(ConfigureAwaitOptions.None);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/DocumentRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/DocumentRepositoryTests.cs
@@ -174,6 +174,57 @@ public class DocumentRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
+    #region GetDocumentIdWithCompanyUserCheckAsync
+
+    [Fact]
+    public async Task GetDocumentIdWithCompanyUserCheckAsync_With_ReturnsExpected()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.GetDocumentIdWithCompanyUserCheckAsync(new Guid("00000000-0000-0000-0000-000000000001"), new("ac1cf001-7fbc-1f2f-817f-bce058020006"));
+
+        // Assert
+        result.Should().NotBe(default);
+        result.IsSameUser.Should().BeTrue();
+        result.IsRoleOperator.Should().BeTrue();
+        result.IsStatusConfirmed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetDocumentIdWithCompanyUserCheckAsync_WithWrongUserData_ReturnsIsRoleOperatorFalse()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.GetDocumentIdWithCompanyUserCheckAsync(new Guid("5adbdf90-c6ef-47a5-b596-2f00a731c39a"), new("ac1cf001-7fbc-1f2f-817f-bce058019992"));
+
+        // Assert
+        result.Should().NotBe(default);
+        result.IsSameUser.Should().BeTrue();
+        result.IsRoleOperator.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetDocumentIdWithCompanyUserCheckAsync_WithCompanyApplicationIsStatusConfirmed()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.GetDocumentIdWithCompanyUserCheckAsync(new Guid("ec12dc7e-a8fa-4aa5-945a-f7e64be30841"), new("8b42e6de-7b59-4217-a63c-198e83d93776"));
+
+        // Assert
+        result.Should().NotBe(default);
+        result.IsSameUser.Should().BeTrue();
+        result.IsStatusConfirmed.Should().BeTrue();
+
+    }
+
+    #endregion
+
     #region GetDocumentDataAndIsCompanyUserAsync_ReturnsExpectedDocuments
 
     [Fact]

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -2870,7 +2870,7 @@ public class RegistrationBusinessLogicTest
         var documentId = Guid.NewGuid();
         var content = new byte[7];
         A.CallTo(() => _documentRepository.GetDocumentIdWithCompanyUserCheckAsync(documentId, _identity.IdentityId))
-            .Returns((documentId, true, true, true));
+            .Returns((documentId, true, true, false));
         A.CallTo(() => _documentRepository.GetDocumentByIdAsync(documentId))
             .Returns(new Document(documentId, content, content, "test.pdf", MediaTypeId.PDF, DateTimeOffset.UtcNow, DocumentStatusId.LOCKED, DocumentTypeId.APP_CONTRACT));
         var sut = new RegistrationBusinessLogic(Options.Create(new RegistrationSettings()), null!, null!, null!, _portalRepositories, null!, _identityService, _dateTimeProvider, _mailingProcessCreation);
@@ -2924,7 +2924,7 @@ public class RegistrationBusinessLogicTest
         // Arrange
         var documentId = Guid.NewGuid();
         A.CallTo(() => _documentRepository.GetDocumentIdWithCompanyUserCheckAsync(documentId, _identity.IdentityId))
-            .Returns((documentId, true, true, false));
+            .Returns((documentId, true, true, true));
         var sut = new RegistrationBusinessLogic(Options.Create(new RegistrationSettings()), null!, null!, null!, _portalRepositories, null!, _identityService, _dateTimeProvider, _mailingProcessCreation);
 
         // Act


### PR DESCRIPTION
## Description

Currently the endpoint GET: /api/registration/documents/{documentId} only response the document for the user which has uploaded the document. This check should be adjusted with adding check of OPERATOR and company application status confirmed.

## Why

These additional check required for getting document to particular user satisfies the check condition.

## Issue

Link to Github issue.

#1070 

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
