### PR TITLE
fix(activeApps): respond sorted list of Apps

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
@@ -68,6 +68,7 @@ public class OfferRepository(PortalDbContext dbContext) : IOfferRepository
         dbContext.Offers.AsNoTracking()
             .AsSplitQuery()
             .Where(offer => offer.DateReleased.HasValue && offer.DateReleased <= DateTime.UtcNow && offer.OfferTypeId == OfferTypeId.APP && offer.OfferStatusId == OfferStatusId.ACTIVE)
+            .OrderByDescending(x => x.DateReleased)
             .Select(a => new ActiveAppData(
                 a.Id,
                 a.Name,


### PR DESCRIPTION
## Description

On the portal home page, the 'New Apps' section is showing apps in a random order instead of the most recently created four apps, making it difficult to identify the latest additions.

## Why

Apps are displayed in a random order rather than the most recent four created apps.

## Issue

Ref: #1131

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
