### PR TITLE
feat(partnerNetwork): Get data from partner network pool by portal backend (#61)

### DIFF
--- a/docs/api/administration-service.yaml
+++ b/docs/api/administration-service.yaml
@@ -3182,6 +3182,52 @@ paths:
           description: Internal Server Error
         '401':
           description: The User is unauthorized
+  /api/administration/PartnerNetwork/legalEntities/search:
+    post:
+      tags:
+        - PartnerNetwork
+      summary: 'Gets partner network data from BPN Pool (Authorization required - Roles: view_partner_network)'
+      description: 'Example: Get: /api/registration/legalEntities/search?page=0&size=10&bpnl='
+      parameters:
+        - name: page
+          in: query
+          description: 'The page of partner network data, default is 0.'
+          schema:
+            type: integer
+            format: int32
+            default: 0
+          example: 0
+        - name: size
+          in: query
+          description: 'Amount of partner network data, default is 10.'
+          schema:
+            type: integer
+            format: int32
+            default: 10
+          example: 10
+      requestBody:
+        description: The bpnls to get the selected record
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartnerNetworkRequest'
+      responses:
+        '200':
+          description: Returns the list of partner networks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PartnerNetworkResponse'
+        '503':
+          description: The requested service responded with the given error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal Server Error
+        '401':
+          description: The User is unauthorized
   '/api/administration/registration/application/{applicationId}/companyDetailsWithAddress':
     get:
       tags:
@@ -5997,6 +6043,276 @@ components:
         clientSecret:
           type: string
       additionalProperties: false
+    BpdmAdministrativeAreaLevelData:
+      type: object
+      properties:
+        countryCode:
+          type: string
+          nullable: true
+        regionName:
+          type: string
+          nullable: true
+        regionCode:
+          type: string
+          nullable: true
+      additionalProperties: false
+    BpdmAlternativePostalAddressData:
+      type: object
+      properties:
+        geographicCoordinates:
+          $ref: '#/components/schemas/BpdmGeographicCoordinatesData'
+        country:
+          $ref: '#/components/schemas/BpdmCountryData'
+        postalCode:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        administrativeAreaLevel1:
+          $ref: '#/components/schemas/BpdmAdministrativeAreaLevelData'
+        deliveryServiceNumber:
+          type: string
+          nullable: true
+        deliveryServiceType:
+          type: string
+          nullable: true
+        deliveryServiceQualifier:
+          type: string
+          nullable: true
+      additionalProperties: false
+    BpdmConfidenceCriteriaData:
+      type: object
+      properties:
+        sharedByOwner:
+          type: boolean
+        checkedByExternalDataSource:
+          type: boolean
+        numberOfSharingMembers:
+          type: integer
+          format: int32
+        lastConfidenceCheckAt:
+          type: string
+          format: date-time
+        nextConfidenceCheckAt:
+          type: string
+          format: date-time
+        confidenceLevel:
+          type: integer
+          format: int32
+      additionalProperties: false
+    BpdmCountryData:
+      type: object
+      properties:
+        technicalKey:
+          type: string
+        name:
+          type: string
+      additionalProperties: false
+    BpdmGeographicCoordinatesData:
+      type: object
+      properties:
+        longitude:
+          type: number
+          format: double
+        latitude:
+          type: number
+          format: double
+        altitude:
+          type: number
+          format: double
+          nullable: true
+      additionalProperties: false
+    BpdmIdentifierData:
+      type: object
+      properties:
+        value:
+          type: string
+        type:
+          $ref: '#/components/schemas/BpdmTechnicalKeyData'
+        issuingBody:
+          type: string
+          nullable: true
+      additionalProperties: false
+    BpdmLegalEntityAddressData:
+      type: object
+      properties:
+        bpna:
+          type: string
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        bpnLegalEntity:
+          type: string
+          nullable: true
+        bpnSite:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        addressType:
+          type: string
+        states:
+          type: array
+          items:
+            $ref: '#/components/schemas/BpdmLegalEntityAddressStateData'
+        identifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BpdmLegalEntityAddressIdentifierData'
+        physicalPostalAddress:
+          $ref: '#/components/schemas/BpdmPhysicalPostalAddressData'
+        alternativePostalAddress:
+          $ref: '#/components/schemas/BpdmAlternativePostalAddressData'
+        confidenceCriteria:
+          $ref: '#/components/schemas/BpdmConfidenceCriteriaData'
+        isCatenaXMemberData:
+          type: boolean
+      additionalProperties: false
+    BpdmLegalEntityAddressIdentifierData:
+      type: object
+      properties:
+        value:
+          type: string
+          nullable: true
+        type:
+          $ref: '#/components/schemas/BpdmTechnicalKeyData'
+      additionalProperties: false
+    BpdmLegalEntityAddressStateData:
+      type: object
+      properties:
+        description:
+          type: string
+          nullable: true
+        validFrom:
+          type: string
+          format: date-time
+          nullable: true
+        validTo:
+          type: string
+          format: date-time
+          nullable: true
+        type:
+          $ref: '#/components/schemas/BpdmTechnicalKeyData'
+      additionalProperties: false
+    BpdmLegalFormData:
+      type: object
+      properties:
+        technicalKey:
+          type: string
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        abbreviation:
+          type: string
+          nullable: true
+      additionalProperties: false
+    BpdmPhysicalPostalAddressData:
+      type: object
+      properties:
+        geographicCoordinates:
+          $ref: '#/components/schemas/BpdmGeographicCoordinatesData'
+        country:
+          $ref: '#/components/schemas/BpdmCountryData'
+        postalCode:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        street:
+          $ref: '#/components/schemas/BpdmStreetData'
+        administrativeAreaLevel1:
+          $ref: '#/components/schemas/BpdmAdministrativeAreaLevelData'
+        administrativeAreaLevel2:
+          type: string
+          nullable: true
+        administrativeAreaLevel3:
+          type: string
+          nullable: true
+        district:
+          type: string
+          nullable: true
+        companyPostalCode:
+          type: string
+          nullable: true
+        industrialZone:
+          type: string
+          nullable: true
+        building:
+          type: string
+          nullable: true
+        floor:
+          type: string
+          nullable: true
+        door:
+          type: string
+          nullable: true
+      additionalProperties: false
+    BpdmRelationData:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/BpdmTechnicalKeyData'
+        startBpnl:
+          type: string
+          nullable: true
+        endBpnl:
+          type: string
+          nullable: true
+        validFrom:
+          type: string
+          format: date-time
+          nullable: true
+        validTo:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+    BpdmStatusData:
+      type: object
+      properties:
+        validFrom:
+          type: string
+          format: date-time
+          nullable: true
+        validTo:
+          type: string
+          format: date-time
+          nullable: true
+        type:
+          $ref: '#/components/schemas/BpdmTechnicalKeyData'
+      additionalProperties: false
+    BpdmStreetData:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        houseNumber:
+          type: string
+          nullable: true
+        milestone:
+          type: string
+          nullable: true
+        direction:
+          type: string
+          nullable: true
+      additionalProperties: false
+    BpdmTechnicalKeyData:
+      type: object
+      properties:
+        technicalKey:
+          type: string
+        name:
+          type: string
+      additionalProperties: false
     CertificateSorting:
       enum:
         - CertificateTypeAsc
@@ -7440,6 +7756,77 @@ components:
           format: email
           default: string
           nullable: true
+      additionalProperties: false
+    PartnerNetworkData:
+      type: object
+      properties:
+        bpn:
+          type: string
+        legalName:
+          type: string
+          nullable: true
+        legalShortName:
+          type: string
+          nullable: true
+        currentness:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        identifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BpdmIdentifierData'
+        legalForm:
+          $ref: '#/components/schemas/BpdmLegalFormData'
+        states:
+          type: array
+          items:
+            $ref: '#/components/schemas/BpdmStatusData'
+        confidenceCriteria:
+          $ref: '#/components/schemas/BpdmConfidenceCriteriaData'
+        isCatenaXMemberData:
+          type: boolean
+        relations:
+          type: array
+          items:
+            $ref: '#/components/schemas/BpdmRelationData'
+        legalEntityAddress:
+          $ref: '#/components/schemas/BpdmLegalEntityAddressData'
+      additionalProperties: false
+    PartnerNetworkRequest:
+      type: object
+      properties:
+        bpnls:
+          type: array
+          items:
+            type: string
+        legalName:
+          type: string
+      additionalProperties: false
+    PartnerNetworkResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartnerNetworkData'
+        contentSize:
+          type: integer
+          format: int32
+        page:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int32
+        totalPages:
+          type: integer
+          format: int32
       additionalProperties: false
     PartnerRegistrationData:
       type: object

--- a/src/administration/Administration.Service/BusinessLogic/IPartnerNetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IPartnerNetworkBusinessLogic.cs
@@ -18,6 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic
 {
     public interface IPartnerNetworkBusinessLogic
@@ -27,5 +29,16 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLog
         /// </summary>
         /// <param name="bpnIds">Ids of BPN</param>
         IAsyncEnumerable<string> GetAllMemberCompaniesBPNAsync(IEnumerable<string>? bpnIds);
+
+        /// <summary>
+        /// Gets partner network data from BPN Pool
+        /// </summary>
+        /// <param name="page" example="0">The page of partner network data, default is 0.</param>
+        /// <param name="size" example="10">Amount of partner network data, default is 10.</param>
+        /// <param name="partnerNetworkRequest">The bpnls to get the selected record</param>
+        /// <param name="token">Access token to access the partner network pool</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Returns a List of partner networks</returns>
+        Task<PartnerNetworkResponse> GetPartnerNetworkDataAsync(int page, int size, PartnerNetworkRequest partnerNetworkRequest, string token, CancellationToken cancellationToken);
     }
 }

--- a/src/administration/Administration.Service/BusinessLogic/PartnerNetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/PartnerNetworkBusinessLogic.cs
@@ -18,6 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library;
+using Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 
@@ -26,17 +29,155 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLog
 public class PartnerNetworkBusinessLogic : IPartnerNetworkBusinessLogic
 {
     private readonly IPortalRepositories _portalRepositories;
+    private readonly IBpnAccess _bpnAccess;
 
     /// <summary>
     /// Constructor
     /// </summary>
     /// <param name="portalRepositories"></param>
-    public PartnerNetworkBusinessLogic(IPortalRepositories portalRepositories)
+    /// <param name="bpnAccess"></param>
+    public PartnerNetworkBusinessLogic(IPortalRepositories portalRepositories, IBpnAccess bpnAccess)
     {
         _portalRepositories = portalRepositories;
+        _bpnAccess = bpnAccess;
     }
 
     /// <inheritdoc/>
     public IAsyncEnumerable<string> GetAllMemberCompaniesBPNAsync(IEnumerable<string>? bpnIds) =>
         _portalRepositories.GetInstance<ICompanyRepository>().GetAllMemberCompaniesBPNAsync(bpnIds?.Select(x => x.ToUpper()));
+
+    /// <inheritdoc/>
+    public async Task<PartnerNetworkResponse> GetPartnerNetworkDataAsync(int page, int size, PartnerNetworkRequest partnerNetworkRequest, string token, CancellationToken cancellationToken)
+    {
+        var data = await _bpnAccess.FetchPartnerNetworkData(page, size, partnerNetworkRequest.Bpnls, partnerNetworkRequest.LegalName, token, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        return new PartnerNetworkResponse(ParsePartnerNetworkData(data.Content), data.ContentSize, data.Page, data.TotalElements, data.TotalPages);
+    }
+
+    private static IEnumerable<PartnerNetworkData> ParsePartnerNetworkData(IEnumerable<BpdmLegalEntityDto> bpdmLegalEntityDtos) =>
+        bpdmLegalEntityDtos.Select(data =>
+            new PartnerNetworkData(
+                data.Bpn,
+                data.LegalName,
+                data.LegalShortName,
+                data.Currentness,
+                data.CreatedAt,
+                data.UpdatedAt,
+                data.Identifiers.Select(identifier =>
+                    new BpdmIdentifierData(
+                        identifier.Value,
+                        new BpdmTechnicalKeyData(identifier.Type.TechnicalKey, identifier.Type.Name),
+                        identifier.IssuingBody
+                    )),
+                data.LegalForm != null ? new BpdmLegalFormData(
+                    data.LegalForm.TechnicalKey,
+                    data.LegalForm.Name,
+                    data.LegalForm.Abbreviation
+                ) : null,
+                data.States.Select(state =>
+                    new BpdmStatusData(
+                        state.ValidFrom,
+                        state.ValidTo,
+                        new BpdmTechnicalKeyData(state!.Type!.TechnicalKey, state!.Type!.Name)
+                    )),
+                data.ConfidenceCriteria != null ? new BpdmConfidenceCriteriaData(
+                    data.ConfidenceCriteria.SharedByOwner,
+                    data.ConfidenceCriteria.CheckedByExternalDataSource,
+                    data.ConfidenceCriteria.NumberOfSharingMembers,
+                    data.ConfidenceCriteria.LastConfidenceCheckAt,
+                    data.ConfidenceCriteria.NextConfidenceCheckAt,
+                    data.ConfidenceCriteria.ConfidenceLevel
+                ) : null,
+                data.IsCatenaXMemberData,
+                data.Relations.Select(relation =>
+                    new BpdmRelationData(
+                        new BpdmTechnicalKeyData(relation.Type.TechnicalKey, relation.Type.Name),
+                        relation.StartBpnl,
+                        relation.EndBpnl,
+                        relation.ValidFrom,
+                        relation.ValidTo
+                    )),
+                data.LegalEntityAddress != null ? new BpdmLegalEntityAddressData(
+                    data.LegalEntityAddress.Bpna,
+                    data.LegalEntityAddress.Name,
+                    data.LegalEntityAddress.BpnLegalEntity,
+                    data.LegalEntityAddress.BpnSite,
+                    data.LegalEntityAddress.CreatedAt,
+                    data.LegalEntityAddress.UpdatedAt,
+                    data.LegalEntityAddress.AddressType,
+                    data.LegalEntityAddress.States.Select(state =>
+                        new BpdmLegalEntityAddressStateData(
+                            state.Description,
+                            state.ValidFrom,
+                            state.ValidTo,
+                            new BpdmTechnicalKeyData(state.Type.TechnicalKey, state.Type.Name)
+                        )),
+                    data.LegalEntityAddress.Identifiers.Select(identifier =>
+                        new BpdmLegalEntityAddressIdentifierData(
+                            identifier.Value,
+                            new BpdmTechnicalKeyData(identifier.Type.TechnicalKey, identifier.Type.Name)
+                        )),
+                    data.LegalEntityAddress.PhysicalPostalAddress != null ? new BpdmPhysicalPostalAddressData(
+                        data.LegalEntityAddress.PhysicalPostalAddress.GeographicCoordinates != null ? new BpdmGeographicCoordinatesData(
+                            data.LegalEntityAddress.PhysicalPostalAddress.GeographicCoordinates.Longitude,
+                            data.LegalEntityAddress.PhysicalPostalAddress.GeographicCoordinates.Latitude,
+                            data.LegalEntityAddress.PhysicalPostalAddress.GeographicCoordinates.Altitude
+                        ) : null,
+                        data.LegalEntityAddress.PhysicalPostalAddress.Country != null ? new BpdmCountryData(
+                            data.LegalEntityAddress.PhysicalPostalAddress.Country.TechnicalKey,
+                            data.LegalEntityAddress.PhysicalPostalAddress.Country.Name
+                        ) : null,
+                        data.LegalEntityAddress.PhysicalPostalAddress.PostalCode,
+                        data.LegalEntityAddress.PhysicalPostalAddress.City,
+                        data.LegalEntityAddress.PhysicalPostalAddress.Street != null ? new BpdmStreetData(
+                            data.LegalEntityAddress.PhysicalPostalAddress.Street.Name,
+                            data.LegalEntityAddress.PhysicalPostalAddress.Street.HouseNumber,
+                            data.LegalEntityAddress.PhysicalPostalAddress.Street.Milestone,
+                            data.LegalEntityAddress.PhysicalPostalAddress.Street.Direction
+                        ) : null,
+                        data.LegalEntityAddress.PhysicalPostalAddress.AdministrativeAreaLevel1 != null ? new BpdmAdministrativeAreaLevelData(
+                            data.LegalEntityAddress.PhysicalPostalAddress.AdministrativeAreaLevel1.CountryCode,
+                            data.LegalEntityAddress.PhysicalPostalAddress.AdministrativeAreaLevel1.RegionName,
+                            data.LegalEntityAddress.PhysicalPostalAddress.AdministrativeAreaLevel1.RegionCode
+                        ) : null,
+                        data.LegalEntityAddress.PhysicalPostalAddress.AdministrativeAreaLevel2,
+                        data.LegalEntityAddress.PhysicalPostalAddress.AdministrativeAreaLevel3,
+                        data.LegalEntityAddress.PhysicalPostalAddress.District,
+                        data.LegalEntityAddress.PhysicalPostalAddress.CompanyPostalCode,
+                        data.LegalEntityAddress.PhysicalPostalAddress.IndustrialZone,
+                        data.LegalEntityAddress.PhysicalPostalAddress.Building,
+                        data.LegalEntityAddress.PhysicalPostalAddress.Floor,
+                        data.LegalEntityAddress.PhysicalPostalAddress.Door
+                    ) : null,
+                    data.LegalEntityAddress.AlternativePostalAddress != null ? new BpdmAlternativePostalAddressData(
+                        data.LegalEntityAddress.AlternativePostalAddress.GeographicCoordinates != null ? new BpdmGeographicCoordinatesData(
+                            data.LegalEntityAddress.AlternativePostalAddress.GeographicCoordinates.Longitude,
+                            data.LegalEntityAddress.AlternativePostalAddress.GeographicCoordinates.Latitude,
+                            data.LegalEntityAddress.AlternativePostalAddress.GeographicCoordinates.Altitude
+                        ) : null,
+                        data.LegalEntityAddress.AlternativePostalAddress.Country != null ? new BpdmCountryData(
+                            data.LegalEntityAddress.AlternativePostalAddress.Country.TechnicalKey,
+                            data.LegalEntityAddress.AlternativePostalAddress.Country.Name
+                        ) : null,
+                        data.LegalEntityAddress.AlternativePostalAddress.PostalCode,
+                        data.LegalEntityAddress.AlternativePostalAddress.City,
+                        data.LegalEntityAddress.AlternativePostalAddress.AdministrativeAreaLevel1 != null ? new BpdmAdministrativeAreaLevelData(
+                            data.LegalEntityAddress.AlternativePostalAddress.AdministrativeAreaLevel1.CountryCode,
+                            data.LegalEntityAddress.AlternativePostalAddress.AdministrativeAreaLevel1.RegionName,
+                            data.LegalEntityAddress.AlternativePostalAddress.AdministrativeAreaLevel1.RegionCode
+                        ) : null,
+                        data.LegalEntityAddress.AlternativePostalAddress.DeliveryServiceNumber,
+                        data.LegalEntityAddress.AlternativePostalAddress.DeliveryServiceType,
+                        data.LegalEntityAddress.AlternativePostalAddress.DeliveryServiceQualifier
+                    ) : null,
+                    data.LegalEntityAddress.ConfidenceCriteria != null ? new BpdmConfidenceCriteriaData(
+                        data.LegalEntityAddress.ConfidenceCriteria.SharedByOwner,
+                        data.LegalEntityAddress.ConfidenceCriteria.CheckedByExternalDataSource,
+                        data.LegalEntityAddress.ConfidenceCriteria.NumberOfSharingMembers,
+                        data.LegalEntityAddress.ConfidenceCriteria.LastConfidenceCheckAt,
+                        data.LegalEntityAddress.ConfidenceCriteria.NextConfidenceCheckAt,
+                        data.LegalEntityAddress.ConfidenceCriteria.ConfidenceLevel
+                    ) : null,
+                    data.LegalEntityAddress.IsCatenaXMemberData
+                ) : null
+            ));
 }

--- a/src/administration/Administration.Service/Controllers/PartnerNetworkController.cs
+++ b/src/administration/Administration.Service/Controllers/PartnerNetworkController.cs
@@ -21,7 +21,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
+using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Authentication;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Web.PublicInfos;
 
@@ -60,4 +63,23 @@ public class PartnerNetworkController : ControllerBase
     [PublicUrl(CompanyRoleId.ACTIVE_PARTICIPANT, CompanyRoleId.SERVICE_PROVIDER, CompanyRoleId.APP_PROVIDER)]
     public IAsyncEnumerable<string> GetAllMemberCompaniesBPNAsync([FromQuery] IEnumerable<string>? bpnIds = null) =>
         _logic.GetAllMemberCompaniesBPNAsync(bpnIds);
+
+    /// <summary>
+    /// Gets partner network data from BPN Pool
+    /// </summary>
+    /// <param name="page" example="0">The page of partner network data, default is 0.</param>
+    /// <param name="size" example="10">Amount of partner network data, default is 10.</param>
+    /// <param name="partnerNetworkRequest">The bpnls to get the selected record</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Returns a List of partner networks</returns>
+    /// <remarks>Example: Get: /api/registration/legalEntities/search?page=0&amp;size=10&amp;bpnl=</remarks>
+    /// <response code="200">Returns the list of partner networks</response>
+    /// <response code="503">The requested service responded with the given error.</response>
+    [HttpPost]
+    [Authorize(Roles = "view_partner_network")]
+    [Route("legalEntities/search")]
+    [ProducesResponseType(typeof(PartnerNetworkResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
+    public Task<PartnerNetworkResponse> GetPartnerNetworkDataAsync([FromBody] PartnerNetworkRequest partnerNetworkRequest, [FromQuery] int page = 0, [FromQuery] int size = 10, CancellationToken cancellationToken = default) =>
+        this.WithBearerToken(token => _logic.GetPartnerNetworkDataAsync(page, size, partnerNetworkRequest, token, cancellationToken));
 }

--- a/src/administration/Administration.Service/Models/PartnerNetworkRequest.cs
+++ b/src/administration/Administration.Service/Models/PartnerNetworkRequest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 Microsoft and BMW Group AG
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 BMW Group AG
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,13 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Models;
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
 
-namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library;
-
-public interface IBpnAccess
-{
-    Task<BpdmLegalEntityDto> FetchLegalEntityByBpn(string businessPartnerNumber, string token, CancellationToken cancellationToken);
-
-    Task<BpdmPartnerNetworkData> FetchPartnerNetworkData(int page, int size, IEnumerable<string> bpnl, string legalName, string token, CancellationToken cancellationToken);
-}
+public record PartnerNetworkRequest(
+    IEnumerable<string> Bpnls,
+    string LegalName
+);

--- a/src/administration/Administration.Service/Models/PartnerNetworkResponse.cs
+++ b/src/administration/Administration.Service/Models/PartnerNetworkResponse.cs
@@ -1,0 +1,169 @@
+/********************************************************************************
+ * Copyright (c) 2022 BMW Group AG
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+
+public record PartnerNetworkResponse(
+    IEnumerable<PartnerNetworkData> Content,
+    int ContentSize,
+    int Page,
+    int TotalElements,
+    int TotalPages
+);
+
+public record PartnerNetworkData(
+    string Bpn,
+    string? LegalName,
+    string? LegalShortName,
+    DateTimeOffset Currentness,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt,
+    IEnumerable<BpdmIdentifierData> Identifiers,
+    BpdmLegalFormData? LegalForm,
+    IEnumerable<BpdmStatusData> States,
+    BpdmConfidenceCriteriaData? ConfidenceCriteria,
+    bool IsCatenaXMemberData,
+    IEnumerable<BpdmRelationData> Relations,
+    BpdmLegalEntityAddressData? LegalEntityAddress
+);
+
+public record BpdmIdentifierData(
+    string Value,
+    BpdmTechnicalKeyData Type,
+    string? IssuingBody
+);
+
+public record BpdmTechnicalKeyData(
+    string TechnicalKey,
+    string Name
+);
+
+public record BpdmLegalFormData(
+    string? TechnicalKey,
+    string? Name,
+    string? Abbreviation
+);
+
+public record BpdmStatusData(
+    DateTimeOffset? ValidFrom,
+    DateTimeOffset? ValidTo,
+    BpdmTechnicalKeyData Type
+);
+
+public record BpdmConfidenceCriteriaData(
+    bool SharedByOwner,
+    bool CheckedByExternalDataSource,
+    int NumberOfSharingMembers,
+    DateTime LastConfidenceCheckAt,
+    DateTime NextConfidenceCheckAt,
+    int ConfidenceLevel
+);
+
+public record BpdmRelationData(
+    BpdmTechnicalKeyData Type,
+    string? StartBpnl,
+    string? EndBpnl,
+    DateTimeOffset? ValidFrom,
+    DateTimeOffset? ValidTo
+);
+
+public record BpdmLegalEntityAddressData
+(
+    string? Bpna,
+    string? Name,
+    string? BpnLegalEntity,
+    string? BpnSite,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt,
+    string AddressType,
+    IEnumerable<BpdmLegalEntityAddressStateData> States,
+    IEnumerable<BpdmLegalEntityAddressIdentifierData> Identifiers,
+    BpdmPhysicalPostalAddressData? PhysicalPostalAddress,
+    BpdmAlternativePostalAddressData? AlternativePostalAddress,
+    BpdmConfidenceCriteriaData? ConfidenceCriteria,
+    bool IsCatenaXMemberData
+);
+
+public record BpdmLegalEntityAddressStateData
+(
+    string? Description,
+    DateTimeOffset? ValidFrom,
+    DateTimeOffset? ValidTo,
+    BpdmTechnicalKeyData Type
+);
+
+public record BpdmLegalEntityAddressIdentifierData
+(
+    string? Value,
+    BpdmTechnicalKeyData Type
+);
+
+public record BpdmPhysicalPostalAddressData(
+    BpdmGeographicCoordinatesData? GeographicCoordinates,
+    BpdmCountryData? Country,
+    string? PostalCode,
+    string? City,
+    BpdmStreetData? Street,
+    BpdmAdministrativeAreaLevelData? AdministrativeAreaLevel1,
+    string? AdministrativeAreaLevel2,
+    string? AdministrativeAreaLevel3,
+    string? District,
+    string? CompanyPostalCode,
+    string? IndustrialZone,
+    string? Building,
+    string? Floor,
+    string? Door
+);
+
+public record BpdmAlternativePostalAddressData(
+    BpdmGeographicCoordinatesData? GeographicCoordinates,
+    BpdmCountryData? Country,
+    string? PostalCode,
+    string? City,
+    BpdmAdministrativeAreaLevelData? AdministrativeAreaLevel1,
+    string? DeliveryServiceNumber,
+    string? DeliveryServiceType,
+    string? DeliveryServiceQualifier
+);
+
+public record BpdmGeographicCoordinatesData(
+    double Longitude,
+    double Latitude,
+    double? Altitude
+);
+
+public record BpdmCountryData
+(
+    string TechnicalKey,
+    string Name
+);
+
+public record BpdmStreetData(
+    string? Name,
+    string? HouseNumber,
+    string? Milestone,
+    string? Direction
+);
+
+public record BpdmAdministrativeAreaLevelData(
+    string? CountryCode,
+    string? RegionName,
+    string? RegionCode
+);

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -81,8 +81,6 @@ await WebAppHelper
         builder.Services.AddApplicationChecklist(builder.Configuration.GetSection("ApplicationChecklist"))
                         .AddOfferSubscriptionProcess();
 
-        builder.Services.AddBpnAccess(builder.Configuration.GetValue<string>("BPN_Address") ?? throw new ConfigurationException("BPN_Address is not configured"));
-
         builder.Services.AddTransient<IConnectorsBusinessLogic, ConnectorsBusinessLogic>()
             .ConfigureConnectorsSettings(builder.Configuration.GetSection("Connectors"));
 

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -21,6 +21,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.DependencyInjection;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Extensions;
@@ -79,6 +80,8 @@ await WebAppHelper
 
         builder.Services.AddApplicationChecklist(builder.Configuration.GetSection("ApplicationChecklist"))
                         .AddOfferSubscriptionProcess();
+
+        builder.Services.AddBpnAccess(builder.Configuration.GetValue<string>("BPN_Address") ?? throw new ConfigurationException("BPN_Address is not configured"));
 
         builder.Services.AddTransient<IConnectorsBusinessLogic, ConnectorsBusinessLogic>()
             .ConfigureConnectorsSettings(builder.Configuration.GetSection("Connectors"));

--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -26,6 +26,7 @@
   "Cors": {
     "AllowedOrigins": []
   },
+  "BPN_Address": "",
   "Keycloak": {
     "central": {
       "ConnectionString": "",

--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -26,7 +26,6 @@
   "Cors": {
     "AllowedOrigins": []
   },
-  "BPN_Address": "",
   "Keycloak": {
     "central": {
       "ConnectionString": "",

--- a/src/externalsystems/Bpdm.Library/BpnAccess.cs
+++ b/src/externalsystems/Bpdm.Library/BpnAccess.cs
@@ -64,7 +64,7 @@ public class BpnAccess(IHttpClientFactory httpFactory) : IBpnAccess
             Query = $"page={page}&size={size}"
         }.Uri;
         var request = new BpdmPartnerNetworkRequest(bpnl, legalName);
-        var content = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
+        using var content = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 
         async ValueTask<(bool, string?)> CreateErrorMessage(HttpResponseMessage errorResponse) =>
             (false, (await errorResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None)));

--- a/src/externalsystems/Bpdm.Library/Models/BpdmPartnerNetworkData.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmPartnerNetworkData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 Microsoft and BMW Group AG
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Microsoft and BMW Group AG
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,13 +18,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Models;
+using System.Text.Json.Serialization;
 
-namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library;
+namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Models;
 
-public interface IBpnAccess
-{
-    Task<BpdmLegalEntityDto> FetchLegalEntityByBpn(string businessPartnerNumber, string token, CancellationToken cancellationToken);
-
-    Task<BpdmPartnerNetworkData> FetchPartnerNetworkData(int page, int size, IEnumerable<string> bpnl, string legalName, string token, CancellationToken cancellationToken);
-}
+public record BpdmPartnerNetworkData(
+    [property: JsonPropertyName("content")] IEnumerable<BpdmLegalEntityDto> Content,
+    [property: JsonPropertyName("contentSize")] int ContentSize,
+    [property: JsonPropertyName("page")] int Page,
+    [property: JsonPropertyName("totalElements")] int TotalElements,
+    [property: JsonPropertyName("totalPages")] int TotalPages
+);

--- a/src/externalsystems/Bpdm.Library/Models/BpdmPartnerNetworkRequest.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmPartnerNetworkRequest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 Microsoft and BMW Group AG
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Microsoft and BMW Group AG
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,13 +18,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Models;
+using System.Text.Json.Serialization;
 
-namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library;
+namespace Org.Eclipse.TractusX.Portal.Backend.Bpdm.Library.Models;
 
-public interface IBpnAccess
-{
-    Task<BpdmLegalEntityDto> FetchLegalEntityByBpn(string businessPartnerNumber, string token, CancellationToken cancellationToken);
-
-    Task<BpdmPartnerNetworkData> FetchPartnerNetworkData(int page, int size, IEnumerable<string> bpnl, string legalName, string token, CancellationToken cancellationToken);
-}
+public record BpdmPartnerNetworkRequest(
+    [property: JsonPropertyName("bpnLs")] IEnumerable<string> Bpnls,
+    [property: JsonPropertyName("legalName")] string LegalName
+);

--- a/tests/administration/Administration.Service.Tests/Controllers/PartnerNetworkControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/PartnerNetworkControllerTest.cs
@@ -19,6 +19,9 @@
 
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Controllers;
+using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
+using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Controllers;
 
@@ -37,6 +40,9 @@ public class PartnerNetworkControllerTest
         _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
         _logic = A.Fake<IPartnerNetworkBusinessLogic>();
         _controller = new PartnerNetworkController(_logic);
+        var identity = A.Fake<IIdentityData>();
+        A.CallTo(() => identity.IdentityId).Returns(Guid.NewGuid());
+        _controller.AddControllerContextWithClaimAndBearer("ac-token", identity);
     }
 
     [Theory]
@@ -58,5 +64,20 @@ public class PartnerNetworkControllerTest
         A.CallTo(() => _logic.GetAllMemberCompaniesBPNAsync(A<IEnumerable<string>?>.That.IsSameAs(bpn))).MustHaveHappenedOnceExactly();
 
         result.Should().HaveSameCount(data).And.ContainInOrder(data);
+    }
+
+    [Fact]
+    public async Task GetPartnerNetworkDataAsync_ReturnsExpected()
+    {
+        //Arrange
+        var request = new PartnerNetworkRequest(_fixture.CreateMany<string>(3), "");
+        var page = 0;
+        var size = 1;
+
+        // Act
+        await _controller.GetPartnerNetworkDataAsync(request, page, size, CancellationToken.None);
+
+        // Assert
+        A.CallTo(() => _logic.GetPartnerNetworkDataAsync(page, size, request, "ac-token", A<CancellationToken>._)).MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/externalsystems/Bpdm.Library/BPNAccessTest.cs
+++ b/tests/externalsystems/Bpdm.Library/BPNAccessTest.cs
@@ -309,4 +309,327 @@ public class BPNAccessTest
     }
 
     #endregion
+
+    #region FetchPartnerNetworkData
+
+    [Fact]
+    public async Task FetchPartnerNetworkData_Success_ReturnsExpected()
+    {
+        //Arrange
+        HttpRequestMessage? request = null;
+
+        const string json = @"{
+                ""totalElements"": 46,
+                ""totalPages"": 5,
+                ""page"": 0,
+                ""contentSize"": 10,
+                ""content"": [
+                    {
+                    ""bpnl"": ""BPNL000000000001"",
+                    ""legalName"": ""Comapany Test Auto"",
+                    ""legalShortName"": ""CTA"",
+                    ""legalForm"": {
+                        ""technicalKey"": ""CUSTOM_LEGAL_FORM_f254bb28-92f2-4b49-81a8-f364cde5a5cc"",
+                        ""name"": ""Legal Form for Test Automation"",
+                        ""abbreviation"": null
+                    },
+                    ""identifiers"": [
+                        {
+                        ""value"": ""1c4815e7-c5b6-41a3-862a-a815ee2a836e"",
+                        ""type"": {
+                            ""technicalKey"": ""CUSTOM_LE_ID_e6e534ac-ff59-40ab-bd0d-da94f73f700e"",
+                            ""name"": ""Custom Identifier Type of LE for Test Automation""
+                        },
+                        ""issuingBody"": ""ISSUE_BODY_TEST_AUTO""
+                        }
+                    ],
+                    ""states"": [
+                        {
+                        ""validFrom"": ""2023-07-16T05:54:48.942"",
+                        ""validTo"": ""2024-06-09T07:31:01.213"",
+                        ""type"": {
+                            ""technicalKey"": ""ACTIVE"",
+                            ""name"": ""Active""
+                        }
+                        }
+                    ],
+                    ""relations"": [
+                        
+                    ],
+                    ""currentness"": ""2023-09-20T05:31:17.009357Z"",
+                    ""confidenceCriteria"": {
+                        ""sharedByOwner"": false,
+                        ""checkedByExternalDataSource"": false,
+                        ""numberOfSharingMembers"": 1,
+                        ""lastConfidenceCheckAt"": ""2023-12-29T07:56:51.44798"",
+                        ""nextConfidenceCheckAt"": ""2023-12-29T07:56:51.44798"",
+                        ""confidenceLevel"": 0
+                    },
+                    ""isCatenaXMemberData"": true,
+                    ""createdAt"": ""2023-09-20T05:31:17.090516Z"",
+                    ""updatedAt"": ""2023-09-20T05:31:17.090523Z"",
+                    ""legalAddress"": {
+                        ""bpna"": ""BPNA000000000001"",
+                        ""name"": ""ADDRESS_TEST_AUTO"",
+                        ""states"": [
+                        {
+                            ""validFrom"": ""2023-07-16T05:54:48.942"",
+                            ""validTo"": ""2024-06-05T07:31:01.213"",
+                            ""type"": {
+                            ""technicalKey"": ""ACTIVE"",
+                            ""name"": ""Active""
+                            }
+                        }
+                        ],
+                        ""identifiers"": [
+                        {
+                            ""value"": ""1c4815e7-c5b6-41a3-862a-a815ee2a836e"",
+                            ""type"": {
+                            ""technicalKey"": ""CUSTOM_ADD_ID_0501e165-a446-40f9-b49b-63158abec717"",
+                            ""name"": ""Custom Identifier Type of Test Automation""
+                            }
+                        }
+                        ],
+                        ""physicalPostalAddress"": {
+                        ""geographicCoordinates"": {
+                            ""longitude"": 0.0,
+                            ""latitude"": 0.0,
+                            ""altitude"": 0.0
+                        },
+                        ""country"": {
+                            ""technicalKey"": ""DE"",
+                            ""name"": ""Germany""
+                        },
+                        ""administrativeAreaLevel1"": null,
+                        ""administrativeAreaLevel2"": ""test1"",
+                        ""administrativeAreaLevel3"": ""test2"",
+                        ""postalCode"": ""1111"",
+                        ""city"": ""TestCity"",
+                        ""district"": ""Test district"",
+                        ""street"": {
+                            ""name"": ""Stuttgarter Strasse"",
+                            ""houseNumber"": ""1"",
+                            ""houseNumberSupplement"": null,
+                            ""milestone"": ""Test milestone 1"",
+                            ""direction"": ""Test direction 1"",
+                            ""namePrefix"": null,
+                            ""additionalNamePrefix"": null,
+                            ""nameSuffix"": null,
+                            ""additionalNameSuffix"": null
+                        },
+                        ""companyPostalCode"": ""1234"",
+                        ""industrialZone"": ""Test industrialZone 1"",
+                        ""building"": ""Test building 1"",
+                        ""floor"": ""F"",
+                        ""door"": ""test door 1""
+                        },
+                        ""alternativePostalAddress"": {
+                        ""geographicCoordinates"": {
+                            ""longitude"": 0.0,
+                            ""latitude"": 0.0,
+                            ""altitude"": null
+                        },
+                        ""country"": {
+                            ""technicalKey"": ""DE"",
+                            ""name"": ""Germany""
+                        },
+                        ""administrativeAreaLevel1"": null,
+                        ""postalCode"": ""2222"",
+                        ""city"": ""Test city 2"",
+                        ""deliveryServiceType"": ""PO_BOX"",
+                        ""deliveryServiceQualifier"": ""test deliveryServiceQualifier"",
+                        ""deliveryServiceNumber"": ""2222""
+                        },
+                        ""bpnLegalEntity"": ""BPNL000000000001"",
+                        ""bpnSite"": null,
+                        ""isCatenaXMemberData"": true,
+                        ""createdAt"": ""2023-09-20T05:31:17.084880Z"",
+                        ""updatedAt"": ""2023-09-20T05:31:17.096188Z"",
+                        ""confidenceCriteria"": {
+                        ""sharedByOwner"": false,
+                        ""checkedByExternalDataSource"": false,
+                        ""numberOfSharingMembers"": 1,
+                        ""lastConfidenceCheckAt"": ""2023-12-29T07:56:51.44798"",
+                        ""nextConfidenceCheckAt"": ""2023-12-29T07:56:51.44798"",
+                        ""confidenceLevel"": 0
+                        },
+                        ""addressType"": ""LegalAddress""
+                    }
+                }
+            ]
+        }";
+
+        using var responseMessage = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(json)
+        };
+        _fixture.ConfigureHttpClientFactoryFixture("pnd", responseMessage, requestMessage => request = requestMessage);
+
+        var token = _fixture.Create<string>();
+        var totalElements = 30;
+        var bpnls = _fixture.CreateMany<string>(totalElements);
+        var legalName = _fixture.Create<string>();
+        var page = 0;
+        var size = 10;
+        var sut = _fixture.Create<BpnAccess>();
+
+        //Act
+        var result = await sut.FetchPartnerNetworkData(page, size, bpnls, legalName, token, CancellationToken.None);
+
+        //Assert
+        request.Should().NotBeNull();
+        request!.RequestUri.Should().NotBeNull();
+        request.RequestUri.Should().NotBeNull();
+        request.RequestUri!.LocalPath.Should().Be($"/members/legal-entities/search");
+        request.RequestUri.Query.Should().Be($"?page={page}&size={size}");
+
+        result.Should().NotBeNull();
+        result.Content.Should().NotBeNull();
+        result.Content.First().LegalEntityAddress!.Bpna.Should().Be("BPNA000000000001");
+    }
+
+    [Fact]
+    public async Task FetchPartnerNetworkData_InvalidJsonResponse_Throws()
+    {
+        //Arrange
+        var json = _fixture.Create<string>();
+        using var responseMessage = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(json)
+        };
+        _fixture.ConfigureHttpClientFactoryFixture("pnd", responseMessage);
+
+        var token = _fixture.Create<string>();
+        var totalElements = 30;
+        var bpnls = _fixture.CreateMany<string>(totalElements);
+        var legalName = _fixture.Create<string>();
+        var page = 0;
+        var size = 10;
+        var sut = _fixture.Create<BpnAccess>();
+
+        //Act
+        var Act = () => sut.FetchPartnerNetworkData(page, size, bpnls, legalName, token, CancellationToken.None);
+        var result = await Assert.ThrowsAsync<ServiceException>(Act);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.Message.Should().StartWith("Access to external system bpdm did not return a valid json response");
+    }
+
+    [Fact]
+    public async Task FetchPartnerNetworkData_EmptyResponse_Throws()
+    {
+        //Arrange
+        const string json = "";
+        using var responseMessage = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(json)
+        };
+        _fixture.ConfigureHttpClientFactoryFixture("pnd", responseMessage);
+
+        var token = _fixture.Create<string>();
+        var totalElements = 30;
+        var bpnls = _fixture.CreateMany<string>(totalElements);
+        var legalName = _fixture.Create<string>();
+        var page = 0;
+        var size = 10;
+        var sut = _fixture.Create<BpnAccess>();
+
+        //Act
+        var Act = () => sut.FetchPartnerNetworkData(page, size, bpnls, legalName, token, CancellationToken.None);
+        var result = await Assert.ThrowsAsync<ServiceException>(Act);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.Message.Should().StartWith("Access to external system bpdm did not return a valid json response");
+    }
+
+    [Fact]
+    public async Task FetchPartnerNetworkData_NoContentResponse_Throws()
+    {
+        //Arrange
+        using var responseMessage = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+        };
+        _fixture.ConfigureHttpClientFactoryFixture("pnd", responseMessage);
+
+        var token = _fixture.Create<string>();
+        var totalElements = 30;
+        var bpnls = _fixture.CreateMany<string>(totalElements);
+        var legalName = _fixture.Create<string>();
+        var page = 0;
+        var size = 10;
+        var sut = _fixture.Create<BpnAccess>();
+
+        //Act
+        var Act = () => sut.FetchPartnerNetworkData(page, size, bpnls, legalName, token, CancellationToken.None);
+        var result = await Assert.ThrowsAsync<ServiceException>(Act);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.Message.Should().StartWith("Access to external system bpdm did not return a valid json response");
+    }
+
+    [Fact]
+    public async Task FetchPartnerNetworkData_InvalidJsonType_Throws()
+    {
+        //Arrange
+        const string json = "{\"some\": [{\"other\": \"json\"}]}";
+        using var responseMessage = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(json)
+        };
+        _fixture.ConfigureHttpClientFactoryFixture("pnd", responseMessage);
+
+        var token = _fixture.Create<string>();
+        var totalElements = 30;
+        var bpnls = _fixture.CreateMany<string>(totalElements);
+        var legalName = _fixture.Create<string>();
+        var page = 0;
+        var size = 10;
+        var sut = _fixture.Create<BpnAccess>();
+
+        //Act
+        var Act = () => sut.FetchPartnerNetworkData(page, size, bpnls, legalName, token, CancellationToken.None);
+        var result = await Assert.ThrowsAsync<ServiceException>(Act);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.Message.Should().StartWith("Access to external system bpdm did not return a valid legal entity response");
+    }
+
+    [Fact]
+    public async Task FetchPartnerNetworkData_UnsuccessfulCall_Throws()
+    {
+        //Arrange
+        var json = _fixture.Create<string>();
+        using var responseMessage = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.BadRequest,
+            Content = new StringContent(json)
+        };
+        _fixture.ConfigureHttpClientFactoryFixture("pnd", responseMessage);
+
+        var token = _fixture.Create<string>();
+        var totalElements = 30;
+        var bpnls = _fixture.CreateMany<string>(totalElements);
+        var legalName = _fixture.Create<string>();
+        var page = 0;
+        var size = 10;
+        var sut = _fixture.Create<BpnAccess>();
+
+        //Act
+        var Act = () => sut.FetchPartnerNetworkData(page, size, bpnls, legalName, token, CancellationToken.None);
+        var result = await Assert.ThrowsAsync<ServiceException>(Act);
+
+        //Assert
+        result.Message.Should().Contain($"call to external system fetch-partner-network failed with statuscode {(int)HttpStatusCode.BadRequest}");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Description

Developed an API in portal-backend to get data from partner-network-pool instead of calling business-partner-pool service directly from the portal-frontend.

## Why

This approach will make it consistent and secure, as we are already been calling business-partner-pool service from portal-backed to get legal-entity data by BPN.

## Issue

Ref: #1079

## Corresponding Configuration PR

https://github.com/eclipse-tractusx/portal/pull/461

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
