### PR TITLE
fix: adjust remove registration role query

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
@@ -270,15 +270,15 @@ public class UserRolesRepository : IUserRolesRepository
                         .Where(instance => iamClientIds.Contains(instance.IamClient!.ClientClientId))
                         .Select(appInstance => new
                         {
-                            AppInstance = appInstance,
-                            UserRole = identityAssignedRole.UserRole
+                            appInstance.IamClient!.ClientClientId,
+                            identityAssignedRole.UserRole
                         }))
             })
             .Where(x => x.RoleData.Any())
             .Select(x => new ValueTuple<Guid, IEnumerable<(string, Guid, string)>>(
                 x.Identity.Id,
                 x.RoleData.Select(roleData => new ValueTuple<string, Guid, string>(
-                            roleData.AppInstance.IamClient!.ClientClientId,
+                            roleData.ClientClientId,
                             roleData.UserRole.Id,
                             roleData.UserRole.UserRoleText))))
             .Take(2)

--- a/src/registration/ApplicationActivation.Library/ApplicationActivationService.cs
+++ b/src/registration/ApplicationActivation.Library/ApplicationActivationService.cs
@@ -216,16 +216,16 @@ public class ApplicationActivationService(
                 throw new UnexpectedConditionException("userRoleIds should never be empty here");
             }
 
-            var iamUserId =
-                await provisioningManager.GetUserByUserName(userData.IdentityId.ToString())
-                    .ConfigureAwait(ConfigureAwaitOptions.None) ??
-                throw new ConflictException($"user {userData.IdentityId} not found in keycloak");
-
             var roleNamesToDelete = userData.InstanceRoleData
                 .GroupBy(clientRoleData => clientRoleData.ClientClientId)
                 .ToImmutableDictionary(
                     clientRoleDataGroup => clientRoleDataGroup.Key,
                     clientRoleData => clientRoleData.Select(y => y.UserRoleText));
+
+            var iamUserId =
+                await provisioningManager.GetUserByUserName(userData.IdentityId.ToString())
+                    .ConfigureAwait(ConfigureAwaitOptions.None) ??
+                throw new ConflictException($"user {userData.IdentityId} not found in keycloak");
 
             await provisioningManager.DeleteClientRolesFromCentralUserAsync(iamUserId, roleNamesToDelete)
                 .ConfigureAwait(ConfigureAwaitOptions.None);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -75,7 +75,8 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         data.Should().HaveCount(2);
-        data.Should().AllSatisfy(((Guid, IEnumerable<(string, Guid, string)> UserRoleIds) userData) => userData.UserRoleIds.Should().ContainSingle());
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract - null could happen if the database doesn't have the include
+        data.Should().AllSatisfy(((Guid, IEnumerable<(string, Guid, string)> UserRoleIds) userData) => userData.UserRoleIds.Should().ContainSingle().And.Satisfy(x => x.Item1 != null));
     }
 
     #endregion


### PR DESCRIPTION
## Description

fixing the query to select the registration roles

## Why

The clientClientId of the selection was always null, therefor the process worker can't successfully complete the onboarding

## Issue

Refs: #1108

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
