### PR TITLE
fix(osp): applied regex validation on uniqueIds param

### DIFF
--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Identity/Directory.Build.props
+++ b/src/framework/Framework.Identity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -36,4 +36,9 @@ public static class ValidationExpressions
     /// </remarks>
     public const string Company = @"^(?!.*\s$)([\p{L}\u0E00-\u0E7F\d\p{Sc}@%*+_\-/\\,.:;=<>!?&^#'\x22()[\]]\s?){1,160}$";
     public const string ExternalCertificateNumber = @"^[a-zA-Z0-9]{0,36}$";
+    public const string COMMERCIAL_REG_NUMBER = "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-)?){4,21}$";
+    public const string VAT_ID = "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-|\\/)?){5,18}$";
+    public const string LEI_CODE = "^[A-Za-z0-9]{20}$";
+    public const string VIES = "^[A-Z]{2}[0-9A-Za-z+*.]{2,12}$";
+    public const string EORI = "^[A-Z]{2}[A-Za-z0-9]{1,15}$";
 }

--- a/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
+++ b/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/registration/Registration.Common/RegistrationValidation.cs
+++ b/src/registration/Registration.Common/RegistrationValidation.cs
@@ -18,6 +18,7 @@
  ********************************************************************************/
 
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Linq;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Registration.Common.ErrorHandling;
@@ -28,6 +29,11 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
 public static class RegistrationValidation
 {
     private static readonly Regex BpnRegex = new(ValidationExpressions.Bpn, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static readonly Regex CommercialRegNumRegex = new(ValidationExpressions.COMMERCIAL_REG_NUMBER, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static readonly Regex VatIdRegex = new(ValidationExpressions.VAT_ID, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static readonly Regex LeiCodeRegex = new(ValidationExpressions.LEI_CODE, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static readonly Regex ViesRegex = new(ValidationExpressions.VIES, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static readonly Regex EoriRegex = new(ValidationExpressions.EORI, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
     public static void ValidateData(this RegistrationData data)
     {
@@ -72,6 +78,14 @@ public static class RegistrationValidation
                 RegistrationValidationErrors.UNIQUE_IDS_NO_DUPLICATE_VALUES,
                 Enumerable.Repeat(new ErrorParameter("duplicateValues", string.Join(", ", duplicateIds.Select(uniqueId => uniqueId.UniqueIdentifierId))), 1));
         }
+
+        data.UniqueIds.Where(uniqueId => IsInvalidValueByUniqueIdentifier(uniqueId.Value, uniqueId.UniqueIdentifierId))
+            .IfAny(invalidUniqueIdentifiersValues =>
+                {
+                    throw new ControllerArgumentException(
+                        $"Invalid value of uniqueIds: '{string.Join(", ", invalidUniqueIdentifiersValues.Select(uniqueId => uniqueId.UniqueIdentifierId))}'",
+                        nameof(data.UniqueIds));
+                });
     }
 
     public static async Task ValidateDatabaseData(this RegistrationData data, Func<string, Task<bool>> checkBpn, Func<string, Task<bool>> checkCountryExistByAlpha2Code, Func<string, IEnumerable<UniqueIdentifierId>, Task<(bool IsValidCountry, IEnumerable<UniqueIdentifierId> UniqueIdentifierIds)>> getCountryAssignedIdentifiers, bool checkBpnAlreadyExists)
@@ -116,4 +130,15 @@ public static class RegistrationValidation
             }
         }
     }
+
+    private static bool IsInvalidValueByUniqueIdentifier(string value, UniqueIdentifierId uniqueIdentifierId) =>
+        uniqueIdentifierId switch
+        {
+            UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !CommercialRegNumRegex.IsMatch(value),
+            UniqueIdentifierId.VAT_ID => !VatIdRegex.IsMatch(value),
+            UniqueIdentifierId.LEI_CODE => !LeiCodeRegex.IsMatch(value),
+            UniqueIdentifierId.VIES => !ViesRegex.IsMatch(value),
+            UniqueIdentifierId.EORI => !EoriRegex.IsMatch(value),
+            _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId))
+        };
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/NetworkBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/NetworkBusinessLogicTests.cs
@@ -47,6 +47,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.Busin
 public class NetworkBusinessLogicTests
 {
     private const string Bpn = "BPNL00000001TEST";
+    private const string VatId = "DE123456789";
     private static readonly string ExistingExternalId = Guid.NewGuid().ToString();
     private static readonly Guid CompanyId = new("95c4339e-e087-4cd2-a5b8-44d385e64630");
     private static readonly Guid UserRoleId = Guid.NewGuid();
@@ -140,12 +141,32 @@ public class NetworkBusinessLogicTests
     }
 
     [Fact]
+    public async Task HandlePartnerRegistration_WithInvalidUniqueId_ThrowsControllerArgumentException()
+    {
+        // Arrange
+        var data = _fixture.Build<PartnerRegistrationData>()
+            .With(x => x.BusinessPartnerNumber, Bpn)
+            .With(x => x.CountryAlpha2Code, "DE")
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, "123"), new CompanyUniqueIdData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "12")])
+            .Create();
+
+        // Act
+        async Task Act() => await _sut.HandlePartnerRegistration(data);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+        ex.Message.Should().Be("Invalid value of uniqueIds: 'VAT_ID, COMMERCIAL_REG_NUMBER' (Parameter 'UniqueIds')");
+        ex.ParamName.Should().Be("UniqueIds");
+    }
+
+    [Fact]
     public async Task HandlePartnerRegistration_WithoutExistingBusinessPartnerNumber_ThrowsControllerArgumentException()
     {
         // Arrange
         var data = _fixture.Build<PartnerRegistrationData>()
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.BusinessPartnerNumber, "BPNL00000001FAIL")
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
 
         // Act
@@ -164,6 +185,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.BusinessPartnerNumber, Bpn)
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.CompanyRoles, Enumerable.Empty<CompanyRoleId>())
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
 
         // Act
@@ -185,6 +207,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.BusinessPartnerNumber, Bpn)
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.UserDetails, new[] { new UserDetailData(null, Guid.NewGuid().ToString(), "test", "Test", "test", email) })
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
 
         // Act
@@ -204,6 +227,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.BusinessPartnerNumber, Bpn)
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.UserDetails, new[] { new UserDetailData(null, Guid.NewGuid().ToString(), "test", firstName, "test", "test@email.com") })
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
 
         // Act
@@ -223,6 +247,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.BusinessPartnerNumber, Bpn)
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.UserDetails, new[] { new UserDetailData(null, Guid.NewGuid().ToString(), "test", "test", lastname, "test@email.com") })
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
 
         // Act
@@ -242,6 +267,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.UserDetails, new[] { new UserDetailData(null, Guid.NewGuid().ToString(), "test", "test", "test", "test@email.com") })
             .With(x => x.ExternalId, ExistingExternalId)
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
 
         // Act
@@ -261,6 +287,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.BusinessPartnerNumber, Bpn)
             .With(x => x.UserDetails, new[] { new UserDetailData(null, Guid.NewGuid().ToString(), "test", "test", "test", "test@email.com") })
             .With(x => x.CountryAlpha2Code, "XX")
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
 
         // Act
@@ -280,6 +307,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.BusinessPartnerNumber, Bpn)
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.UserDetails, new[] { new UserDetailData(null, "123", "test", "test", "test", "test@email.com") })
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
         A.CallTo(() => _identity.CompanyId).Returns(NoIdpCompanyId);
 
@@ -300,6 +328,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.BusinessPartnerNumber, Bpn)
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.UserDetails, new[] { new UserDetailData(null, "123", "test", "test", "test", "test@email.com") })
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
         A.CallTo(() => _identity.CompanyId).Returns(MultiIdpCompanyId);
 
@@ -322,6 +351,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.BusinessPartnerNumber, Bpn)
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.UserDetails, new[] { new UserDetailData(notExistingIdpId, "123", "test", "test", "test", "test@email.com") })
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
 
         // Act
@@ -341,6 +371,7 @@ public class NetworkBusinessLogicTests
             .With(x => x.BusinessPartnerNumber, Bpn)
             .With(x => x.CountryAlpha2Code, "DE")
             .With(x => x.UserDetails, new[] { new UserDetailData(IdpId, "123", "test", "test", "test", "test@email.com") })
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, VatId)])
             .Create();
         A.CallTo(() => _userProvisioningService.GetRoleDatas(A<IEnumerable<UserRoleConfig>>._))
             .Throws(new ControllerArgumentException($"invalid roles: clientId: 'cl1', roles: [Company Admin]"));

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -78,6 +78,7 @@ public class RegistrationBusinessLogicTest
     private readonly Guid _existingApplicationId;
     private readonly string _displayName;
     private readonly string _alpha2code;
+    private readonly string _vatId;
     private readonly TestException _error;
     private readonly IOptions<RegistrationSettings> _options;
     private readonly IStaticDataRepository _staticDataRepository;
@@ -136,6 +137,7 @@ public class RegistrationBusinessLogicTest
         _existingApplicationId = _fixture.Create<Guid>();
         _displayName = _fixture.Create<string>();
         _alpha2code = "XY";
+        _vatId = "DE123456789";
         _error = _fixture.Create<TestException>();
 
         _processLine =
@@ -644,6 +646,7 @@ public class RegistrationBusinessLogicTest
             .With(x => x.BusinessPartnerNumber, "BPNL00000001TEST")
             .With(x => x.CompanyId, companyId)
             .With(x => x.CountryAlpha2Code, _alpha2code)
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, _vatId)])
             .Create();
         A.CallTo(() => _companyRepository.CheckBpnExists("BPNL00000001TEST")).Returns(true);
 
@@ -707,6 +710,7 @@ public class RegistrationBusinessLogicTest
             .With(x => x.BusinessPartnerNumber, "BPNL00000001TEST")
             .With(x => x.CompanyId, companyId)
             .With(x => x.CountryAlpha2Code, _alpha2code)
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, _vatId)])
             .Create();
 
         var sut = new RegistrationBusinessLogic(
@@ -771,6 +775,7 @@ public class RegistrationBusinessLogicTest
             .With(x => x.BusinessPartnerNumber, "BPNL00000001TEST")
             .With(x => x.CompanyId, companyId)
             .With(x => x.CountryAlpha2Code, _alpha2code)
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, _vatId)])
             .Create();
 
         var sut = new RegistrationBusinessLogic(
@@ -836,6 +841,7 @@ public class RegistrationBusinessLogicTest
             .With(x => x.BusinessPartnerNumber, bpn)
             .With(x => x.CompanyId, companyId)
             .With(x => x.CountryAlpha2Code, _alpha2code)
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, _vatId)])
             .Create();
 
         var existingData = _fixture.Build<CompanyApplicationDetailData>()
@@ -903,6 +909,7 @@ public class RegistrationBusinessLogicTest
             .With(x => x.BusinessPartnerNumber, default(string?))
             .With(x => x.CompanyId, companyId)
             .With(x => x.CountryAlpha2Code, _alpha2code)
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, _vatId)])
             .Create();
 
         var existingData = _fixture.Build<CompanyApplicationDetailData>()
@@ -1001,6 +1008,7 @@ public class RegistrationBusinessLogicTest
             .With(x => x.BusinessPartnerNumber, default(string?))
             .With(x => x.CompanyId, companyId)
             .With(x => x.CountryAlpha2Code, _alpha2code)
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, _vatId)])
             .Create();
 
         var existingData = _fixture.Build<CompanyApplicationDetailData>()
@@ -1092,11 +1100,17 @@ public class RegistrationBusinessLogicTest
         var uniqueIdentifiers = _fixture.CreateMany<UniqueIdentifierId>(4);
 
         var firstIdData = _fixture.Build<CompanyUniqueIdData>()
-            .With(x => x.UniqueIdentifierId, uniqueIdentifiers.First()).Create(); // shall not modify
+            .With(x => x.UniqueIdentifierId, uniqueIdentifiers.First())
+            .With(x => x.Value, "HRB123456")
+            .Create(); // shall not modify
         var secondIdData = _fixture.Build<CompanyUniqueIdData>()
-            .With(x => x.UniqueIdentifierId, uniqueIdentifiers.ElementAt(1)).Create(); // shall modify
+            .With(x => x.UniqueIdentifierId, uniqueIdentifiers.ElementAt(1))
+            .With(x => x.Value, "DE124356789")
+            .Create(); // shall modify
         var thirdIdData = _fixture.Build<CompanyUniqueIdData>()
-            .With(x => x.UniqueIdentifierId, uniqueIdentifiers.ElementAt(2)).Create(); // shall create new
+            .With(x => x.UniqueIdentifierId, uniqueIdentifiers.ElementAt(2))
+            .With(x => x.Value, "54930084UKLVMY22DS16")
+            .Create(); // shall create new
 
         var companyData = _fixture.Build<CompanyDetailData>()
             .With(x => x.BusinessPartnerNumber, default(string?))
@@ -1184,6 +1198,7 @@ public class RegistrationBusinessLogicTest
         var companyData = _fixture.Build<CompanyDetailData>()
             .With(x => x.BusinessPartnerNumber, default(string?))
             .With(x => x.CountryAlpha2Code, _alpha2code)
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, _vatId)])
             .Create();
         var identityData = A.Fake<IIdentityData>();
         A.CallTo(() => identityData.IdentityId).Returns(Guid.NewGuid());
@@ -1231,7 +1246,10 @@ public class RegistrationBusinessLogicTest
             .With(x => x.CountryAlpha2Code, _alpha2code)
             .With(x => x.UniqueIds,
                 identifiers.Select(id =>
-                    _fixture.Build<CompanyUniqueIdData>().With(x => x.UniqueIdentifierId, id).Create()))
+                    _fixture.Build<CompanyUniqueIdData>()
+                    .With(x => x.UniqueIdentifierId, id)
+                    .With(x => x.Value, _vatId)
+                    .Create()))
             .Create();
 
         var sut = new RegistrationBusinessLogic(


### PR DESCRIPTION
## Description

Applied one more validation on `uniqueIds` param through regex.

## Why

Currently, request is being validated with invalid data e.g: "VAT ID" --> “value“ : “XYZ“

![image](https://github.com/user-attachments/assets/83a4f60a-e15c-4504-b06e-2c2ca405f913)

## Issue

Ref: #1157

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
