### PR TITLE
fix(connector): only provider should update connector

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -410,7 +410,7 @@ public class ConnectorsBusinessLogic(
 
         if (connector == null)
         {
-            throw NotFoundException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_FOUND, new ErrorParameter[] { new("connectorId", connectorId.ToString()) });
+            throw NotFoundException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_FOUND, [new("connectorId", connectorId.ToString())]);
         }
 
         if (connector.ConnectorUrl == data.ConnectorUrl)
@@ -418,14 +418,14 @@ public class ConnectorsBusinessLogic(
             return;
         }
 
-        if (!connector.IsHostCompany)
+        if (!connector.IsProviderCompany)
         {
-            throw ForbiddenException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_HOST_COMPANY, new ErrorParameter[] { new("companyId", _identityData.CompanyId.ToString()) });
+            throw ForbiddenException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY, [new("companyId", _identityData.CompanyId.ToString()), new("connectorId", connectorId.ToString())]);
         }
 
         if (connector.Status == ConnectorStatusId.INACTIVE)
         {
-            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_INACTIVE_STATE, new ErrorParameter[] { new("connectorId", connectorId.ToString()), new("connectorStatusId", ConnectorStatusId.INACTIVE.ToString()) });
+            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_INACTIVE_STATE, [new("connectorId", connectorId.ToString()), new("connectorStatusId", ConnectorStatusId.INACTIVE.ToString())]);
         }
 
         var bpn = connector.Type == ConnectorTypeId.CONNECTOR_AS_A_SERVICE
@@ -435,7 +435,7 @@ public class ConnectorsBusinessLogic(
                 .ConfigureAwait(ConfigureAwaitOptions.None);
         if (string.IsNullOrWhiteSpace(bpn))
         {
-            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN, new ErrorParameter[] { new("companyId", _identityData.CompanyId.ToString()) });
+            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN, [new("companyId", _identityData.CompanyId.ToString())]);
         }
 
         connectorsRepository.AttachAndModifyConnector(connectorId, null, con =>

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorUpdateInformation.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorUpdateInformation.cs
@@ -28,7 +28,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 public record ConnectorUpdateInformation(
     ConnectorStatusId Status,
     ConnectorTypeId Type,
-    bool IsHostCompany,
+    bool IsProviderCompany,
     string ConnectorUrl,
     string? Bpn,
     Guid? SelfDescriptionDocumentId,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -192,7 +192,7 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
             .Select(c => new ConnectorUpdateInformation(
                 c.StatusId,
                 c.TypeId,
-                c.HostId == companyId,
+                c.ProviderId == companyId,
                 c.ConnectorUrl,
                 c.Provider!.BusinessPartnerNumber,
                 c.SelfDescriptionDocumentId,

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -1043,13 +1043,13 @@ public class ConnectorsBusinessLogicTests
     }
 
     [Fact]
-    public async Task UpdateConnectorUrl_WithUserNotOfHostCompany_ThrowsForbiddenException()
+    public async Task UpdateConnectorUrl_WithUserNotOfProviderCompany_ThrowsForbiddenException()
     {
         // Arrange
         var connectorId = Guid.NewGuid();
         var data = _fixture.Build<ConnectorUpdateInformation>()
             .With(x => x.ConnectorUrl, "https://old.de")
-            .With(x => x.IsHostCompany, false)
+            .With(x => x.IsProviderCompany, false)
             .Create();
         A.CallTo(() => _connectorsRepository.GetConnectorUpdateInformation(connectorId, _identity.CompanyId))
             .Returns(data);
@@ -1059,7 +1059,7 @@ public class ConnectorsBusinessLogicTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
-        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_NOT_HOST_COMPANY.ToString());
+        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY.ToString());
     }
 
     [Fact]
@@ -1069,7 +1069,7 @@ public class ConnectorsBusinessLogicTests
         var connectorId = Guid.NewGuid();
         var data = _fixture.Build<ConnectorUpdateInformation>()
             .With(x => x.ConnectorUrl, "https://old.de")
-            .With(x => x.IsHostCompany, true)
+            .With(x => x.IsProviderCompany, true)
             .With(x => x.Status, ConnectorStatusId.INACTIVE)
             .Create();
         A.CallTo(() => _connectorsRepository.GetConnectorUpdateInformation(connectorId, _identity.CompanyId))
@@ -1090,7 +1090,7 @@ public class ConnectorsBusinessLogicTests
         var connectorId = Guid.NewGuid();
         var data = _fixture.Build<ConnectorUpdateInformation>()
             .With(x => x.ConnectorUrl, "https://old.de")
-            .With(x => x.IsHostCompany, true)
+            .With(x => x.IsProviderCompany, true)
             .With(x => x.Status, ConnectorStatusId.ACTIVE)
             .With(x => x.Type, ConnectorTypeId.CONNECTOR_AS_A_SERVICE)
             .With(x => x.Bpn, default(string?))
@@ -1113,7 +1113,7 @@ public class ConnectorsBusinessLogicTests
         var connectorId = Guid.NewGuid();
         var data = _fixture.Build<ConnectorUpdateInformation>()
             .With(x => x.ConnectorUrl, "https://old.de")
-            .With(x => x.IsHostCompany, true)
+            .With(x => x.IsProviderCompany, true)
             .With(x => x.Status, ConnectorStatusId.ACTIVE)
             .With(x => x.Type, ConnectorTypeId.COMPANY_CONNECTOR)
             .With(x => x.Bpn, "BPNL123456789")
@@ -1143,7 +1143,7 @@ public class ConnectorsBusinessLogicTests
             .Create();
         var data = _fixture.Build<ConnectorUpdateInformation>()
             .With(x => x.ConnectorUrl, "https://old.de")
-            .With(x => x.IsHostCompany, true)
+            .With(x => x.IsProviderCompany, true)
             .With(x => x.Status, ConnectorStatusId.ACTIVE)
             .With(x => x.Type, ConnectorTypeId.CONNECTOR_AS_A_SERVICE)
             .With(x => x.Bpn, "BPNL123456789")

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -1186,7 +1186,7 @@ public class ConnectorsBusinessLogicTests
         var connectorId = Guid.NewGuid();
         var data = _fixture.Build<ConnectorUpdateInformation>()
             .With(x => x.ConnectorUrl, "https://old.de")
-            .With(x => x.IsHostCompany, true)
+            .With(x => x.IsProviderCompany, true)
             .With(x => x.Status, ConnectorStatusId.ACTIVE)
             .With(x => x.Type, ConnectorTypeId.CONNECTOR_AS_A_SERVICE)
             .With(x => x.Bpn, "BPNL123456789")

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -432,7 +432,6 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result.Should().NotBeNull();
         result!.IsProviderCompany.Should().BeTrue();
-
     }
 
     [Fact]
@@ -447,7 +446,6 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result.Should().NotBeNull();
         result!.IsProviderCompany.Should().BeFalse();
-
     }
 
     #endregion
@@ -483,6 +481,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
             }
         }
     }
+
     [Fact]
     public async Task GetConnectorEndPointDataAsync_CheckHostBPN_ReturnsExpectedResult()
     {
@@ -499,7 +498,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
             x => x.ConnectorEndpoint == "www.connector7.de",
             x => x.ConnectorEndpoint == "www.connector43.de");
         result.Where(x => x.BusinessPartnerNumber == "BPNL00000003CRHK").Should().HaveCount(1).And.Satisfy(
-       x => x.ConnectorEndpoint == "www.connector6.de");
+            x => x.ConnectorEndpoint == "www.connector6.de");
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -36,6 +36,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 {
     private readonly TestDbFixture _dbTestDbFixture;
     private readonly Guid _userCompanyId = new("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87");
+    private readonly Guid _providerCompanyId = new("41fd2ab8-71cd-4546-9bef-a388d91b2542");
     private readonly IEnumerable<ProcessStepTypeId> _processStepsToFilter = [
         ProcessStepTypeId.CREATE_DIM_TECHNICAL_USER,
         ProcessStepTypeId.RETRIGGER_CREATE_DIM_TECHNICAL_USER,
@@ -417,6 +418,34 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetConnectorUpdateInformation_ReturnIsProviderTrue()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.GetConnectorUpdateInformation(new Guid("7e86a0b8-6903-496b-96d1-0ef508206839"), _providerCompanyId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result?.IsProviderCompany.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetConnectorUpdateInformation_ReturnIsProviderFalse()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.GetConnectorUpdateInformation(new Guid("7e86a0b8-6903-496b-96d1-0ef508206839"), _userCompanyId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result?.IsProviderCompany.Should().BeFalse();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -431,7 +431,10 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result?.IsProviderCompany.Should().BeTrue();
+        if (result != null)
+        {
+            result.IsProviderCompany.Should().BeTrue();
+        }
     }
 
     [Fact]
@@ -445,7 +448,10 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result?.IsProviderCompany.Should().BeFalse();
+        if (result != null)
+        {
+            result.IsProviderCompany.Should().BeFalse();
+        }
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -431,10 +431,8 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        if (result != null)
-        {
-            result.IsProviderCompany.Should().BeTrue();
-        }
+        result!.IsProviderCompany.Should().BeTrue();
+
     }
 
     [Fact]
@@ -448,10 +446,8 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        if (result != null)
-        {
-            result.IsProviderCompany.Should().BeFalse();
-        }
+        result!.IsProviderCompany.Should().BeFalse();
+
     }
 
     #endregion


### PR DESCRIPTION
## Description

Updated the validation on update connector api so that only provider can update the connector

## Why

Currently it was not possible for provider to update the connector url which provided by themself only

## Issue

#1085 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
