### PR TITLE
fix(connector): fixed the edc discovery endpoint

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -130,11 +130,11 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
     public IAsyncEnumerable<(string BusinessPartnerNumber, string ConnectorEndpoint)> GetConnectorEndPointDataAsync(IEnumerable<string> bpns) =>
         dbContext.Connectors
             .AsNoTracking()
-            .Where(connector => connector.StatusId == ConnectorStatusId.ACTIVE && (!bpns.Any() || bpns.Contains(connector.Provider!.BusinessPartnerNumber)))
-            .OrderBy(connector => connector.ProviderId)
+            .Where(connector => connector.StatusId == ConnectorStatusId.ACTIVE && (!bpns.Any() || bpns.Contains(connector.Host!.BusinessPartnerNumber)))
+            .OrderBy(connector => connector.HostId)
             .Select(connector => new ValueTuple<string, string>
             (
-                connector.Provider!.BusinessPartnerNumber!,
+                connector.Host!.BusinessPartnerNumber!,
                 connector.ConnectorUrl
             ))
             .AsAsyncEnumerable();

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyConnectorViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyConnectorViewTests.cs
@@ -46,7 +46,7 @@ public class CompanyConnectorViewTests : IAssemblyFixture<TestDbFixture>
 
         // Act
         var result = await sut.CompanyConnectorView.ToListAsync();
-        result.Should().HaveCount(10);
+        result.Should().HaveCount(11);
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class CompanyConnectorViewTests : IAssemblyFixture<TestDbFixture>
         result!.CompanyId.Should().Be(companyId);
         result.CompanyName.Should().Be("CX-Test-Access");
         result.ConnectorStatus.Should().Be("PENDING");
-        result.ConnectorUrl.Should().Be("www.google.de");
+        result.ConnectorUrl.Should().Be("www.connector123.de");
     }
 
     private async Task<PortalDbContext> CreateContext()

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -73,10 +73,10 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
             x => x.Name == "Test Connector 6"
                 && x.TechnicalUser!.Id == new Guid("cd436931-8399-4c1d-bd81-7dffb298c7ca")
                 && x.TechnicalUser.Name == "test-user-service-accounts"
-                && x.ConnectorUrl == "www.google.de",
+                && x.ConnectorUrl == "www.connector6.de",
             x => x.Name == "Test Connector 1"
                 && x.TechnicalUser == null
-                && x.ConnectorUrl == "www.google.de");
+                && x.ConnectorUrl == "www.connector1.de");
     }
 
     #endregion
@@ -173,7 +173,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         result.IsProviderCompany.Should().BeTrue();
         result.ConnectorData.Name.Should().Be("Test Connector 1");
         result.ConnectorData.TechnicalUser.Should().BeNull();
-        result.ConnectorData.ConnectorUrl.Should().Be("www.google.de");
+        result.ConnectorData.ConnectorUrl.Should().Be("www.connector1.de");
     }
 
     [Fact]
@@ -382,7 +382,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
                 x.TechnicalUser!.Id == new Guid("d0c8ae19-d4f3-49cc-9cb4-6c766d4680f4") &&
                 x.TechnicalUser.Name == "sa-test" &&
                 x.TechnicalUser.Description == "SA with connector" &&
-                x.ConnectorUrl == "www.google.de");
+                x.ConnectorUrl == "www.connector3.de");
     }
 
     [Fact]
@@ -436,7 +436,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     [Theory]
     [InlineData(new[] { "BPNL00000003AYRE", "BPNL00000003CRHK" }, 3, 2)]
-    [InlineData(new string[] { }, 4, 3)]
+    [InlineData(new string[] { }, 5, 3)]
     [InlineData(new[] { "not a bpn" }, 0, 0)]
     public async Task GetConnectorEndPointDataAsync_WithExistingConnector_ReturnsExpectedResult(IEnumerable<string> bpns, int numResults, int numGroups)
     {
@@ -462,6 +462,24 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
                 grouped.Select(x => x.Key).Should().HaveSameCount(bpns).And.AllSatisfy(x => bpns.Should().Contain(x));
             }
         }
+    }
+    [Fact]
+    public async Task GetConnectorEndPointDataAsync_CheckHostBPN_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+        var hostBpn = new[] { "BPNL00000003LLHA", "BPNL00000003CRHK" };
+
+        // Act
+        var result = await sut.GetConnectorEndPointDataAsync(hostBpn).ToListAsync();
+
+        // Assert
+        result.Should().NotBeNull().And.HaveCount(3);
+        result.Where(x => x.BusinessPartnerNumber == "BPNL00000003LLHA").Should().HaveCount(2).And.Satisfy(
+            x => x.ConnectorEndpoint == "www.connector7.de",
+            x => x.ConnectorEndpoint == "www.connector43.de");
+        result.Where(x => x.BusinessPartnerNumber == "BPNL00000003CRHK").Should().HaveCount(1).And.Satisfy(
+       x => x.ConnectorEndpoint == "www.connector6.de");
     }
 
     #endregion
@@ -569,11 +587,12 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result.Content.Should().HaveCount(4).And.Satisfy(
+        result.Content.Should().HaveCount(5).And.Satisfy(
             x => x.Name == "Test Connector 7",
             x => x.Name == "Test Connector 6",
             x => x.Name == "Test Connector 5",
-            x => x.Name == "Test Connector 4");
+            x => x.Name == "Test Connector 4",
+            x => x.Name == "Test Connector 43");
     }
 
     #endregion
@@ -604,7 +623,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.CheckConnectorExists("Test Connector 6", "www.google.de").ConfigureAwait(false);
+        var result = await sut.CheckConnectorExists("Test Connector 6", "www.connector6.de").ConfigureAwait(false);
 
         // Assert
         result.Should().BeTrue();

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -376,7 +376,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
             x.ConnectorData.SequenceEqual(new[]{ new SubscriptionAssignedConnectorData(
                 new Guid("bd644d9c-ca12-4488-ae38-6eb902c9bec0"),
                 "Test Connector 123",
-                "www.google.de")}));
+                "www.connector123.de")}));
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connectors.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connectors.unittest.json
@@ -2,7 +2,7 @@
   {
     "id": "7e86a0b8-6903-496b-96d1-0ef508206836",
     "name": "Test Connector 4",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector4.de",
     "type_id": 1,
     "status_id": 2,
     "provider_id": "ac861325-bc54-4583-bcdc-9e9f2a38ff84",
@@ -13,7 +13,7 @@
   {
     "id": "595a5784-3f28-4ec3-a986-651342d1be81",
     "name": "Test Connector 6",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector6.de",
     "type_id": 1,
     "status_id": 2,
     "provider_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
@@ -25,7 +25,7 @@
   {
     "id": "727365d6-5599-4598-a888-58733fa138e7",
     "name": "Test Connector 5",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector5.de",
     "type_id": 1,
     "status_id": 2,
     "provider_id": "ac861325-bc54-4583-bcdc-9e9f2a38ff84",
@@ -36,7 +36,7 @@
   {
     "id": "8e10b910-523c-435e-b700-4a0c7b31f044",
     "name": "Test Connector 7",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector7.de",
     "type_id": 1,
     "status_id": 2,
     "provider_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
@@ -47,7 +47,7 @@
   {
     "id": "7e86a0b8-6903-496b-96d1-0ef508206833",
     "name": "Test Connector 1",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector1.de",
     "type_id": 1,
     "status_id": 1,
     "provider_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
@@ -58,7 +58,7 @@
   {
     "id": "7e86a0b8-6903-496b-96d1-0ef508206839",
     "name": "Test Connector 2",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector2.de",
     "type_id": 1,
     "status_id": 1,
     "provider_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
@@ -69,7 +69,7 @@
   {
     "id": "7e86a0b8-6903-496b-96d1-0ef508206838",
     "name": "Test Connector 3",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector3.de",
     "type_id": 2,
     "status_id": 1,
     "provider_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
@@ -81,7 +81,7 @@
   {
     "id": "4618c650-709c-4580-956a-85b76eecd4b8",
     "name": "Test Connector 666",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector666.de",
     "type_id": 2,
     "status_id": 1,
     "provider_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
@@ -92,7 +92,7 @@
   {
     "id": "bd644d9c-ca12-4488-ae38-6eb902c9bec0",
     "name": "Test Connector 123",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector123.de",
     "type_id": 2,
     "status_id": 1,
     "provider_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f88",
@@ -103,7 +103,7 @@
   {
     "id": "12481a39-ca13-4760-bbbb-f6ff98508007",
     "name": "Test Connector 42",
-    "connector_url": "www.google.de",
+    "connector_url": "www.connector42.de",
     "type_id": 1,
     "status_id": 1,
     "provider_id": "a45f3b2e-29f7-4b52-8bb2-15b204849d87",
@@ -111,5 +111,16 @@
     "location_id": "DE",
     "self_description_document_id": null,
     "sd_creation_process_id":  "4a5059d9-c427-42b7-aa54-5e5a240946d3"
+  },
+  {
+    "id": "12481a39-ca13-4760-bbbb-f6ff98508008",
+    "name": "Test Connector 43",
+    "connector_url": "www.connector43.de",
+    "type_id": 1,
+    "status_id": 2,
+    "provider_id": "a45f3b2e-29f7-4b52-8bb2-15b204849d87",
+    "host_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
+    "location_id": "DE",
+    "self_description_document_id": null
   }
 ]


### PR DESCRIPTION
## Description

Fixed the EDC discovery endpoint by filtering an grouping it by Host 

## Why

Earlier its was filtering by provider which was showing managed connector under provider BPN which is incorrect.

## Issue

#1089 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
