### PR TITLE
feat(connector): connector controller change url added

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -437,15 +437,20 @@ public class ConnectorsBusinessLogic(
 
         if (connector.SelfDescriptionDocumentId != Guid.Empty)
         {
-            documentRepository.AttachAndModifyDocument((Guid)connector.SelfDescriptionDocumentId!, null, doc =>
+            documentRepository.AttachAndModifyDocument(connector.SelfDescriptionDocumentId.Value, null, doc =>
             {
                 doc.DocumentStatusId = DocumentStatusId.INACTIVE;
             });
         }
 
+        if (connector.SelfDescriptionCompanyDocumentId is null)
+        {
+            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_NO_DESCRIPTION, [new("connectorId", connectorId.ToString())]);
+        }
+
         var selfDescriptionDocumentUrl = $"{_settings.SelfDescriptionDocumentUrl}/{connector.SelfDescriptionCompanyDocumentId}";
         await sdFactoryBusinessLogic
-            .RegisterConnectorAsync(connectorId, selfDescriptionDocumentUrl, connector.Bpn!, cancellationToken)
+            .RegisterConnectorAsync(connectorId, selfDescriptionDocumentUrl, bpn, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
         await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -435,7 +435,7 @@ public class ConnectorsBusinessLogic(
             con.ConnectorUrl = data.ConnectorUrl;
         });
 
-        if (connector.SelfDescriptionDocumentId != Guid.Empty)
+        if (connector.SelfDescriptionDocumentId != null)
         {
             documentRepository.AttachAndModifyDocument(connector.SelfDescriptionDocumentId.Value, null, doc =>
             {

--- a/src/administration/Administration.Service/BusinessLogic/IConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IConnectorsBusinessLogic.cs
@@ -89,7 +89,8 @@ public interface IConnectorsBusinessLogic
     /// </summary>
     /// <param name="connectorId">Id of the connector</param>
     /// <param name="data">Update data for the connector</param>
-    Task UpdateConnectorUrl(Guid connectorId, ConnectorUpdateRequest data);
+    /// <param name="cancellationToken">CancellationToken</param>
+    Task UpdateConnectorUrl(Guid connectorId, ConnectorUpdateRequest data, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the offer subscription data

--- a/src/administration/Administration.Service/Controllers/ConnectorsController.cs
+++ b/src/administration/Administration.Service/Controllers/ConnectorsController.cs
@@ -208,6 +208,7 @@ public class ConnectorsController(IConnectorsBusinessLogic logic)
     /// </summary>
     /// <param name="connectorId" example="5636F9B9-C3DE-4BA5-8027-00D17A2FECFB">Id of the connector to trigger the daps call.</param>
     /// <param name="data">The update data</param>
+    /// <param name="cancellationToken">CancellationToken</param>
     /// <returns>NoContent Result.</returns>
     /// <remarks>Example: PUT: /api/administration/connectors/{connectorId}/connectorUrl</remarks>
     /// <response code="204">Url was successfully updated.</response>
@@ -224,9 +225,9 @@ public class ConnectorsController(IConnectorsBusinessLogic logic)
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status503ServiceUnavailable)]
-    public async Task<NoContentResult> UpdateConnectorUrl([FromRoute] Guid connectorId, [FromBody] ConnectorUpdateRequest data)
+    public async Task<NoContentResult> UpdateConnectorUrl([FromRoute] Guid connectorId, [FromBody] ConnectorUpdateRequest data, CancellationToken cancellationToken)
     {
-        await logic.UpdateConnectorUrl(connectorId, data)
+        await logic.UpdateConnectorUrl(connectorId, data, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);
         return NoContent();
     }

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorUpdateInformation.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorUpdateInformation.cs
@@ -30,4 +30,6 @@ public record ConnectorUpdateInformation(
     ConnectorTypeId Type,
     bool IsHostCompany,
     string ConnectorUrl,
-    string? Bpn);
+    string? Bpn,
+    Guid? SelfDescriptionDocumentId,
+    Guid? SelfDescriptionCompanyDocumentId);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -192,8 +192,9 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
                 c.TypeId,
                 c.HostId == companyId,
                 c.ConnectorUrl,
-                c.Provider!.BusinessPartnerNumber
-            ))
+                c.Provider!.BusinessPartnerNumber,
+                c.SelfDescriptionDocumentId,
+                c.Host!.SelfDescriptionDocumentId))
             .SingleOrDefaultAsync();
 
     public void DeleteConnector(Guid connectorId) =>

--- a/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
@@ -219,10 +219,10 @@ public class ConnectorsControllerTests
         var data = new ConnectorUpdateRequest("https://test.com");
 
         // Act
-        var result = await _controller.UpdateConnectorUrl(connectorId, data);
+        var result = await _controller.UpdateConnectorUrl(connectorId, data, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _logic.UpdateConnectorUrl(connectorId, data)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.UpdateConnectorUrl(connectorId, data, CancellationToken.None)).MustHaveHappenedOnceExactly();
         result.Should().BeOfType<NoContentResult>();
     }
 


### PR DESCRIPTION
## Description

in endpoint api/administration/Connectors/{connectorId}/connectorUrl
open the table portal.documents, search for the connectors.self_description_document_id inside the field id and set the status to "INACTIVE"
now trigger the SD factory endpoint 

## Why

The backend logic will set the current connector assigned self-description to "INACTIVE" - no matter which status the document has currently (retrieve via the table portal.connectors the linked self-description document from the attribute connectors.self_description_document_id.

## Issue

#549 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
