### PR TITLE
fix(connector): change providercompany check to get access for managed connector

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -78,12 +78,7 @@ public class ConnectorsBusinessLogic(
             throw NotFoundException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_FOUND, new ErrorParameter[] { new("connectorId", connectorId.ToString()) });
         }
 
-        if (!result.IsProviderCompany)
-        {
-            throw ForbiddenException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY, new ErrorParameter[] { new("companyId", companyId.ToString()), new("connectorId", connectorId.ToString()) });
-        }
-
-        return result.ConnectorData;
+        return result;
     }
 
     /// <inheritdoc/>

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -78,7 +78,12 @@ public class ConnectorsBusinessLogic(
             throw NotFoundException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_FOUND, new ErrorParameter[] { new("connectorId", connectorId.ToString()) });
         }
 
-        return result;
+        if (!result.IsProvidingOrHostCompany)
+        {
+            throw ForbiddenException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY, new ErrorParameter[] { new("companyId", companyId.ToString()), new("connectorId", connectorId.ToString()) });
+        }
+
+        return result.ConnectorData;
     }
 
     /// <inheritdoc/>

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -80,7 +80,7 @@ public class ConnectorsBusinessLogic(
 
         if (!result.IsProvidingOrHostCompany)
         {
-            throw ForbiddenException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY, new ErrorParameter[] { new("companyId", companyId.ToString()), new("connectorId", connectorId.ToString()) });
+            throw ForbiddenException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY_NOR_HOST, new ErrorParameter[] { new("companyId", companyId.ToString()), new("connectorId", connectorId.ToString()) });
         }
 
         return result.ConnectorData;

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -84,12 +84,11 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
                     c.ConnectorUrl)
         ).SingleOrDefaultAsync();
 
-    public Task<(ConnectorData ConnectorData, bool IsProviderCompany)> GetConnectorByIdForCompany(Guid connectorId, Guid companyId) =>
+    public Task<ConnectorData?> GetConnectorByIdForCompany(Guid connectorId, Guid companyId) =>
         dbContext.Connectors
             .AsNoTracking()
             .Where(connector => connector.Id == connectorId && connector.StatusId != ConnectorStatusId.INACTIVE)
-            .Select(connector => new ValueTuple<ConnectorData, bool>(
-                new ConnectorData(
+            .Select(connector => new ConnectorData(
                     connector.Name,
                     connector.Location!.Alpha2Code,
                     connector.Id,
@@ -103,10 +102,8 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
                         connector.TechnicalUser.Name,
                         connector.TechnicalUser.ClientClientId,
                         connector.TechnicalUser.Description),
-                    connector.ConnectorUrl),
-                connector.ProviderId == companyId
-            ))
-            .SingleOrDefaultAsync();
+                    connector.ConnectorUrl)
+            ).SingleOrDefaultAsync();
 
     public Task<(ConnectorInformationData ConnectorInformationData, bool IsProviderUser)> GetConnectorInformationByIdForIamUser(Guid connectorId, Guid userCompanyId) =>
         dbContext.Connectors

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -87,7 +87,7 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
     public Task<ConnectorData?> GetConnectorByIdForCompany(Guid connectorId, Guid companyId) =>
         dbContext.Connectors
             .AsNoTracking()
-            .Where(connector => connector.Id == connectorId && connector.StatusId != ConnectorStatusId.INACTIVE)
+            .Where(connector => connector.HostId == companyId && connector.Id == connectorId && connector.StatusId != ConnectorStatusId.INACTIVE)
             .Select(connector => new ConnectorData(
                     connector.Name,
                     connector.Location!.Alpha2Code,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
@@ -43,7 +43,7 @@ public interface IConnectorsRepository
     /// <returns>Pagination.Source of connectors that allows transformation.</returns>
     Func<int, int, Task<Pagination.Source<ManagedConnectorData>?>> GetManagedConnectorsForCompany(Guid companyId);
 
-    Task<(ConnectorData ConnectorData, bool IsProviderCompany)> GetConnectorByIdForCompany(Guid connectorId, Guid companyId);
+    Task<ConnectorData?> GetConnectorByIdForCompany(Guid connectorId, Guid companyId);
 
     Task<(ConnectorInformationData ConnectorInformationData, bool IsProviderUser)> GetConnectorInformationByIdForIamUser(Guid connectorId, Guid userCompanyId);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
@@ -43,7 +43,7 @@ public interface IConnectorsRepository
     /// <returns>Pagination.Source of connectors that allows transformation.</returns>
     Func<int, int, Task<Pagination.Source<ManagedConnectorData>?>> GetManagedConnectorsForCompany(Guid companyId);
 
-    Task<ConnectorData?> GetConnectorByIdForCompany(Guid connectorId, Guid companyId);
+    public Task<(ConnectorData ConnectorData, bool IsProvidingOrHostCompany)> GetConnectorByIdForCompany(Guid connectorId, Guid companyId);
 
     Task<(ConnectorInformationData ConnectorInformationData, bool IsProviderUser)> GetConnectorInformationByIdForIamUser(Guid connectorId, Guid userCompanyId);
 

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -1277,7 +1277,7 @@ public class ConnectorsBusinessLogicTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
-        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY.ToString());
+        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY_NOR_HOST.ToString());
     }
 
     [Fact]

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -1261,24 +1261,7 @@ public class ConnectorsBusinessLogicTests
 
     #endregion
 
-    #region GetCompanyConnectorData
-
-    [Fact]
-    public async Task GetCompanyConnectorData_WithInvalid_ThrowsForbiddenException()
-    {
-        // Arrange
-        var connectorId = Guid.NewGuid();
-        var connectorData = _fixture.Create<ConnectorData>();
-        A.CallTo(() => _connectorsRepository.GetConnectorByIdForCompany(connectorId, _identity.CompanyId))
-            .Returns((connectorData, false));
-
-        // Act
-        async Task Act() => await _logic.GetCompanyConnectorData(connectorId);
-
-        // Assert
-        var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
-        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY.ToString());
-    }
+    #region GetCompanyConnectorData    
 
     [Fact]
     public async Task GetCompanyConnectorData_WithNotExisting_ThrowsNotFoundException()
@@ -1286,7 +1269,7 @@ public class ConnectorsBusinessLogicTests
         // Arrange
         var connectorId = Guid.NewGuid();
         A.CallTo(() => _connectorsRepository.GetConnectorByIdForCompany(connectorId, _identity.CompanyId))
-            .Returns<(ConnectorData, bool)>(default);
+            .Returns<ConnectorData?>(default);
 
         // Act
         async Task Act() => await _logic.GetCompanyConnectorData(connectorId);
@@ -1305,7 +1288,7 @@ public class ConnectorsBusinessLogicTests
             .With(x => x.Name, "Test Connector")
             .Create();
         A.CallTo(() => _connectorsRepository.GetConnectorByIdForCompany(connectorId, _identity.CompanyId))
-            .Returns((connectorData, true));
+            .Returns(connectorData);
 
         // Act
         var result = await _logic.GetCompanyConnectorData(connectorId);

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -1261,7 +1261,24 @@ public class ConnectorsBusinessLogicTests
 
     #endregion
 
-    #region GetCompanyConnectorData    
+    #region GetCompanyConnectorData   
+
+    [Fact]
+    public async Task GetCompanyConnectorData_WithInvalid_ThrowsForbiddenException()
+    {
+        // Arrange
+        var connectorId = Guid.NewGuid();
+        var connectorData = _fixture.Create<ConnectorData>();
+        A.CallTo(() => _connectorsRepository.GetConnectorByIdForCompany(connectorId, _identity.CompanyId))
+            .Returns((connectorData, false));
+
+        // Act
+        async Task Act() => await _logic.GetCompanyConnectorData(connectorId);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
+        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_NOT_PROVIDER_COMPANY.ToString());
+    }
 
     [Fact]
     public async Task GetCompanyConnectorData_WithNotExisting_ThrowsNotFoundException()
@@ -1269,7 +1286,7 @@ public class ConnectorsBusinessLogicTests
         // Arrange
         var connectorId = Guid.NewGuid();
         A.CallTo(() => _connectorsRepository.GetConnectorByIdForCompany(connectorId, _identity.CompanyId))
-            .Returns<ConnectorData?>(default);
+           .Returns<(ConnectorData, bool)>(default);
 
         // Act
         async Task Act() => await _logic.GetCompanyConnectorData(connectorId);
@@ -1288,7 +1305,7 @@ public class ConnectorsBusinessLogicTests
             .With(x => x.Name, "Test Connector")
             .Create();
         A.CallTo(() => _connectorsRepository.GetConnectorByIdForCompany(connectorId, _identity.CompanyId))
-            .Returns(connectorData);
+             .Returns((connectorData, true));
 
         // Act
         var result = await _logic.GetCompanyConnectorData(connectorId);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -159,21 +159,24 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #region GetConnectorByIdForIamUser
 
-    [Fact]
-    public async Task GetConnectorByIdForIamUser_ReturnsExpectedAppCount()
+    [Theory]
+    [InlineData("7e86a0b8-6903-496b-96d1-0ef508206839", "41fd2ab8-71cd-4546-9bef-a388d91b2542", true)]
+    [InlineData("7e86a0b8-6903-496b-96d1-0ef508206839", "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87", true)]
+    [InlineData("7e86a0b8-6903-496b-96d1-0ef508206839", "deadbeef-dead-beef-dead-beefdeadbeef", false)]
+    public async Task GetConnectorByIdForIamUser_ReturnsExpected(Guid connectorId, Guid companyId, bool isProviderOrHost)
     {
         // Arrange
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.GetConnectorByIdForCompany(new Guid("7e86a0b8-6903-496b-96d1-0ef508206833"), _userCompanyId);
+        var result = await sut.GetConnectorByIdForCompany(connectorId, companyId);
 
         // Assert
         result.Should().NotBeNull();
-        result.IsProvidingOrHostCompany.Should().BeTrue();
-        result.ConnectorData.Name.Should().Be("Test Connector 1");
+        result.IsProvidingOrHostCompany.Should().Be(isProviderOrHost);
+        result.ConnectorData.Name.Should().Be("Test Connector 2");
         result.ConnectorData.TechnicalUser.Should().BeNull();
-        result.ConnectorData.ConnectorUrl.Should().Be("www.connector1.de");
+        result.ConnectorData.ConnectorUrl.Should().Be("www.connector2.de");
     }
 
     [Fact]
@@ -187,20 +190,6 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().Be(default);
-    }
-
-    [Fact]
-    public async Task GetConnectorByIdForIamUser_WithoutMatchingUser_ReturnsIsProviderUserFalse()
-    {
-        // Arrange
-        var (sut, _) = await CreateSut();
-
-        // Act
-        var result = await sut.GetConnectorByIdForCompany(new Guid("5aea3711-cc54-47b4-b7eb-ba9f3bf1cb15"), Guid.NewGuid());
-
-        // Assert
-        result.Should().NotBeNull();
-        result.IsProvidingOrHostCompany.Should().BeFalse();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -170,10 +170,9 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result.IsProviderCompany.Should().BeTrue();
-        result.ConnectorData.Name.Should().Be("Test Connector 1");
-        result.ConnectorData.TechnicalUser.Should().BeNull();
-        result.ConnectorData.ConnectorUrl.Should().Be("www.connector1.de");
+        result!.Name.Should().Be("Test Connector 1");
+        result!.TechnicalUser.Should().BeNull();
+        result!.ConnectorUrl.Should().Be("www.connector1.de");
     }
 
     [Fact]
@@ -187,20 +186,6 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().Be(default);
-    }
-
-    [Fact]
-    public async Task GetConnectorByIdForIamUser_WithoutMatchingUser_ReturnsIsProviderUserFalse()
-    {
-        // Arrange
-        var (sut, _) = await CreateSut();
-
-        // Act
-        var result = await sut.GetConnectorByIdForCompany(new Guid("5aea3711-cc54-47b4-b7eb-ba9f3bf1cb15"), Guid.NewGuid());
-
-        // Assert
-        result.Should().NotBeNull();
-        result.IsProviderCompany.Should().BeFalse();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -170,9 +170,10 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result!.Name.Should().Be("Test Connector 1");
-        result!.TechnicalUser.Should().BeNull();
-        result!.ConnectorUrl.Should().Be("www.connector1.de");
+        result.IsProvidingOrHostCompany.Should().BeTrue();
+        result.ConnectorData.Name.Should().Be("Test Connector 1");
+        result.ConnectorData.TechnicalUser.Should().BeNull();
+        result.ConnectorData.ConnectorUrl.Should().Be("www.connector1.de");
     }
 
     [Fact]
@@ -186,6 +187,20 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().Be(default);
+    }
+
+    [Fact]
+    public async Task GetConnectorByIdForIamUser_WithoutMatchingUser_ReturnsIsProviderUserFalse()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.GetConnectorByIdForCompany(new Guid("5aea3711-cc54-47b4-b7eb-ba9f3bf1cb15"), Guid.NewGuid());
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsProvidingOrHostCompany.Should().BeFalse();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalDbContextTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalDbContextTests.cs
@@ -94,7 +94,7 @@ public class PortalDbContextTests : IAssemblyFixture<TestDbFixture>
         ca.DateLastChanged.Should().Be(now);
         var auditEntries = await sut.AuditCompanyApplication20231115.Where(x => x.Id == id).ToListAsync();
         auditEntries.Should().ContainSingle().Which.Should().Match<AuditCompanyApplication20231115>(
-            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(1) && x.AuditV1OperationId == AuditOperationId.INSERT && (x.AuditV1DateLastChanged - now) < TimeSpan.FromSeconds(1) && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"));
+            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(2) && x.AuditV1OperationId == AuditOperationId.INSERT && (x.AuditV1DateLastChanged - now) < TimeSpan.FromSeconds(2) && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"));
         await trans.RollbackAsync();
     }
 
@@ -124,8 +124,8 @@ public class PortalDbContextTests : IAssemblyFixture<TestDbFixture>
         ca.DateLastChanged.Should().Be(later);
         var auditEntries = await sut.AuditCompanyApplication20231115.Where(x => x.Id == id).ToListAsync();
         auditEntries.Should().HaveCount(2).And.Satisfy(
-            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(1) && x.AuditV1OperationId == AuditOperationId.INSERT && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"),
-            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(1) && x.AuditV1OperationId == AuditOperationId.DELETE && (x.AuditV1DateLastChanged - later) < TimeSpan.FromSeconds(1) && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"));
+            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(2) && x.AuditV1OperationId == AuditOperationId.INSERT && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"),
+            x => x.ApplicationStatusId == CompanyApplicationStatusId.CREATED && (x.DateCreated - before) < TimeSpan.FromSeconds(2) && x.AuditV1OperationId == AuditOperationId.DELETE && (x.AuditV1DateLastChanged - later) < TimeSpan.FromSeconds(2) && x.LastEditorId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001"));
         await trans.RollbackAsync();
     }
 


### PR DESCRIPTION
## Description

In endpoint API: GET: /api/administration/connectors/{connectorId} 
As a customer/host company user can't see the details of managed connector getting company {companyId} is not provider of connector {connectorId} error
## Why

Only provider and host/customer company should be able to see the details of connector.

## Issue

#1090 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
