### PR TITLE
feat(BpnDidService): Transition from API Key to Technical User Authentication for BDRS Integration (#59)

### DIFF
--- a/src/externalsystems/BpnDidResolver.Library/BpnDidResolverService.cs
+++ b/src/externalsystems/BpnDidResolver.Library/BpnDidResolverService.cs
@@ -17,21 +17,43 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Microsoft.Extensions.Options;
+using Org.Eclipse.TractusX.Portal.Backend.BpnDidResolver.Library.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Dim.Library.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Token;
 using System.Net.Http.Json;
 using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.BpnDidResolver.Library;
 
-public class BpnDidResolverService(IHttpClientFactory httpClientFactory) : IBpnDidResolverService
+public class BpnDidResolverService : IBpnDidResolverService
 {
+    private readonly ITokenService _tokenService;
+    private readonly BpnDidResolverSettings _settings;
     private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    /// <summary>
+    /// Creates a new instance of <see cref="BpnDidResolverService"/>
+    /// </summary>
+    /// <param name="tokenService"></param>
+    /// <param name="options"></param>
+    public BpnDidResolverService(ITokenService tokenService, IOptions<BpnDidResolverSettings> options)
+    {
+        _tokenService = tokenService;
+        _settings = options.Value;
+    }
 
     public async Task<bool> TransmitDidAndBpn(string did, string bpn, CancellationToken cancellationToken)
     {
-        using var httpClient = httpClientFactory.CreateClient(nameof(BpnDidResolverService));
+        using var httpClient = await _tokenService.GetAuthorizedClient<BpnDidResolverService>(_settings, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
         var data = new BpnMappingData(bpn, did);
-        var result = await httpClient.PostAsJsonAsync("api/management/bpn-directory", data, Options, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+
+        async ValueTask<(bool, string?)> CreateErrorMessage(HttpResponseMessage errorResponse) =>
+            (false, (await errorResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None)));
+
+        var result = await httpClient.PostAsJsonAsync("api/management/bpn-directory", data, Options, cancellationToken)
+            .CatchingIntoServiceExceptionFor("transmit-did-bpn", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE, CreateErrorMessage).ConfigureAwait(false);
         return result.IsSuccessStatusCode;
     }
 }

--- a/src/externalsystems/BpnDidResolver.Library/DependencyInjection/BpnDidResolverServiceCollectionExtension.cs
+++ b/src/externalsystems/BpnDidResolver.Library/DependencyInjection/BpnDidResolverServiceCollectionExtension.cs
@@ -37,13 +37,9 @@ public static class BpnDidResolverServiceCollectionExtension
 
         var sp = services.BuildServiceProvider();
         var settings = sp.GetRequiredService<IOptions<BpnDidResolverSettings>>();
-        services.AddHttpClient(nameof(BpnDidResolverService), c =>
-        {
-            var baseAddress = settings.Value.BaseAddress;
-            c.BaseAddress = new Uri(baseAddress.EndsWith('/') ? baseAddress : $"{baseAddress}/");
-            c.DefaultRequestHeaders.Add("X-Api-Key", settings.Value.ApiKey);
-        });
+        var baseAddress = settings.Value.BaseAddress;
         services
+            .AddCustomHttpClientWithAuthentication<BpnDidResolverService>(baseAddress.EndsWith('/') ? baseAddress : $"{baseAddress}/")
             .AddTransient<IBpnDidResolverService, BpnDidResolverService>()
             .AddTransient<IBpnDidResolverBusinessLogic, BpnDidResolverBusinessLogic>();
 

--- a/src/externalsystems/BpnDidResolver.Library/DependencyInjection/BpnDidResolverSettings.cs
+++ b/src/externalsystems/BpnDidResolver.Library/DependencyInjection/BpnDidResolverSettings.cs
@@ -17,15 +17,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Token;
 using System.ComponentModel.DataAnnotations;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.BpnDidResolver.Library.DependencyInjection;
 
-public class BpnDidResolverSettings
+public class BpnDidResolverSettings : KeyVaultAuthSettings
 {
     [Required(AllowEmptyStrings = false)]
     public string BaseAddress { get; set; } = null!;
-
-    [Required(AllowEmptyStrings = false)]
-    public string ApiKey { get; set; } = null!;
 }

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identities.json
@@ -160,5 +160,13 @@
     "user_status_id": 1,
     "user_entity_id": null,
     "identity_type_id": 2
+  },
+  {
+    "id": "b28aaf44-acd6-4b77-879b-398fdec28c8b",
+    "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "date_created": "2024-11-05 18:01:33.439000 +00:00",
+    "user_status_id": 1,
+    "user_entity_id": null,
+    "identity_type_id": 2
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identity_assigned_roles.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/identity_assigned_roles.json
@@ -3,5 +3,10 @@
     "identity_id": "ac1cf001-7fbc-1f2f-817f-bce058020006",
     "user_role_id": "58f897ec-0aad-4588-8ffa-5f45d6638632",
     "last_editor_id": null
+  },
+  {
+    "identity_id": "b28aaf44-acd6-4b77-879b-398fdec28c8b",
+    "user_role_id": "c01818be-4978-41f4-bf63-fa6d2de53212",
+    "last_editor_id": null
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/technical_users.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/technical_users.json
@@ -164,5 +164,13 @@
     "technical_user_type_id": 2,
     "technical_user_kind_id": 1,
     "client_client_id": "sa-cl25-cx-3"
+  },
+  {
+    "id": "b28aaf44-acd6-4b77-879b-398fdec28c8b",
+    "name": "sa-cl25-01",
+    "description": "This client/technical user will be used to communicate between portal and BDRS to store new BPNL/DID connections.",
+    "technical_user_type_id": 2,
+    "technical_user_kind_id": 1,
+    "client_client_id": "sa-cl25-01"
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_assigned_collections.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_assigned_collections.json
@@ -246,5 +246,9 @@
   {
     "user_role_collection_id": "a5b8b1de-7759-4620-9c87-6b6d74fb4fbc",
     "user_role_id": "9956fa8d-e454-49ca-a3b1-45e2c106fe59"
+  },
+  {
+    "user_role_collection_id": "1a24eca5-901f-4191-84a7-4ef09a894575",
+    "user_role_id": "c01818be-4978-41f4-bf63-fa6d2de53212"
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_descriptions.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_descriptions.json
@@ -318,5 +318,15 @@
     "user_role_id": "a53a95be-ea7b-4033-926c-26275dc16e0f",
     "language_short_name": "en",
     "description": "Reserviere und bearbeitete Golden Record Tasks im Schritt 'Pool'."
+  },
+  {
+    "user_role_id": "c01818be-4978-41f4-bf63-fa6d2de53212",
+    "language_short_name": "en",
+    "description": "Create and manage BPN/DID records inside the service BDRS."
+  },
+  {
+    "user_role_id": "c01818be-4978-41f4-bf63-fa6d2de53212",
+    "language_short_name": "de",
+    "description": "Erstellen und verwalten Sie BPN/DID-Datensätze im BDRS Service."
   }
 ]

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_roles.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_roles.json
@@ -196,5 +196,11 @@
     "user_role": "BPDM Orchestrator Processor PoolSync",
     "offer_id": "0ffcb416-1101-4ba6-8d4a-a9dfa31745a4",
     "last_editor_id": null
+  },
+  {
+    "id": "c01818be-4978-41f4-bf63-fa6d2de53212",
+    "user_role": "BDRS Management",
+    "offer_id": "0ffcb416-1101-4ba6-8d4a-a9dfa31745a4",
+    "last_editor_id": null
   }
 ]

--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -371,8 +371,14 @@
       ]
     },
     "BpnDidResolver": {
-      "BaseAddress": "",
-      "ApiKey": ""
+      "Username": "",
+      "Password": "",
+      "ClientId": "",
+      "GrantType": "",
+      "ClientSecret": "",
+      "Scope": "",
+      "TokenAddress": "",
+      "BaseAddress": ""
     }
   },
   "Processes": {

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -688,7 +688,7 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result.Should().NotBe(default);
         result.Bpn.Should().Be("BPNL00000003CRHK");
-        result.TechnicalUserRoleIds.Should().HaveCount(19).And.OnlyHaveUniqueItems();
+        result.TechnicalUserRoleIds.Should().HaveCount(20).And.OnlyHaveUniqueItems();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRoleCollectionRolesViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRoleCollectionRolesViewTests.cs
@@ -45,7 +45,7 @@ public class CompanyRoleCollectionRolesViewTests : IAssemblyFixture<TestDbFixtur
 
         // Act
         var result = await sut.CompanyRoleCollectionRolesView.ToListAsync();
-        result.Should().HaveCount(62);
+        result.Should().HaveCount(63);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserRepositoryTests.cs
@@ -292,7 +292,7 @@ public class TechnicalUserRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result!.Count.Should().Be(21);
+        result!.Count.Should().Be(22);
         result.Data.Should().HaveCount(10)
             .And.AllSatisfy(x => x.Should().Match<CompanyServiceAccountData>(y =>
                 y.TechnicalUserTypeId == TechnicalUserTypeId.OWN &&
@@ -371,7 +371,7 @@ public class TechnicalUserRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result!.Count.Should().Be(18);
+        result!.Count.Should().Be(19);
         result.Data.Should().HaveCount(10);
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -57,7 +57,7 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         var data = await sut.GetCoreOfferRolesAsync(_validCompanyId, "en", ClientId).ToListAsync();
 
         // Assert
-        data.Should().HaveCount(19);
+        data.Should().HaveCount(20);
     }
 
     #endregion
@@ -110,9 +110,9 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         var data = await sut.GetServiceAccountRolesAsync(_validCompanyId, ClientId, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1), Constants.DefaultLanguage).ToListAsync();
 
         // Assert
-        data.Should().HaveCount(19);
+        data.Should().HaveCount(20);
         data.Should().OnlyHaveUniqueItems();
-        data.Where(x => !x.External).Should().HaveCount(18);
+        data.Where(x => !x.External).Should().HaveCount(19);
         data.Where(x => x.External).Should().ContainSingle();
     }
 


### PR DESCRIPTION
## Description

We need to update the authentication mechanism for our portal's integration with the BDRS. The current implementation uses an API Key, but it is needed to switch to a new authentication method using a technical user with client ID and secret. 

## Why

The endpoints the portal is hitting remain unchanged, however, the error handling got improved to support the new errors provided with the technical user authentication method.

## Issue

Ref: #1078

## Corresponding Configuration PR
https://github.com/eclipse-tractusx/portal/pull/474

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
