### PR TITLE
fix: adjust query to get users for role assignment

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -249,7 +249,7 @@ public class ApplicationRepository(PortalDbContext portalDbContext)
             .Select(invitation => invitation.CompanyUser)
             .Where(companyUser =>
                 companyUser!.Identity!.UserStatusId == UserStatusId.ACTIVE &&
-                userRoleIds.Any(x => companyUser.Identity.IdentityAssignedRoles.Select(iar => iar.UserRoleId).Contains(x)))
+                userRoleIds.Any(x => !companyUser.Identity.IdentityAssignedRoles.Any(iar => iar.UserRoleId == x)))
             .Select(companyUser => new CompanyInvitedUserData(
                 companyUser!.Id,
                 companyUser.Identity!.IdentityAssignedRoles.Select(companyUserAssignedRole => companyUserAssignedRole.UserRoleId)))

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
@@ -28,23 +28,12 @@ using Xunit.Extensions.AssemblyFixture;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Tests;
 
-public class ApplicationRepositoryTests : IAssemblyFixture<TestDbFixture>
+public class ApplicationRepositoryTests(TestDbFixture testDbFixture)
+    : IAssemblyFixture<TestDbFixture>
 {
     private static readonly Guid SubmittedApplicationWithBpn = new("6b2d1263-c073-4a48-bfaf-704dc154ca9f");
     private static readonly Guid ApplicationWithoutBpn = new("4829b64c-de6a-426c-81fc-c0bcf95bcb76");
     private static readonly Guid CompanyId = new("2dc4249f-b5ca-4d42-bef1-7a7a950a4f88");
-    private readonly IFixture _fixture;
-    private readonly TestDbFixture _dbTestDbFixture;
-
-    public ApplicationRepositoryTests(TestDbFixture testDbFixture)
-    {
-        _fixture = new Fixture().Customize(new AutoFakeItEasyCustomization { ConfigureMembers = true });
-        _fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
-            .ForEach(b => _fixture.Behaviors.Remove(b));
-
-        _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
-        _dbTestDbFixture = testDbFixture;
-    }
 
     #region GetCompanyUserRoleWithAddressUntrackedAsync
 
@@ -662,15 +651,55 @@ public class ApplicationRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
+    #region GetInvitedUsersWithoutInitialRoles
+
+    [Fact]
+    public async Task GetInvitedUsersWithoutInitialRoles_WithAllRoles_ReturnsEmpty()
+    {
+        // Arrange
+        var userRoles = new[]
+        {
+            new Guid("58f897ec-0aad-4588-8ffa-5f45d6638632"),
+            new Guid("efc20368-9e82-46ff-b88f-6495b9810253"),
+            new Guid("aabcdfeb-6669-4c74-89f0-19cda090873f")
+        };
+        var sut = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetInvitedUsersWithoutInitialRoles(SubmittedApplicationWithBpn, userRoles).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetInvitedUsersWithoutInitialRoles_WithNotExistingRole_ReturnsExpected()
+    {
+        // Arrange
+        var userRoleId = Guid.NewGuid();
+        var sut = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetInvitedUsersWithoutInitialRoles(SubmittedApplicationWithBpn, new[] { userRoleId }).ToListAsync().ConfigureAwait(false);
+
+        // Assert
+        result.Should().ContainSingle().And.Satisfy(x =>
+            x.CompanyUserId == new Guid("ac1cf001-7fbc-1f2f-817f-bce058020001") &&
+            x.RoleIds.Count() == 3);
+    }
+
+    #endregion
+
     private async Task<(IApplicationRepository sut, PortalDbContext context)> CreateSutWithContext()
     {
-        var context = await _dbTestDbFixture.GetPortalDbContext();
+        var context = await testDbFixture.GetPortalDbContext();
         var sut = new ApplicationRepository(context);
         return (sut, context);
     }
+
     private async Task<IApplicationRepository> CreateSut()
     {
-        var context = await _dbTestDbFixture.GetPortalDbContext();
+        var context = await testDbFixture.GetPortalDbContext();
         var sut = new ApplicationRepository(context);
         return sut;
     }


### PR DESCRIPTION
## Description

Adjusted the query to get users for the initial role assignment

## Why

Currently the query filters users which don't have the initial roles assigned out of the result, thus no users gets the roles assigned.

## Issue

Refs: #1134

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
