### PR TITLE
chore: check for uncommitted files and commit api specs

### DIFF
--- a/.github/workflows/pre-checks.yml
+++ b/.github/workflows/pre-checks.yml
@@ -69,6 +69,15 @@ jobs:
         run: dotnet restore src
       - name: Build
         run: dotnet build src --configuration Release --no-restore
+      - name: Check for uncommitted files in working directory # refers to updated api specifications, please refer to /docs/api/README.md
+        run: |
+          git_status=$(git status --porcelain)
+          if [ -n "$git_status" ]; then
+            echo "Please commit the file(s) in your working directory after executing the build command"
+            exit 1
+          else
+            echo "No modified files found in the working directory."
+          fi
       - name: Check Format
         run: dotnet format src --verify-no-changes --no-restore
       - name: Test

--- a/docs/api/apps-service.yaml
+++ b/docs/api/apps-service.yaml
@@ -2522,7 +2522,7 @@ components:
           description: Price.
         leadPictureId:
           type: string
-          description: Lead pircture Id.
+          description: Lead picture Id.
           format: uuid
         useCases:
           type: array

--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -2362,6 +2362,11 @@ components:
         provider:
           type: string
           description: Provider of the app.
+        leadPictureId:
+          type: string
+          description: Lead picture Id.
+          format: uuid
+          nullable: true
         contactEmail:
           type: string
           description: Contact email address.
@@ -2496,6 +2501,10 @@ components:
           nullable: true
         provider:
           type: string
+        leadPictureId:
+          type: string
+          format: uuid
+          nullable: true
         contactEmail:
           type: string
           nullable: true


### PR DESCRIPTION
## Description

- pre-checks: add step to check for uncommitted files: refers to updated api specifications
see failing example: https://github.com/eclipse-tractusx/portal-backend/actions/runs/11365413480/job/31613546790
see successful example: https://github.com/eclipse-tractusx/portal-backend/actions/runs/11365510125/job/31613850865#step:7:13
- commit updated api specifications


## Why

check need due to https://github.com/eclipse-tractusx/portal-backend/issues/1021

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code changes
- [x] I have successfully tested my changes
