### PR TITLE
fix(osp): added short name in company creation

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/NetworkBusinessLogic.cs
@@ -141,6 +141,7 @@ public class NetworkBusinessLogic(
         {
             c.AddressId = address.Id;
             c.BusinessPartnerNumber = data.BusinessPartnerNumber?.ToUpper();
+            c.Shortname = data.ShortName;
         });
 
         companyRepository.CreateUpdateDeleteIdentifiers(company.Id, Enumerable.Empty<(UniqueIdentifierId, string)>(), data.UniqueIds.Select(x => (x.UniqueIdentifierId, x.Value)));

--- a/src/administration/Administration.Service/Models/PartnerRegistrationData.cs
+++ b/src/administration/Administration.Service/Models/PartnerRegistrationData.cs
@@ -27,6 +27,7 @@ public record PartnerRegistrationData
 (
     string ExternalId,
     string Name,
+    string? ShortName,
     [property: JsonPropertyName("bpn")] string? BusinessPartnerNumber,
     string City,
     string StreetName,
@@ -37,7 +38,7 @@ public record PartnerRegistrationData
     IEnumerable<CompanyUniqueIdData> UniqueIds,
     IEnumerable<UserDetailData> UserDetails,
     IEnumerable<CompanyRoleId> CompanyRoles
-) : RegistrationData(Name, City, StreetName, CountryAlpha2Code, BusinessPartnerNumber, null, Region, null, StreetNumber, ZipCode, UniqueIds);
+) : RegistrationData(Name, City, StreetName, CountryAlpha2Code, BusinessPartnerNumber, ShortName, Region, null, StreetNumber, ZipCode, UniqueIds);
 
 public record UserDetailData(
     Guid? IdentityProviderId,

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/NetworkBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/NetworkBusinessLogicTests.cs
@@ -363,6 +363,7 @@ public class NetworkBusinessLogicTests
         var data = new PartnerRegistrationData(
             Guid.NewGuid().ToString(),
             "Test N2N",
+            null,
             Bpn,
             "Munich",
             "Street",
@@ -398,6 +399,7 @@ public class NetworkBusinessLogicTests
         var data = new PartnerRegistrationData(
             Guid.NewGuid().ToString(),
             "Test N2N",
+            "N2N",
             Bpn,
             "Munich",
             "Street",
@@ -438,6 +440,7 @@ public class NetworkBusinessLogicTests
         var data = new PartnerRegistrationData(
             Guid.NewGuid().ToString(),
             "Test N2N",
+            null,
             Bpn,
             "Munich",
             "Street",
@@ -522,6 +525,7 @@ public class NetworkBusinessLogicTests
         companies.Should().ContainSingle()
             .Which.Should().Match<Company>(x =>
                 x.Name == data.Name &&
+                x.Shortname == data.ShortName &&
                 x.CompanyStatusId == CompanyStatusId.PENDING);
         processes.Should().ContainSingle()
             .Which.Should().Match<Process>(
@@ -572,6 +576,7 @@ public class NetworkBusinessLogicTests
         var data = new PartnerRegistrationData(
             Guid.NewGuid().ToString(),
             "Test N2N",
+            "N2N",
             businessPartnerNumber,
             "Munich",
             "Street",
@@ -661,6 +666,7 @@ public class NetworkBusinessLogicTests
         companies.Should().ContainSingle()
             .Which.Should().Match<Company>(x =>
                 x.Name == data.Name &&
+                x.Shortname == data.ShortName &&
                 x.CompanyStatusId == CompanyStatusId.PENDING);
         processes.Should().ContainSingle()
             .Which.Should().Match<Process>(x =>


### PR DESCRIPTION
## Description

Added short name in company creation

## Why

Api had this field in request but was missing in the code while creating the company

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
