### PR TITLE
fix(providerHomepage): responding providerUrl for service

### DIFF
--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -2380,6 +2380,10 @@ components:
         price:
           type: string
           description: Pricing information of the app.
+        providerUri:
+          type: string
+          description: Provider's homepage url or marketing url
+          nullable: true
         offerSubscriptionDetailData:
           type: array
           items:

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -99,6 +99,7 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
             result.Description,
             result.LicenseTypeId,
             result.Price,
+            result.ProviderUri,
             result.OfferSubscriptionDetailData,
             result.ServiceTypeIds,
             result.Documents.GroupBy(doc => doc.DocumentTypeId).ToDictionary(d => d.Key, d => d.Select(x => new DocumentData(x.DocumentId, x.DocumentName))),

--- a/src/marketplace/Services.Service/ViewModels/ServiceDetailResponse.cs
+++ b/src/marketplace/Services.Service/ViewModels/ServiceDetailResponse.cs
@@ -34,6 +34,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.ViewModels;
 /// <param name="Description">The description of the service.</param>
 /// <param name="LicenseType">LicenseType for offer</param>
 /// <param name="Price">Pricing information of the app.</param>
+/// <param name="ProviderUri">Provider's homepage url or marketing url</param>
 /// <param name="OfferSubscriptionDetailData">Detail Data of the offer subscription</param>
 /// <param name="ServiceTypes">Collection of the assigned serviceTypeIds.</param>
 /// <param name="Documents">documents assigned to offer</param>
@@ -48,6 +49,7 @@ public record ServiceDetailResponse(
     string? Description,
     LicenseTypeId LicenseType,
     string Price,
+    string? ProviderUri,
     IEnumerable<OfferSubscriptionStateDetailData> OfferSubscriptionDetailData,
     IEnumerable<ServiceTypeId> ServiceTypes,
     IDictionary<DocumentTypeId, IEnumerable<DocumentData>> Documents,

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferDetailData.cs
@@ -51,6 +51,7 @@ public record OfferDetailData(
 /// <param name="ContactEmail">Contact email address.</param>
 /// <param name="Description">The description of the service.</param>
 /// <param name="Price">Pricing information of the app.</param>
+/// <param name="ProviderUri">Provider's homepage url or marketing url</param>
 /// <param name="OfferSubscriptionDetailData">Detail Data of the offer subscription</param>
 /// <param name="ServiceTypeIds">Collection of the assigned serviceTypeIds.</param>
 /// <param name="Documents">Collections of the Document type Data.</param>
@@ -64,6 +65,7 @@ public record ServiceDetailData(
     string? ContactEmail,
     string? Description,
     string Price,
+    string? ProviderUri,
     IEnumerable<OfferSubscriptionStateDetailData> OfferSubscriptionDetailData,
     IEnumerable<ServiceTypeId> ServiceTypeIds,
     IEnumerable<DocumentTypeData> Documents,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
@@ -278,6 +278,7 @@ public class OfferRepository(PortalDbContext dbContext) : IOfferRepository
                 offer.ContactEmail,
                 offer.OfferDescriptions.SingleOrDefault(d => d.LanguageShortName == languageShortName)!.DescriptionLong,
                 offer.OfferLicenses.FirstOrDefault()!.Licensetext,
+                offer.MarketingUrl,
                 offer.OfferSubscriptions
                     .Where(os => os.CompanyId == userCompanyId)
                     .Select(x => new OfferSubscriptionStateDetailData(x.Id, x.OfferSubscriptionStatusId)),

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
@@ -295,6 +295,7 @@ public class ServiceBusinessLogicTests
         result.TechnicalUserProfile.Should().ContainSingle().Which.Should().Match<KeyValuePair<Guid, IEnumerable<string>>>(
             x => x.Value.SequenceEqual(new[] { "role1", "role2" }));
         result.LeadPictureId.Should().NotBeEmpty();
+        result.ProviderUri.Should().NotBeEmpty();
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferRepositoryTests.cs
@@ -450,6 +450,7 @@ public class OfferRepositoryTests : IAssemblyFixture<TestDbFixture>
                 x => technicalUserRoleDatas.Single(t => t.TechnicalUserProfileId == x.TechnicalUserProfileId).UserRoles.Count() == 1,
                 x => technicalUserRoleDatas.Single(t => t.TechnicalUserProfileId == x.TechnicalUserProfileId).UserRoles.Count() == 2);
         offerDetail.LeadPictureId.Should().Be(new Guid("9685f744-9d90-4102-a949-fcd0bb86f951"));
+        offerDetail.ProviderUri.Should().Be("https://google.com");
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offers.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offers.unittest.json
@@ -36,7 +36,7 @@
       "name": "Consulting Service - Data Readiness",
       "date_created": "2023-01-01 00:00:00.000000 +00:00",
       "date_released": "2023-01-01 00:00:00.000001 +00:00",
-      "marketing_url": null,
+      "marketing_url": "https://google.com",
       "contact_email": null,
       "contact_number": "0000",
       "provider_company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",


### PR DESCRIPTION
## Description

Responding providerUrl field for service details.

## Why

The 'Provider Homepage' field is blank on the Service details page, even though a URL was provided during the service creation process.

## Issue

Ref: #1125

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes