### PR TITLE
feat: enable multiple technical user for offers

### DIFF
--- a/docs/api/administration-service.yaml
+++ b/docs/api/administration-service.yaml
@@ -4314,7 +4314,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceAccountCreationInfo'
+              $ref: '#/components/schemas/TechnicalUserCreationInfo'
       responses:
         '200':
           description: The service account was created.
@@ -7688,21 +7688,6 @@ components:
           type: string
           nullable: true
       additionalProperties: false
-    ServiceAccountCreationInfo:
-      type: object
-      properties:
-        name:
-          type: string
-        description:
-          type: string
-        authenticationType:
-          $ref: '#/components/schemas/IamClientAuthMethod'
-        roleIds:
-          type: array
-          items:
-            type: string
-            format: uuid
-      additionalProperties: false
     ServiceAccountDetails:
       type: object
       properties:
@@ -7746,6 +7731,21 @@ components:
           type: string
         authenticationType:
           $ref: '#/components/schemas/IamClientAuthMethod'
+      additionalProperties: false
+    TechnicalUserCreationInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        authenticationType:
+          $ref: '#/components/schemas/IamClientAuthMethod'
+        roleIds:
+          type: array
+          items:
+            type: string
+            format: uuid
       additionalProperties: false
     TechnicalUserData:
       type: object

--- a/src/administration/Administration.Service/BusinessLogic/ITechnicalUserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ITechnicalUserBusinessLogic.cs
@@ -26,9 +26,9 @@ using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 
-public interface IServiceAccountBusinessLogic
+public interface ITechnicalUserBusinessLogic
 {
-    Task<IEnumerable<ServiceAccountDetails>> CreateOwnCompanyServiceAccountAsync(ServiceAccountCreationInfo serviceAccountCreationInfos);
+    Task<IEnumerable<ServiceAccountDetails>> CreateOwnCompanyServiceAccountAsync(TechnicalUserCreationInfo technicalUserCreationInfos);
     Task DeleteOwnCompanyServiceAccountAsync(Guid serviceAccountId);
     Task<ServiceAccountConnectorOfferData> GetOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId);
     Task<ServiceAccountDetails> UpdateOwnCompanyServiceAccountDetailsAsync(Guid serviceAccountId, ServiceAccountEditableDetails serviceAccountDetails);

--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -36,12 +36,12 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Controllers
 [EnvironmentRoute("MVC_ROUTING_BASEPATH", "serviceaccount")]
 [Produces("application/json")]
 [Consumes("application/json")]
-public class ServiceAccountController(IServiceAccountBusinessLogic logic) : ControllerBase
+public class ServiceAccountController(ITechnicalUserBusinessLogic logic) : ControllerBase
 {
     /// <summary>
     /// Creates a new technical user / service account with selected role under the same org as the requester
     /// </summary>
-    /// <param name="serviceAccountCreationInfo"></param>
+    /// <param name="technicalUserCreationInfo"></param>
     /// <returns></returns>
     /// <remarks>Example: POST: api/administration/serviceaccount/owncompany/serviceaccounts</remarks>
     /// <response code="200">The service account was created.</response>
@@ -54,8 +54,8 @@ public class ServiceAccountController(IServiceAccountBusinessLogic logic) : Cont
     [ProducesResponseType(typeof(IEnumerable<ServiceAccountDetails>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    public Task<IEnumerable<ServiceAccountDetails>> ExecuteCompanyUserCreation([FromBody] ServiceAccountCreationInfo serviceAccountCreationInfo) =>
-        logic.CreateOwnCompanyServiceAccountAsync(serviceAccountCreationInfo);
+    public Task<IEnumerable<ServiceAccountDetails>> ExecuteCompanyUserCreation([FromBody] TechnicalUserCreationInfo technicalUserCreationInfo) =>
+        logic.CreateOwnCompanyServiceAccountAsync(technicalUserCreationInfo);
 
     /// <summary>
     /// Deletes the service account with the given id

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -63,7 +63,7 @@ await WebAppHelper
         builder.Services.AddTransient<IRegistrationBusinessLogic, RegistrationBusinessLogic>()
             .ConfigureRegistrationSettings(builder.Configuration.GetSection("Registration"));
 
-        builder.Services.AddTransient<IServiceAccountBusinessLogic, ServiceAccountBusinessLogic>()
+        builder.Services.AddTransient<ITechnicalUserBusinessLogic, TechnicalUserBusinessLogic>()
             .ConfigureServiceAccountSettings(builder.Configuration.GetSection("ServiceAccount"));
 
         builder.Services.AddTransient<IDocumentsBusinessLogic, DocumentsBusinessLogic>()

--- a/src/marketplace/Offers.Library/Service/ITechnicalUserProfileService.cs
+++ b/src/marketplace/Offers.Library/Service/ITechnicalUserProfileService.cs
@@ -30,12 +30,12 @@ public interface ITechnicalUserProfileService
     /// </summary>
     /// <param name="offerId">Id of the offer</param>
     /// <returns></returns>
-    Task<IEnumerable<ServiceAccountCreationInfo>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId);
+    Task<IEnumerable<TechnicalUserCreationInfo>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId);
 
     /// <summary>
     ///  Gets the technical user profiles for the specific offer subscription
     /// </summary>
     /// <param name="subscriptionId">Id of the offer</param>
     /// <returns></returns>
-    Task<IEnumerable<ServiceAccountCreationInfo>> GetTechnicalUserProfilesForOfferSubscription(Guid subscriptionId);
+    Task<IEnumerable<TechnicalUserCreationInfo>> GetTechnicalUserProfilesForOfferSubscription(Guid subscriptionId);
 }

--- a/src/marketplace/Offers.Library/Service/OfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSetupService.cs
@@ -45,7 +45,7 @@ public class OfferSetupService : IOfferSetupService
 {
     private readonly IPortalRepositories _portalRepositories;
     private readonly IProvisioningManager _provisioningManager;
-    private readonly IServiceAccountCreation _serviceAccountCreation;
+    private readonly ITechnicalUserCreation _technicalUserCreation;
     private readonly INotificationService _notificationService;
     private readonly IOfferSubscriptionProcessService _offerSubscriptionProcessService;
     private readonly IMailingProcessCreation _mailingProcessCreation;
@@ -59,7 +59,7 @@ public class OfferSetupService : IOfferSetupService
     /// </summary>
     /// <param name="portalRepositories">Factory to access the repositories</param>
     /// <param name="provisioningManager">Access to the provisioning manager</param>
-    /// <param name="serviceAccountCreation">Access to the service account creation</param>
+    /// <param name="technicalUserCreation">Access to the service account creation</param>
     /// <param name="notificationService">Creates notifications for the user</param>
     /// <param name="offerSubscriptionProcessService">Access to offer subscription process service</param>
     /// <param name="technicalUserProfileService">Access to the technical user profile service</param>
@@ -70,7 +70,7 @@ public class OfferSetupService : IOfferSetupService
     public OfferSetupService(
         IPortalRepositories portalRepositories,
         IProvisioningManager provisioningManager,
-        IServiceAccountCreation serviceAccountCreation,
+        ITechnicalUserCreation technicalUserCreation,
         INotificationService notificationService,
         IOfferSubscriptionProcessService offerSubscriptionProcessService,
         ITechnicalUserProfileService technicalUserProfileService,
@@ -81,7 +81,7 @@ public class OfferSetupService : IOfferSetupService
     {
         _portalRepositories = portalRepositories;
         _provisioningManager = provisioningManager;
-        _serviceAccountCreation = serviceAccountCreation;
+        _technicalUserCreation = technicalUserCreation;
         _notificationService = notificationService;
         _offerSubscriptionProcessService = offerSubscriptionProcessService;
         _technicalUserProfileService = technicalUserProfileService;
@@ -139,12 +139,12 @@ public class OfferSetupService : IOfferSetupService
 
         var technicalUserClientId = clientInfoData?.ClientId ?? $"{offerDetails.OfferName}-{offerDetails.CompanyName}";
         var createTechnicalUserData = new CreateTechnicalUserData(offerDetails.CompanyId, offerDetails.OfferName, offerDetails.Bpn, technicalUserClientId, offerTypeId == OfferTypeId.APP, true);
-        var (_, processId, technicalUsers) = await CreateTechnicalUserForSubscription(data.RequestId, createTechnicalUserData, null).ConfigureAwait(ConfigureAwaitOptions.None);
+        var technicalUsers = await CreateTechnicalUserForSubscription(data.RequestId, createTechnicalUserData, null).ConfigureAwait(ConfigureAwaitOptions.None);
 
         offerSubscriptionsRepository.AttachAndModifyOfferSubscription(data.RequestId, subscription =>
         {
             subscription.OfferSubscriptionStatusId = OfferSubscriptionStatusId.ACTIVE;
-            subscription.ProcessId = processId;
+            subscription.ProcessId = technicalUsers.ProcessId;
         });
 
         await CreateNotifications(itAdminRoles, offerTypeId, offerDetails, _identityData.IdentityId).ConfigureAwait(ConfigureAwaitOptions.None);
@@ -157,7 +157,7 @@ public class OfferSetupService : IOfferSetupService
 
         await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
         return new OfferAutoSetupResponseData(
-            technicalUsers.Select(x => new TechnicalUserInfoData(x.ServiceAccountId, x.UserRoleData.Select(ur => ur.UserRoleText), x.ServiceAccountData?.AuthData.Secret, x.ClientId)),
+            technicalUsers.ServiceAccounts.Select(x => new TechnicalUserInfoData(x.ServiceAccountId, x.UserRoleData.Select(ur => ur.UserRoleText), x.ServiceAccountData?.AuthData.Secret, x.ClientId)),
             clientInfoData);
     }
 
@@ -165,32 +165,33 @@ public class OfferSetupService : IOfferSetupService
     {
         var technicalUserInfoCreations = await _technicalUserProfileService.GetTechnicalUserProfilesForOfferSubscription(subscriptionId).ConfigureAwait(ConfigureAwaitOptions.None);
 
-        ServiceAccountCreationInfo? serviceAccountCreationInfo;
-        try
-        {
-            serviceAccountCreationInfo = technicalUserInfoCreations.SingleOrDefault();
-        }
-        catch (InvalidOperationException)
-        {
-            throw new UnexpectedConditionException($"There should only be one or none technical user profile configured for {subscriptionId}");
-        }
-
-        if (serviceAccountCreationInfo == null)
+        if (!technicalUserInfoCreations.Any())
         {
             return (false, null, []);
         }
 
-        return await _serviceAccountCreation
-            .CreateServiceAccountAsync(
-                serviceAccountCreationInfo,
-                data.CompanyId,
-                data.Bpn == null ? Enumerable.Empty<string>() : Enumerable.Repeat(data.Bpn, 1),
-                TechnicalUserTypeId.MANAGED,
-                data.EnhanceTechnicalUserName,
-                data.Enabled,
-                new ServiceAccountCreationProcessData(ProcessTypeId.OFFER_SUBSCRIPTION, processId),
-                sa => { sa.OfferSubscriptionId = subscriptionId; })
-            .ConfigureAwait(ConfigureAwaitOptions.None);
+        var serviceAccounts = new List<CreatedServiceAccountData>();
+        var hasExternalServiceAccount = false;
+        var processIdToUse = processId;
+        foreach (var serviceAccountCreationInfo in technicalUserInfoCreations)
+        {
+            var serviceAccountResult = await _technicalUserCreation
+                .CreateTechnicalUsersAsync(
+                    serviceAccountCreationInfo,
+                    data.CompanyId,
+                    data.Bpn == null ? Enumerable.Empty<string>() : Enumerable.Repeat(data.Bpn, 1),
+                    TechnicalUserTypeId.MANAGED,
+                    data.EnhanceTechnicalUserName,
+                    data.Enabled,
+                    new ServiceAccountCreationProcessData(ProcessTypeId.OFFER_SUBSCRIPTION, processIdToUse),
+                    sa => { sa.OfferSubscriptionId = subscriptionId; })
+                .ConfigureAwait(ConfigureAwaitOptions.None);
+            processIdToUse = serviceAccountResult.ProcessId;
+            serviceAccounts.AddRange(serviceAccountResult.TechnicalUsers);
+            hasExternalServiceAccount = hasExternalServiceAccount || serviceAccountResult.HasExternalTechnicalUser;
+        }
+
+        return (hasExternalServiceAccount, processIdToUse, serviceAccounts);
     }
 
     /// <inheritdoc />
@@ -275,8 +276,8 @@ public class OfferSetupService : IOfferSetupService
         var creationData = await _technicalUserProfileService.GetTechnicalUserProfilesForOffer(offerId, offerTypeId).ConfigureAwait(ConfigureAwaitOptions.None);
         foreach (var creationInfo in creationData)
         {
-            var (_, _, result) = await _serviceAccountCreation
-                .CreateServiceAccountAsync(
+            var (_, _, result) = await _technicalUserCreation
+                .CreateTechnicalUsersAsync(
                     creationInfo,
                     data.CompanyId,
                     data.Bpn == null ? Enumerable.Empty<string>() : [data.Bpn],
@@ -543,12 +544,12 @@ public class OfferSetupService : IOfferSetupService
 
         var technicalUserClientId = data.ClientId ?? $"{data.OfferName}-{data.CompanyName}";
         var createTechnicalUserData = new CreateTechnicalUserData(data.CompanyId, data.OfferName, data.Bpn, technicalUserClientId, true, false);
-        var (hasExternalServiceAccount, _, serviceAccounts) = await CreateTechnicalUserForSubscription(offerSubscriptionId, createTechnicalUserData, processId).ConfigureAwait(ConfigureAwaitOptions.None);
-        var technicalClientIds = serviceAccounts.Select(x => x.ClientId);
+        var technicalUsers = await CreateTechnicalUserForSubscription(offerSubscriptionId, createTechnicalUserData, processId).ConfigureAwait(ConfigureAwaitOptions.None);
+        var technicalClientIds = technicalUsers.ServiceAccounts.Select(sa => sa.ClientId);
 
         var content = JsonSerializer.Serialize(new
         {
-            technicalClientIds,
+            technicalClientIds
         });
 
         await _notificationService.CreateNotifications(
@@ -561,7 +562,7 @@ public class OfferSetupService : IOfferSetupService
 
         return new ValueTuple<IEnumerable<ProcessStepTypeId>?, ProcessStepStatusId, bool, string?>(
             [
-                hasExternalServiceAccount
+                technicalUsers.HasExternalServiceAccount
                     ? ProcessStepTypeId.OFFERSUBSCRIPTION_CREATE_DIM_TECHNICAL_USER
                     : ProcessStepTypeId.MANUAL_TRIGGER_ACTIVATE_SUBSCRIPTION
             ],

--- a/src/marketplace/Offers.Library/Service/TechnicalUserProfileService.cs
+++ b/src/marketplace/Offers.Library/Service/TechnicalUserProfileService.cs
@@ -42,7 +42,7 @@ public class TechnicalUserProfileService : ITechnicalUserProfileService
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<ServiceAccountCreationInfo>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId)
+    public async Task<IEnumerable<TechnicalUserCreationInfo>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId)
     {
         var data = await _portalRepositories.GetInstance<IOfferRepository>()
             .GetServiceAccountProfileData(offerId, offerTypeId)
@@ -54,11 +54,11 @@ public class TechnicalUserProfileService : ITechnicalUserProfileService
 
         return CheckTechnicalUserData(data)
             ? data.ServiceAccountProfiles.Select(x => GetServiceAccountData(data.OfferName!, x))
-            : Enumerable.Empty<ServiceAccountCreationInfo>();
+            : Enumerable.Empty<TechnicalUserCreationInfo>();
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<ServiceAccountCreationInfo>> GetTechnicalUserProfilesForOfferSubscription(Guid subscriptionId)
+    public async Task<IEnumerable<TechnicalUserCreationInfo>> GetTechnicalUserProfilesForOfferSubscription(Guid subscriptionId)
     {
         var data = await _portalRepositories.GetInstance<IOfferRepository>()
             .GetServiceAccountProfileDataForSubscription(subscriptionId)
@@ -70,7 +70,7 @@ public class TechnicalUserProfileService : ITechnicalUserProfileService
 
         return CheckTechnicalUserData(data)
             ? data.ServiceAccountProfiles.Select(x => GetServiceAccountData(data.OfferName!, x))
-            : Enumerable.Empty<ServiceAccountCreationInfo>();
+            : Enumerable.Empty<TechnicalUserCreationInfo>();
     }
 
     private static bool CheckTechnicalUserData((bool IsSingleInstance, IEnumerable<IEnumerable<UserRoleData>> ServiceAccountProfiles, string? OfferName) data)
@@ -83,7 +83,7 @@ public class TechnicalUserProfileService : ITechnicalUserProfileService
         return !data.IsSingleInstance && data.ServiceAccountProfiles.Any();
     }
 
-    private static ServiceAccountCreationInfo GetServiceAccountData(string offerName, IEnumerable<UserRoleData> serviceAccountUserRoles) =>
+    private static TechnicalUserCreationInfo GetServiceAccountData(string offerName, IEnumerable<UserRoleData> serviceAccountUserRoles) =>
         new(
             offerName,
             $"Technical User for app {offerName} - {string.Join(",", serviceAccountUserRoles.Select(x => x.UserRoleText))}",

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferCompanySubscriptionStatusData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferCompanySubscriptionStatusData.cs
@@ -25,37 +25,12 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 /// <summary>
 /// View model containing an offer id and connected company subscription statuses.
 /// </summary>
-public class OfferCompanySubscriptionStatusData
-{
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    public OfferCompanySubscriptionStatusData()
-    {
-        CompanySubscriptionStatuses = new HashSet<CompanySubscriptionStatusData>();
-    }
-
-    /// <summary>
-    /// Id of the offer.
-    /// </summary>
-    public Guid OfferId { get; set; }
-
-    /// <summary>
-    /// Name of the service.
-    /// </summary>
-    public string? ServiceName { get; set; }
-
-    /// <summary>
-    /// Subscription statuses of subscribing companies.
-    /// </summary>
-    public IEnumerable<CompanySubscriptionStatusData> CompanySubscriptionStatuses { get; set; }
-
-    /// <summary>
-    /// Id of the lead Image
-    /// </summary>
-    /// <value></value>
-    public Guid Image { get; set; }
-}
+public record OfferCompanySubscriptionStatusData(
+    Guid OfferId,
+    string? ServiceName,
+    IEnumerable<CompanySubscriptionStatusData> CompanySubscriptionStatuses,
+    Guid Image
+);
 
 /// <summary>
 /// View model containing the ID of a company and its app subscription status in a specific context.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -58,11 +58,10 @@ public class OfferSubscriptionsRepository(PortalDbContext dbContext) : IOfferSub
                     SubscriptionStatusSorting.OfferIdDesc => (IEnumerable<Offer> o) => o.OrderByDescending(offer => offer.Id),
                     _ => null
                 },
-                g => new OfferCompanySubscriptionStatusData
-                {
-                    OfferId = g.Id,
-                    ServiceName = g.Name,
-                    CompanySubscriptionStatuses = g.OfferSubscriptions
+                g => new OfferCompanySubscriptionStatusData(
+                    g.Id,
+                    g.Name,
+                    g.OfferSubscriptions
                         .Where(os =>
                             statusIds.Contains(os.OfferSubscriptionStatusId) &&
                             (companyName == null || EF.Functions.ILike(os.Company!.Name, $"%{companyName.EscapeForILike()}%")))
@@ -82,11 +81,11 @@ public class OfferSubscriptionsRepository(PortalDbContext dbContext) : IOfferSub
                                         ps.ProcessStepTypeId,
                                         ps.ProcessStepStatusId))
                                     .Distinct())),
-                    Image = g.Documents
+                    g.Documents
                         .Where(document => document.DocumentTypeId == DocumentTypeId.APP_LEADIMAGE && document.DocumentStatusId == DocumentStatusId.LOCKED)
                         .Select(document => document.Id)
                         .FirstOrDefault()
-                })
+                ))
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferSubscription.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferSubscription.cs
@@ -49,7 +49,6 @@ public class OfferSubscription : IAuditableV1, IBaseEntity
     /// <param name="companyId">Company id.</param>
     /// <param name="offerSubscriptionStatusId">app subscription status.</param>
     /// <param name="requesterId">Id of the requester</param>
-    /// <param name="lastEditorId">Id of the editor</param>
     /// <param name="dateCreated">DateCreated of an Subscription</param>
     public OfferSubscription(Guid id, Guid offerId, Guid companyId, OfferSubscriptionStatusId offerSubscriptionStatusId, Guid requesterId, DateTimeOffset dateCreated)
         : this()

--- a/src/provisioning/Provisioning.Library/Extensions/ServiceAccountCreationExtensions.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/ServiceAccountCreationExtensions.cs
@@ -35,7 +35,7 @@ public static class ServiceAccountCreationExtensions
             .EnvironmentalValidation(section);
 
         services
-            .AddTransient<IServiceAccountCreation, ServiceAccountCreation>();
+            .AddTransient<ITechnicalUserCreation, TechnicalUserCreation>();
 
         return services;
     }

--- a/src/provisioning/Provisioning.Library/Models/TechnicalUserCreationInfo.cs
+++ b/src/provisioning/Provisioning.Library/Models/TechnicalUserCreationInfo.cs
@@ -30,7 +30,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 /// <param name="Description">Description for the service account table</param>
 /// <param name="IamClientAuthMethod">Method of the authentication</param>
 /// <param name="UserRoleIds">ids for the user roles</param>
-public record ServiceAccountCreationInfo(
+public record TechnicalUserCreationInfo(
     [property: JsonPropertyName("name")] string Name,
     [property: JsonPropertyName("description")] string Description,
     [property: JsonPropertyName("authenticationType")] IamClientAuthMethod IamClientAuthMethod,

--- a/src/provisioning/Provisioning.Library/Service/ITechnicalUserCreation.cs
+++ b/src/provisioning/Provisioning.Library/Service/ITechnicalUserCreation.cs
@@ -23,7 +23,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Service;
 
-public interface IServiceAccountCreation
+public interface ITechnicalUserCreation
 {
     /// <summary>
     /// Creates the technical user account and stores the client in the service account table
@@ -31,14 +31,14 @@ public interface IServiceAccountCreation
     /// <param name="creationData">Creation Data</param>
     /// <param name="companyId">Id of the company the technical user is created for</param>
     /// <param name="bpns">Optional list of bpns to set for the user</param>
-    /// <param name="companyServiceAccountTypeId">The type of the created service account</param>
+    /// <param name="technicalUserTypeId">The type of the created service account</param>
     /// <param name="enhanceTechnicalUserName">If <c>true</c> the technicalUserName will get enhanced by the id of the clientID.</param>
     /// <param name="enabled">if <c>true</c> the technical user will be enabled, otherwise <c>false</c></param>
     /// <param name="processData">The process that should be created if a role for a provider type was selected</param>
     /// <param name="setOptionalParameter"></param>
     /// <returns>Returns information about the created technical user</returns>
-    Task<(bool HasExternalServiceAccount, Guid? processId, IEnumerable<CreatedServiceAccountData> ServiceAccounts)> CreateServiceAccountAsync(
-            ServiceAccountCreationInfo creationData,
+    Task<(bool HasExternalTechnicalUser, Guid? ProcessId, IEnumerable<CreatedServiceAccountData> TechnicalUsers)> CreateTechnicalUsersAsync(
+            TechnicalUserCreationInfo creationData,
             Guid companyId,
             IEnumerable<string> bpns,
             TechnicalUserTypeId technicalUserTypeId,

--- a/src/provisioning/Provisioning.Library/Service/TechnicalUserCreation.cs
+++ b/src/provisioning/Provisioning.Library/Service/TechnicalUserCreation.cs
@@ -36,16 +36,16 @@ using ServiceAccountData = Org.Eclipse.TractusX.Portal.Backend.Provisioning.Libr
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Service;
 
 /// <inheritdoc />
-public class ServiceAccountCreation(
+public class TechnicalUserCreation(
     IProvisioningManager provisioningManager,
     IPortalRepositories portalRepositories,
     IProvisioningDBAccess provisioningDbAccess,
-    IOptions<ServiceAccountCreationSettings> options) : IServiceAccountCreation
+    IOptions<ServiceAccountCreationSettings> options) : ITechnicalUserCreation
 {
     private readonly ServiceAccountCreationSettings _settings = options.Value;
 
     /// <inheritdoc />
-    async Task<(bool HasExternalServiceAccount, Guid? processId, IEnumerable<CreatedServiceAccountData> ServiceAccounts)> IServiceAccountCreation.CreateServiceAccountAsync(ServiceAccountCreationInfo creationData,
+    async Task<(bool HasExternalTechnicalUser, Guid? ProcessId, IEnumerable<CreatedServiceAccountData> TechnicalUsers)> ITechnicalUserCreation.CreateTechnicalUsersAsync(TechnicalUserCreationInfo creationData,
             Guid companyId,
             IEnumerable<string> bpns,
             TechnicalUserTypeId technicalUserTypeId,

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/TechnicalUserBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/TechnicalUserBusinessLogicTests.cs
@@ -39,7 +39,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.Tests.BusinessLogic;
 
-public class ServiceAccountBusinessLogicTests
+public class TechnicalUserBusinessLogicTests
 {
     private const string ValidBpn = "BPNL00000003CRHK";
     private const string ClientId = "Cl1-CX-Registration";
@@ -54,7 +54,7 @@ public class ServiceAccountBusinessLogicTests
     private static readonly Guid ExternalServiceAccount = Guid.NewGuid();
     private readonly IIdentityData _identity;
     private readonly IEnumerable<Guid> _userRoleIds = Enumerable.Repeat(Guid.NewGuid(), 1);
-    private readonly IServiceAccountCreation _serviceAccountCreation;
+    private readonly ITechnicalUserCreation _technicalUserCreation;
     private readonly ICompanyRepository _companyRepository;
     private readonly IUserRepository _userRepository;
     private readonly IUserRolesRepository _userRolesRepository;
@@ -68,13 +68,13 @@ public class ServiceAccountBusinessLogicTests
     private readonly IOptions<ServiceAccountSettings> _options;
     private readonly IIdentityService _identityService;
 
-    public ServiceAccountBusinessLogicTests()
+    public TechnicalUserBusinessLogicTests()
     {
         _fixture = new Fixture().Customize(new AutoFakeItEasyCustomization { ConfigureMembers = true });
         _fixture.ConfigureFixture();
 
         _provisioningManager = A.Fake<IProvisioningManager>();
-        _serviceAccountCreation = A.Fake<IServiceAccountCreation>();
+        _technicalUserCreation = A.Fake<ITechnicalUserCreation>();
         _serviceAccountManagement = A.Fake<IServiceAccountManagement>();
 
         _companyRepository = A.Fake<ICompanyRepository>();
@@ -113,8 +113,8 @@ public class ServiceAccountBusinessLogicTests
     {
         // Arrange
         SetupCreateOwnCompanyServiceAccount();
-        var serviceAccountCreationInfos = new ServiceAccountCreationInfo("TheName", "Just a short description", IamClientAuthMethod.SECRET, Enumerable.Repeat(UserRoleId1, 1));
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, _serviceAccountCreation, _identityService, _serviceAccountManagement);
+        var serviceAccountCreationInfos = new TechnicalUserCreationInfo("TheName", "Just a short description", IamClientAuthMethod.SECRET, Enumerable.Repeat(UserRoleId1, 1));
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, _technicalUserCreation, _identityService, _serviceAccountManagement);
 
         // Act
         var result = await sut.CreateOwnCompanyServiceAccountAsync(serviceAccountCreationInfos);
@@ -131,8 +131,8 @@ public class ServiceAccountBusinessLogicTests
         var identity = _fixture.Create<IIdentityData>();
         A.CallTo(() => _identityService.IdentityData).Returns(identity);
         SetupCreateOwnCompanyServiceAccount();
-        var serviceAccountCreationInfos = new ServiceAccountCreationInfo("TheName", "Just a short description", IamClientAuthMethod.SECRET, Enumerable.Repeat(UserRoleId1, 1));
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, _serviceAccountCreation, _identityService, _serviceAccountManagement);
+        var serviceAccountCreationInfos = new TechnicalUserCreationInfo("TheName", "Just a short description", IamClientAuthMethod.SECRET, Enumerable.Repeat(UserRoleId1, 1));
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, _technicalUserCreation, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.CreateOwnCompanyServiceAccountAsync(serviceAccountCreationInfos);
@@ -147,8 +147,8 @@ public class ServiceAccountBusinessLogicTests
     {
         // Arrange
         SetupCreateOwnCompanyServiceAccount();
-        var serviceAccountCreationInfos = new ServiceAccountCreationInfo(string.Empty, "Just a short description", IamClientAuthMethod.SECRET, Enumerable.Repeat(UserRoleId1, 1));
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, _serviceAccountCreation, _identityService, _serviceAccountManagement);
+        var serviceAccountCreationInfos = new TechnicalUserCreationInfo(string.Empty, "Just a short description", IamClientAuthMethod.SECRET, Enumerable.Repeat(UserRoleId1, 1));
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, _technicalUserCreation, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.CreateOwnCompanyServiceAccountAsync(serviceAccountCreationInfos);
@@ -166,8 +166,8 @@ public class ServiceAccountBusinessLogicTests
     {
         // Arrange
         SetupCreateOwnCompanyServiceAccount();
-        var serviceAccountCreationInfos = new ServiceAccountCreationInfo("TheName", "Just a short description", IamClientAuthMethod.JWT, Enumerable.Repeat(UserRoleId1, 1));
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, _serviceAccountCreation, _identityService, _serviceAccountManagement);
+        var serviceAccountCreationInfos = new TechnicalUserCreationInfo("TheName", "Just a short description", IamClientAuthMethod.JWT, Enumerable.Repeat(UserRoleId1, 1));
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, _technicalUserCreation, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.CreateOwnCompanyServiceAccountAsync(serviceAccountCreationInfos);
@@ -186,8 +186,8 @@ public class ServiceAccountBusinessLogicTests
         // Arrange
         var wrongUserRoleId = Guid.NewGuid();
         SetupCreateOwnCompanyServiceAccount();
-        var serviceAccountCreationInfos = new ServiceAccountCreationInfo("TheName", "Just a short description", IamClientAuthMethod.SECRET, [UserRoleId1, wrongUserRoleId]);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, _serviceAccountCreation, _identityService, _serviceAccountManagement);
+        var serviceAccountCreationInfos = new TechnicalUserCreationInfo("TheName", "Just a short description", IamClientAuthMethod.SECRET, [UserRoleId1, wrongUserRoleId]);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, _technicalUserCreation, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.CreateOwnCompanyServiceAccountAsync(serviceAccountCreationInfos);
@@ -210,7 +210,7 @@ public class ServiceAccountBusinessLogicTests
     {
         // Arrange
         SetupGetOwnCompanyServiceAccountDetails();
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         var result = await sut.GetOwnCompanyServiceAccountDetailsAsync(ValidServiceAccountId);
@@ -230,7 +230,7 @@ public class ServiceAccountBusinessLogicTests
     {
         // Arrange
         SetupGetOwnCompanyServiceAccountDetails();
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         var result = await sut.GetOwnCompanyServiceAccountDetailsAsync(ValidServiceAccountWithDimDataId);
@@ -252,7 +252,7 @@ public class ServiceAccountBusinessLogicTests
         SetupGetOwnCompanyServiceAccountDetails();
         var invalidCompanyId = Guid.NewGuid();
         A.CallTo(() => _identity.CompanyId).Returns(invalidCompanyId);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.GetOwnCompanyServiceAccountDetailsAsync(ValidServiceAccountId);
@@ -268,7 +268,7 @@ public class ServiceAccountBusinessLogicTests
         // Arrange
         SetupGetOwnCompanyServiceAccountDetails();
         var invalidServiceAccountId = Guid.NewGuid();
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.GetOwnCompanyServiceAccountDetailsAsync(invalidServiceAccountId);
@@ -287,7 +287,7 @@ public class ServiceAccountBusinessLogicTests
     {
         // Arrange
         SetupResetOwnCompanyServiceAccountSecret();
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         var result = await sut.ResetOwnCompanyServiceAccountSecretAsync(ValidServiceAccountId);
@@ -304,7 +304,7 @@ public class ServiceAccountBusinessLogicTests
         SetupResetOwnCompanyServiceAccountSecret();
         var invalidUser = _fixture.Create<IIdentityData>();
         A.CallTo(() => _identityService.IdentityData).Returns(invalidUser);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.ResetOwnCompanyServiceAccountSecretAsync(ValidServiceAccountId);
@@ -320,7 +320,7 @@ public class ServiceAccountBusinessLogicTests
         // Arrange
         SetupResetOwnCompanyServiceAccountSecret();
         var invalidServiceAccountId = Guid.NewGuid();
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.ResetOwnCompanyServiceAccountSecretAsync(invalidServiceAccountId);
@@ -340,7 +340,7 @@ public class ServiceAccountBusinessLogicTests
         // Arrange
         SetupUpdateOwnCompanyServiceAccountDetails();
         var data = new ServiceAccountEditableDetails(ValidServiceAccountId, "new name", "changed description", IamClientAuthMethod.SECRET);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         TechnicalUser? initial = null;
         TechnicalUser? modified = null;
@@ -375,7 +375,7 @@ public class ServiceAccountBusinessLogicTests
         // Arrange
         SetupUpdateOwnCompanyServiceAccountDetails();
         var data = new ServiceAccountEditableDetails(ValidServiceAccountId, "new name", "changed description", IamClientAuthMethod.JWT);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.UpdateOwnCompanyServiceAccountDetailsAsync(ValidServiceAccountId, data);
@@ -393,7 +393,7 @@ public class ServiceAccountBusinessLogicTests
         // Arrange
         SetupUpdateOwnCompanyServiceAccountDetails();
         var data = new ServiceAccountEditableDetails(ValidServiceAccountId, "new name", "changed description", IamClientAuthMethod.SECRET);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.UpdateOwnCompanyServiceAccountDetailsAsync(Guid.NewGuid(), data);
@@ -415,7 +415,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _technicalUserRepository.GetTechnicalUserWithRoleDataClientIdAsync(invalidServiceAccountId, ValidCompanyId))
             .Returns<TechnicalUserWithRoleDataClientId?>(null);
         var data = new ServiceAccountEditableDetails(invalidServiceAccountId, "new name", "changed description", IamClientAuthMethod.SECRET);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.UpdateOwnCompanyServiceAccountDetailsAsync(invalidServiceAccountId, data);
@@ -436,7 +436,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _technicalUserRepository.GetTechnicalUserWithRoleDataClientIdAsync(InactiveServiceAccount, ValidCompanyId))
             .Returns(inactive);
         var data = new ServiceAccountEditableDetails(InactiveServiceAccount, "new name", "changed description", IamClientAuthMethod.SECRET);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.UpdateOwnCompanyServiceAccountDetailsAsync(InactiveServiceAccount, data);
@@ -460,7 +460,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _technicalUserRepository.GetTechnicalUserWithRoleDataClientIdAsync(ExternalServiceAccount, ValidCompanyId))
             .Returns(external);
         var data = new ServiceAccountEditableDetails(ExternalServiceAccount, "new name", "changed description", IamClientAuthMethod.SECRET);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         var result = await sut.UpdateOwnCompanyServiceAccountDetailsAsync(ExternalServiceAccount, data);
@@ -505,7 +505,7 @@ public class ServiceAccountBusinessLogicTests
             .Returns((int skip, int take) => Task.FromResult<Pagination.Source<CompanyServiceAccountData>?>(new(data.Count(), data.Skip(skip).Take(take))));
 
         A.CallTo(() => _portalRepositories.GetInstance<ITechnicalUserRepository>()).Returns(_technicalUserRepository);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         var result = await sut.GetOwnCompanyServiceAccountsDataAsync(1, 10, null, null, isUserInactive, userStatusIds);
@@ -536,7 +536,7 @@ public class ServiceAccountBusinessLogicTests
         var serviceAccountId = Guid.NewGuid();
         SetupDeleteOwnCompanyServiceAccount();
 
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.DeleteOwnCompanyServiceAccountAsync(serviceAccountId);
@@ -556,7 +556,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _technicalUserRepository.GetOwnTechnicalUserWithIamUserRolesAsync(A<Guid>.That.Not.Matches(x => x == ValidServiceAccountId), A<Guid>._, A<IEnumerable<ProcessStepTypeId>>._))
             .Returns<OwnTechnicalUserData?>(null);
 
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.DeleteOwnCompanyServiceAccountAsync(ValidServiceAccountId);
@@ -576,7 +576,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _technicalUserRepository.GetOwnTechnicalUserWithIamUserRolesAsync(A<Guid>.That.Not.Matches(x => x == ValidServiceAccountId), A<Guid>._, A<IEnumerable<ProcessStepTypeId>>._))
             .Returns<OwnTechnicalUserData?>(null);
 
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.DeleteOwnCompanyServiceAccountAsync(ValidServiceAccountId);
@@ -597,7 +597,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _technicalUserRepository.GetOwnTechnicalUserWithIamUserRolesAsync(ValidServiceAccountId, ValidCompanyId, A<IEnumerable<ProcessStepTypeId>>._))
             .Returns(new OwnTechnicalUserData(_userRoleIds, ValidServiceAccountId, userStatusId, true, Guid.NewGuid(), null, null, ConnectorStatusId.ACTIVE, OfferSubscriptionStatusId.PENDING, false, false, null));
 
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.DeleteOwnCompanyServiceAccountAsync(ValidServiceAccountId);
@@ -614,7 +614,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _technicalUserRepository.GetOwnTechnicalUserWithIamUserRolesAsync(ValidServiceAccountId, ValidCompanyId, A<IEnumerable<ProcessStepTypeId>>._))
             .Returns(new OwnTechnicalUserData(_userRoleIds, ValidServiceAccountId, UserStatusId.ACTIVE, false, Guid.NewGuid(), null, null, ConnectorStatusId.ACTIVE, OfferSubscriptionStatusId.PENDING, false, false, null));
 
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         async Task Act() => await sut.DeleteOwnCompanyServiceAccountAsync(ValidServiceAccountId);
@@ -637,7 +637,7 @@ public class ServiceAccountBusinessLogicTests
             .Create();
         var processId = Guid.NewGuid();
         SetupDeleteOwnCompanyServiceAccount(connector, identity, processId);
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         await sut.DeleteOwnCompanyServiceAccountAsync(ValidServiceAccountId);
@@ -663,7 +663,7 @@ public class ServiceAccountBusinessLogicTests
 
         A.CallTo(() => _portalRepositories.GetInstance<IUserRolesRepository>()).Returns(_userRolesRepository);
 
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, null!, _identityService, _serviceAccountManagement);
 
         // Act
         var result = await sut.GetServiceAccountRolesAsync(null).ToListAsync();
@@ -695,7 +695,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _processStepRepository.GetProcessDataForServiceAccountCallback(A<Guid>._, A<IEnumerable<ProcessStepTypeId>>._))
             .Returns((ProcessTypeId.OFFER_SUBSCRIPTION, context, Guid.NewGuid(), Guid.NewGuid()));
 
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, _serviceAccountCreation, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, _technicalUserCreation, _identityService, _serviceAccountManagement);
 
         // Act
         await sut.HandleServiceAccountCreationCallback(process.Id, _fixture.Create<AuthenticationDetail>());
@@ -717,7 +717,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _processStepRepository.GetProcessDataForServiceAccountCallback(A<Guid>._, A<IEnumerable<ProcessStepTypeId>>._))
             .Returns<(ProcessTypeId, VerifyProcessData, Guid?, Guid?)>(default);
 
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, _serviceAccountCreation, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, _technicalUserCreation, _identityService, _serviceAccountManagement);
 
         async Task Act() => await sut.HandleServiceAccountCreationCallback(process.Id, _fixture.Create<AuthenticationDetail>());
 
@@ -740,7 +740,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _processStepRepository.GetProcessDataForServiceAccountCallback(A<Guid>._, A<IEnumerable<ProcessStepTypeId>>._))
             .Returns((ProcessTypeId.OFFER_SUBSCRIPTION, context, null, null));
 
-        var sut = new ServiceAccountBusinessLogic(_provisioningManager, _portalRepositories, _options, _serviceAccountCreation, _identityService, _serviceAccountManagement);
+        var sut = new TechnicalUserBusinessLogic(_provisioningManager, _portalRepositories, _options, _technicalUserCreation, _identityService, _serviceAccountManagement);
 
         async Task Act() => await sut.HandleServiceAccountCreationCallback(process.Id, _fixture.Create<AuthenticationDetail>());
 
@@ -764,7 +764,7 @@ public class ServiceAccountBusinessLogicTests
         A.CallTo(() => _companyRepository.GetBpnAndTechnicalUserRoleIds(A<Guid>.That.Not.Matches(x => x == ValidCompanyId), ClientId))
             .Returns<(string?, IEnumerable<Guid>)>(default);
 
-        A.CallTo(() => _serviceAccountCreation.CreateServiceAccountAsync(A<ServiceAccountCreationInfo>._, A<Guid>.That.Matches(x => x == ValidCompanyId), A<IEnumerable<string>>._, TechnicalUserTypeId.OWN, A<bool>._, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), null))
+        A.CallTo(() => _technicalUserCreation.CreateTechnicalUsersAsync(A<TechnicalUserCreationInfo>._, A<Guid>.That.Matches(x => x == ValidCompanyId), A<IEnumerable<string>>._, TechnicalUserTypeId.OWN, A<bool>._, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), null))
             .Returns((false, null, [new CreatedServiceAccountData(Guid.NewGuid(), "test", "description", UserStatusId.ACTIVE, ClientId, new(ClientId, Guid.NewGuid().ToString(), new ClientAuthData(IamClientAuthMethod.SECRET)), Enumerable.Empty<UserRoleData>())]));
 
         A.CallTo(() => _portalRepositories.GetInstance<ICompanyRepository>()).Returns(_companyRepository);

--- a/tests/administration/Administration.Service.Tests/Controllers/ServiceAccountControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/ServiceAccountControllerTests.cs
@@ -34,7 +34,7 @@ public class ServiceAccountControllerTests
 {
     private readonly IIdentityData _identity;
     private readonly IFixture _fixture;
-    private readonly IServiceAccountBusinessLogic _logic;
+    private readonly ITechnicalUserBusinessLogic _logic;
     private readonly ServiceAccountController _controller;
 
     public ServiceAccountControllerTests()
@@ -48,7 +48,7 @@ public class ServiceAccountControllerTests
         A.CallTo(() => _identity.IdentityId).Returns(Guid.NewGuid());
         A.CallTo(() => _identity.IdentityTypeId).Returns(IdentityTypeId.COMPANY_USER);
         A.CallTo(() => _identity.CompanyId).Returns(Guid.NewGuid());
-        _logic = A.Fake<IServiceAccountBusinessLogic>();
+        _logic = A.Fake<ITechnicalUserBusinessLogic>();
         _controller = new ServiceAccountController(_logic);
         _controller.AddControllerContextWithClaim(_identity);
     }
@@ -61,8 +61,8 @@ public class ServiceAccountControllerTests
         var responseData = _fixture.Build<ServiceAccountDetails>()
             .With(x => x.TechnicalUserId, serviceAccountId)
             .CreateMany(1);
-        var data = _fixture.Create<ServiceAccountCreationInfo>();
-        A.CallTo(() => _logic.CreateOwnCompanyServiceAccountAsync(A<ServiceAccountCreationInfo>._))
+        var data = _fixture.Create<TechnicalUserCreationInfo>();
+        A.CallTo(() => _logic.CreateOwnCompanyServiceAccountAsync(A<TechnicalUserCreationInfo>._))
             .Returns(responseData);
 
         // Act

--- a/tests/endtoend/ServiceAccountCUDScenarios/AdministrationEndpointHelper.cs
+++ b/tests/endtoend/ServiceAccountCUDScenarios/AdministrationEndpointHelper.cs
@@ -103,7 +103,7 @@ public static class AdministrationEndpointHelper
             userRoleIds.AddRange(from t in allServiceAccountsRoles where t.UserRoleText.Contains(p) select t.UserRoleId);
         }
 
-        var serviceAccountCreationInfo = new ServiceAccountCreationInfo(techUserName, Description, IamClientAuthMethod.SECRET, userRoleIds);
+        var serviceAccountCreationInfo = new TechnicalUserCreationInfo(techUserName, Description, IamClientAuthMethod.SECRET, userRoleIds);
         var endpoint = $"{EndPoint}/serviceaccount/owncompany/serviceaccounts";
         var response = Given()
             .DisableSslCertificateValidation()

--- a/tests/provisioning/Provisioning.Library.Tests/Extensions/TechnicalUserCreationTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/Extensions/TechnicalUserCreationTests.cs
@@ -34,7 +34,7 @@ using ServiceAccountData = Org.Eclipse.TractusX.Portal.Backend.Provisioning.Libr
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Tests.Extensions;
 
-public class ServiceAccountCreationTests
+public class TechnicalUserCreationTests
 {
     private const string Bpn = "CAXSDUMMYCATENAZZ";
     private readonly string _iamUserId = Guid.NewGuid().ToString();
@@ -57,9 +57,9 @@ public class ServiceAccountCreationTests
     private readonly IProvisioningManager _provisioningManager;
     private readonly IPortalRepositories _portalRepositories;
     private readonly IProvisioningDBAccess _provisioningDbAccess;
-    private readonly IServiceAccountCreation _sut;
+    private readonly ITechnicalUserCreation _sut;
 
-    public ServiceAccountCreationTests()
+    public TechnicalUserCreationTests()
     {
         var fixture = new Fixture().Customize(new AutoFakeItEasyCustomization { ConfigureMembers = true });
         fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
@@ -90,7 +90,7 @@ public class ServiceAccountCreationTests
         A.CallTo(() => _portalRepositories.GetInstance<IUserRolesRepository>()).Returns(_userRolesRepository);
         A.CallTo(() => _portalRepositories.GetInstance<IProcessStepRepository>()).Returns(_processStepRepository);
 
-        _sut = new ServiceAccountCreation(_provisioningManager, _portalRepositories, _provisioningDbAccess, Options.Create(settings));
+        _sut = new TechnicalUserCreation(_provisioningManager, _portalRepositories, _provisioningDbAccess, Options.Create(settings));
     }
 
     private void ServiceAccountCreationAction(TechnicalUser _) { }
@@ -99,11 +99,11 @@ public class ServiceAccountCreationTests
     public async Task CreateServiceAccountAsync_WithInvalidRole_ThrowsNotFoundException()
     {
         // Arrange
-        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_invalidUserRoleId]);
+        var creationData = new TechnicalUserCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_invalidUserRoleId]);
         Setup();
 
         // Act
-        async Task Act() => await _sut.CreateServiceAccountAsync(creationData, _companyId, Enumerable.Empty<string>(), TechnicalUserTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
+        async Task Act() => await _sut.CreateTechnicalUsersAsync(creationData, _companyId, Enumerable.Empty<string>(), TechnicalUserTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
@@ -132,7 +132,7 @@ public class ServiceAccountCreationTests
         // Arrange
         var serviceAccounts = new List<TechnicalUser>();
         var identities = new List<Identity>();
-        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_validUserRoleId]);
+        var creationData = new TechnicalUserCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_validUserRoleId]);
         var bpns = new[]
         {
             Bpn
@@ -140,11 +140,11 @@ public class ServiceAccountCreationTests
         Setup(serviceAccounts, identities);
 
         // Act
-        var result = await _sut.CreateServiceAccountAsync(creationData, _companyId, bpns, TechnicalUserTypeId.OWN, enhance, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
+        var result = await _sut.CreateTechnicalUsersAsync(creationData, _companyId, bpns, TechnicalUserTypeId.OWN, enhance, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
 
         // Assert
 
-        result.ServiceAccounts.Should().ContainSingle()
+        result.TechnicalUsers.Should().ContainSingle()
             .Which.Should().Match<CreatedServiceAccountData>(x =>
                 x.ClientId == "sa1" &&
                 x.Description == "abc" &&
@@ -210,7 +210,7 @@ public class ServiceAccountCreationTests
         // Arrange
         var serviceAccounts = new List<TechnicalUser>();
         var identities = new List<Identity>();
-        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_dimUserRoleId]);
+        var creationData = new TechnicalUserCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_dimUserRoleId]);
         var bpns = new[]
         {
             Bpn
@@ -218,10 +218,10 @@ public class ServiceAccountCreationTests
         Setup(serviceAccounts, identities);
 
         // Act
-        var result = await _sut.CreateServiceAccountAsync(creationData, _companyId, bpns, TechnicalUserTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
+        var result = await _sut.CreateTechnicalUsersAsync(creationData, _companyId, bpns, TechnicalUserTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
 
         // Assert
-        result.ServiceAccounts.Should().ContainSingle()
+        result.TechnicalUsers.Should().ContainSingle()
             .Which.Should().Match<CreatedServiceAccountData>(x =>
                 x.ClientId == null &&
                 x.Description == "abc" &&
@@ -278,7 +278,7 @@ public class ServiceAccountCreationTests
         // Arrange
         var serviceAccounts = new List<TechnicalUser>();
         var identities = new List<Identity>();
-        var creationData = new ServiceAccountCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_validUserRoleId, _dimUserRoleId]);
+        var creationData = new TechnicalUserCreationInfo("testName", "abc", IamClientAuthMethod.SECRET, [_validUserRoleId, _dimUserRoleId]);
         var bpns = new[]
         {
             Bpn
@@ -286,10 +286,10 @@ public class ServiceAccountCreationTests
         Setup(serviceAccounts, identities);
 
         // Act
-        var result = await _sut.CreateServiceAccountAsync(creationData, _companyId, bpns, TechnicalUserTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
+        var result = await _sut.CreateTechnicalUsersAsync(creationData, _companyId, bpns, TechnicalUserTypeId.OWN, false, true, new ServiceAccountCreationProcessData(ProcessTypeId.DIM_TECHNICAL_USER, null), ServiceAccountCreationAction);
 
         // Assert
-        result.ServiceAccounts.Should().HaveCount(2)
+        result.TechnicalUsers.Should().HaveCount(2)
             .And.Satisfy(
                 x => x.ClientId == "sa1" &&
                      x.Description == "abc" &&


### PR DESCRIPTION
## Description

Remove the limitation to only have one technical user per offer

## Why

To create multiple technical users for an offer

## Issue

Refs: #1136

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
