### PR TITLE
fix(offerSubscription): change role (#69)

### DIFF
--- a/docs/api/apps-service.yaml
+++ b/docs/api/apps-service.yaml
@@ -2189,7 +2189,7 @@ paths:
     get:
       tags:
         - Apps
-      summary: 'Retrieves the details of a subscription (Authorization required - Roles: subscribe_apps)'
+      summary: 'Retrieves the details of a subscription (Authorization required - Roles: view_subscription)'
       description: 'Example: GET: /api/apps/{appId}/subscription/{subscriptionId}/subscriber'
       parameters:
         - name: appId

--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -1348,7 +1348,7 @@ paths:
     get:
       tags:
         - Services
-      summary: 'Retrieves the details of a subscription (Authorization required - Roles: subscribe_service)'
+      summary: 'Retrieves the details of a subscription (Authorization required - Roles: view_service_subscriptions)'
       description: 'Example: GET: /api/services/{serviceId}/subscription/{subscriptionId}/subscriber'
       parameters:
         - name: serviceId

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -398,7 +398,7 @@ public class AppsController : ControllerBase
     /// <response code="403">User's company does not provide the app.</response>
     /// <response code="404">No app or subscription found.</response>
     [HttpGet]
-    [Authorize(Roles = "subscribe_apps")]
+    [Authorize(Roles = "view_subscription")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("{appId}/subscription/{subscriptionId}/subscriber")]
     [ProducesResponseType(typeof(SubscriberSubscriptionDetailData), StatusCodes.Status200OK)]

--- a/src/marketplace/Services.Service/Controllers/ServicesController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServicesController.cs
@@ -282,7 +282,7 @@ public class ServicesController : ControllerBase
     /// <response code="403">User's company does not provide the service.</response>
     /// <response code="404">No service or subscription found.</response>
     [HttpGet]
-    [Authorize(Roles = "subscribe_service")]
+    [Authorize(Roles = "view_service_subscriptions")]
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("{serviceId}/subscription/{subscriptionId}/subscriber")]
     [ProducesResponseType(typeof(SubscriberSubscriptionDetailData), StatusCodes.Status200OK)]


### PR DESCRIPTION
## Description

Roles `subscribe_apps` and `subscribe_service` has been changed to `view_subscription` and `view_service_subscriptions` on following APIs:

GET: /api/apps/{appId}/subscription/{subscriptionId}/subscriber
GET: /api/services/{serviceId}/subscription/{subscriptionId}/subscriber

## Why

App & service subscription details CTA leads to 403 error.

![image](https://github.com/user-attachments/assets/636a7c32-3fd1-4e70-9bde-aa4345f2fdda)

## Issue

Ref: #987

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes