### PR TITLE
fix: adjust query for technical user creation / deletion

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -353,6 +353,7 @@ public class ServiceAccountBusinessLogic(
         {
             throw new ConflictException($"ServiceAccountId must be set for process {processId}");
         }
+
         if (processData.ServiceAccountVersion is null)
         {
             throw new UnexpectedConditionException("ServiceAccountVersion or IdentityVersion should never be null here");

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ProcessStepRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ProcessStepRepository.cs
@@ -110,6 +110,7 @@ public class ProcessStepRepository(PortalDbContext dbContext) : IProcessStepRepo
 
     public Task<(ProcessTypeId ProcessTypeId, VerifyProcessData ProcessData, Guid? ServiceAccountId, Guid? ServiceAccountVersion)> GetProcessDataForServiceAccountCallback(Guid processId, IEnumerable<ProcessStepTypeId> processStepTypeIds) =>
         dbContext.Processes
+            .AsNoTracking()
             .Where(x => x.Id == processId)
             .Select(x => new ValueTuple<ProcessTypeId, VerifyProcessData, Guid?, Guid?>(
                 x.ProcessTypeId,
@@ -126,6 +127,7 @@ public class ProcessStepRepository(PortalDbContext dbContext) : IProcessStepRepo
 
     public Task<(ProcessTypeId ProcessTypeId, VerifyProcessData ProcessData, Guid? ServiceAccountId)> GetProcessDataForServiceAccountDeletionCallback(Guid processId, IEnumerable<ProcessStepTypeId>? processStepTypeIds) =>
         dbContext.Processes
+            .AsNoTracking()
             .Where(x => x.Id == processId && x.ProcessTypeId == ProcessTypeId.DIM_TECHNICAL_USER)
             .Select(x => new ValueTuple<ProcessTypeId, VerifyProcessData, Guid?>(
                 x.ProcessTypeId,


### PR DESCRIPTION
## Description

fixing the query to get the process steps for external technical user creation / deletion

## Why

To fix the callback logic of the external technical user creation / deletion 

## Issue

Refs: #1112

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
