### PR TITLE
feat(keycloak): adjust token handling

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -36,7 +36,6 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.Mailing.Library;

--- a/src/keycloak/Keycloak.Library/Authentication/KeycloakAccessToken.cs
+++ b/src/keycloak/Keycloak.Library/Authentication/KeycloakAccessToken.cs
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Authentication;
+
+public record KeycloakAccessToken(
+    string AccessToken,
+    DateTimeOffset ExpiresIn,
+    DateTimeOffset RefreshExpiresIn,
+    string RefreshToken
+);

--- a/src/keycloak/Keycloak.Library/Authentication/KeycloakAccessTokenExtensions.cs
+++ b/src/keycloak/Keycloak.Library/Authentication/KeycloakAccessTokenExtensions.cs
@@ -1,0 +1,103 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Flurl;
+using Flurl.Http;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using System.Text.Json.Serialization;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Authentication;
+
+internal static class KeycloakAccessTokenExtensions
+{
+    public static async Task<KeycloakAccessToken> GetAccessToken(this KeycloakAccessToken? token, Url url, string realm, string? userName, string password, string? clientSecret, string clientId, CancellationToken cancellationToken)
+    {
+        if (clientSecret == null && userName == null)
+        {
+            throw new ArgumentException($"{nameof(userName)} and {nameof(clientSecret)} must not all be null");
+        }
+
+        if (token is null)
+        {
+            return await GetToken(url, realm, userName, password, clientSecret, clientId, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+
+        if (token.ExpiresIn > DateTimeOffset.UtcNow)
+        {
+            return token;
+        }
+
+        return token.RefreshExpiresIn > DateTimeOffset.UtcNow ?
+            await GetToken(url, realm, [
+                new KeyValuePair<string, string>("grant_type", "refresh_token"),
+                new KeyValuePair<string, string>("refresh_token", token.RefreshToken),
+                new KeyValuePair<string, string>("client_id", clientId)
+            ], cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None) :
+            await GetToken(url, realm, userName, password, clientSecret, clientId, cancellationToken)
+                .ConfigureAwait(ConfigureAwaitOptions.None);
+    }
+
+    private static async Task<KeycloakAccessToken> GetToken(Url url, string realm, string? userName, string password, string? clientSecret, string clientId, CancellationToken cancellationToken)
+    {
+        if (clientSecret != null)
+        {
+            return await GetToken(url, realm, [
+                new KeyValuePair<string, string>("grant_type", "client_credentials"),
+                new KeyValuePair<string, string>("client_secret", clientSecret),
+                new KeyValuePair<string, string>("client_id", clientId)
+            ], cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+
+        if (userName != null)
+        {
+            return await GetToken(url, realm, [
+                new KeyValuePair<string, string>("grant_type", "password"),
+                new KeyValuePair<string, string>("username", userName),
+                new KeyValuePair<string, string>("password", password),
+                new KeyValuePair<string, string>("client_id", "admin-cli")
+            ], cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+
+        throw new ArgumentException($"{nameof(userName)} and {nameof(clientSecret)} must not all be null");
+    }
+
+    private static async Task<KeycloakAccessToken> GetToken(Url url, string realm, List<KeyValuePair<string, string>> keyValues, CancellationToken cancellationToken)
+    {
+        var requestTime = DateTimeOffset.UtcNow;
+        var result = await url
+            .AppendPathSegment($"realms/{realm}/protocol/openid-connect/token")
+            .WithHeader("Content-Type", "application/x-www-form-urlencoded")
+            .PostUrlEncodedAsync(keyValues, cancellationToken: cancellationToken)
+            .ReceiveJson<AccessTokenResponse>().ConfigureAwait(ConfigureAwaitOptions.None);
+
+        if (result is null)
+        {
+            throw new ConflictException("result should never be null");
+        }
+
+        return new KeycloakAccessToken(result.AccessToken, requestTime.AddSeconds(result.ExpiresIn), requestTime.AddSeconds(result.RefreshExpiresIn), result.RefreshToken);
+    }
+
+    private record AccessTokenResponse(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn,
+        [property: JsonPropertyName("refresh_expires_in")] int RefreshExpiresIn,
+        [property: JsonPropertyName("refresh_token")] string RefreshToken
+    );
+}

--- a/src/keycloak/Keycloak.Library/Clients/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/Clients/KeycloakClient.cs
@@ -24,7 +24,6 @@
  ********************************************************************************/
 
 using Flurl.Http;
-using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Common.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Clients;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.ClientScopes;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Common;

--- a/src/keycloak/Keycloak.Library/Common/Extensions/FlurlRequestExtensions.cs
+++ b/src/keycloak/Keycloak.Library/Common/Extensions/FlurlRequestExtensions.cs
@@ -23,74 +23,12 @@
  * SOFTWARE.
  ********************************************************************************/
 
-using Flurl;
 using Flurl.Http;
-using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Common.Extensions;
 
 public static class FlurlRequestExtensions
 {
-    private static async Task<string> GetAccessTokenAsync(string url, string realm, string userName, string password, bool useAuthTrail, CancellationToken cancellationToken)
-    {
-        var authTrail = useAuthTrail ? "/auth" : string.Empty;
-        var result = await url
-            .AppendPathSegment($"{authTrail}/realms/{realm}/protocol/openid-connect/token")
-            .WithHeader("Accept", "application/json")
-            .PostUrlEncodedAsync(new List<KeyValuePair<string, string>>
-            {
-                new KeyValuePair<string, string>("grant_type", "password"),
-                new KeyValuePair<string, string>("username", userName),
-                new KeyValuePair<string, string>("password", password),
-                new KeyValuePair<string, string>("client_id", "admin-cli")
-            },
-            cancellationToken: cancellationToken)
-            .ReceiveJson<AccessTokenResponse>().ConfigureAwait(ConfigureAwaitOptions.None);
-
-        return result.AccessToken;
-    }
-
-    private static async Task<string> GetAccessTokenWithClientIdAsync(string url, string realm, string clientSecret, string? clientId, bool useAuthTrail, CancellationToken cancellationToken)
-    {
-        var authTrail = useAuthTrail ? "/auth" : string.Empty;
-        var result = await url
-            .AppendPathSegment($"{authTrail}/realms/{realm}/protocol/openid-connect/token")
-            .WithHeader("Content-Type", "application/x-www-form-urlencoded")
-            .PostUrlEncodedAsync(new List<KeyValuePair<string, string>>
-            {
-                new("grant_type", "client_credentials"),
-                new("client_secret", clientSecret),
-                new("client_id", clientId ?? "admin-cli")
-            },
-            cancellationToken: cancellationToken)
-            .ReceiveJson<AccessTokenResponse>().ConfigureAwait(ConfigureAwaitOptions.None);
-
-        return result.AccessToken;
-    }
-
-    public static async Task<IFlurlRequest> WithAuthenticationAsync(this IFlurlRequest request, Func<CancellationToken, Task<string>>? getTokenAsync, string url, string realm, string? userName, string? password, string? clientSecret, string? clientId, bool useAuthTrail, CancellationToken cancellationToken)
-    {
-        string? token;
-        if (getTokenAsync != null)
-        {
-            token = await getTokenAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
-        }
-        else if (clientSecret != null)
-        {
-            token = await GetAccessTokenWithClientIdAsync(url, realm, clientSecret, clientId, useAuthTrail, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
-        }
-        else if (userName != null)
-        {
-            token = await GetAccessTokenAsync(url, realm, userName, password ?? "", useAuthTrail, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
-        }
-        else
-        {
-            throw new ArgumentException($"{nameof(getTokenAsync)}, {nameof(userName)} and {nameof(clientSecret)} must not all be null");
-        }
-
-        return request.WithOAuthBearerToken(token);
-    }
-
     public static IFlurlRequest WithForwardedHttpHeaders(this IFlurlRequest request, ForwardedHttpHeaders forwardedHeaders)
     {
         if (!string.IsNullOrEmpty(forwardedHeaders?.forwardedFor))
@@ -110,8 +48,4 @@ public static class FlurlRequestExtensions
 
         return request;
     }
-
-    public record AccessTokenResponse(
-        [property: JsonPropertyName("access_token")] string AccessToken
-    );
 }

--- a/src/keycloak/Keycloak.Library/Groups/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/Groups/KeycloakClient.cs
@@ -24,7 +24,6 @@
  ********************************************************************************/
 
 using Flurl.Http;
-using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Common.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Common;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Groups;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Users;

--- a/src/keycloak/Keycloak.Library/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/KeycloakClient.cs
@@ -26,7 +26,7 @@
 using Flurl;
 using Flurl.Http;
 using Flurl.Http.Configuration;
-using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Common.Extensions;
+using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Authentication;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -44,10 +44,10 @@ public partial class KeycloakClient
     private readonly string? _userName;
     private readonly string? _password;
     private readonly string? _clientSecret;
-    private readonly Func<CancellationToken, Task<string>>? _getTokenAsync;
     private readonly string? _authRealm;
     private readonly string? _clientId;
     private readonly bool _useAuthTrail;
+    private KeycloakAccessToken? _token;
 
     private KeycloakClient(string url)
     {
@@ -74,26 +74,12 @@ public partial class KeycloakClient
         _useAuthTrail = useAuthTrail;
     }
 
-    public KeycloakClient(string url, Func<string> getToken, string? authRealm = null)
-        : this(url)
-    {
-        _getTokenAsync = _ => Task.FromResult(getToken());
-        _authRealm = authRealm;
-    }
-
-    public KeycloakClient(string url, Func<CancellationToken, Task<string>> getTokenAsync, string? authRealm = null)
-        : this(url)
-    {
-        _getTokenAsync = getTokenAsync;
-        _authRealm = authRealm;
-    }
-
     public static KeycloakClient CreateWithClientId(string url, string? clientId, string? clientSecret, bool useAuthTrail, string? authRealm = null)
     {
         return new KeycloakClient(url, userName: null, password: null, authRealm, clientId, clientSecret, useAuthTrail);
     }
 
-    private Task<IFlurlRequest> GetBaseUrlAsync(string targetRealm, CancellationToken cancellationToken = default)
+    private async Task<IFlurlRequest> GetBaseUrlAsync(string targetRealm, CancellationToken cancellationToken = default)
     {
         var url = new Url(_url);
         if (_useAuthTrail)
@@ -102,8 +88,11 @@ public partial class KeycloakClient
             .AppendPathSegment("/auth");
         }
 
+        _token = await _token
+            .GetAccessToken(url.Clone(), _authRealm ?? targetRealm, _userName, _password ?? "", _clientSecret, _clientId ?? "admin-cli", cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+
         return url
             .WithSettings(s => s.JsonSerializer = new DefaultJsonSerializer(_jsonOptions))
-            .WithAuthenticationAsync(_getTokenAsync, _url, _authRealm ?? targetRealm, _userName, _password, _clientSecret, _clientId, _useAuthTrail, cancellationToken);
+            .WithOAuthBearerToken(_token.AccessToken);
     }
 }

--- a/src/keycloak/Keycloak.Library/RolesById/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/RolesById/KeycloakClient.cs
@@ -24,10 +24,8 @@
  ********************************************************************************/
 
 using Flurl.Http;
-using Flurl.Http.Content;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Common;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Roles;
-using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library;
 

--- a/src/keycloak/Keycloak.Seeding/BusinessLogic/KeecloakSeeder.cs
+++ b/src/keycloak/Keycloak.Seeding/BusinessLogic/KeecloakSeeder.cs
@@ -18,7 +18,6 @@
  ********************************************************************************/
 
 using Microsoft.Extensions.Options;
-using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Seeding.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Seeding.Models;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Keycloak.Seeding.BusinessLogic;

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserProfileRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserProfileRepository.cs
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -34,7 +34,6 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Identities;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.ApplicationChecklist.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.Mailing.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library;

--- a/tests/keycloak/Keycloak.Seeding.Tests/Extensions/KeycloakRealmSettingsTests.cs
+++ b/tests/keycloak/Keycloak.Seeding.Tests/Extensions/KeycloakRealmSettingsTests.cs
@@ -22,7 +22,6 @@ using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Seeding.Models;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Keycloak.Seeding.Tests.Extensions;
 
-using System.Collections.Generic;
 using Xunit;
 
 public class KeycloakRealmSettingsTests

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -19,7 +19,6 @@
 
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Tests.Setup;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;

--- a/tests/shared/Tests.Shared/FlurlSetup/FlurlSetupExtensions.cs
+++ b/tests/shared/Tests.Shared/FlurlSetup/FlurlSetupExtensions.cs
@@ -25,7 +25,6 @@ using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.OpenIDConfigur
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.RealmsAdmin;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Roles;
 using Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.Users;
-using Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 using System.Net;
 using IdentityProvider = Org.Eclipse.TractusX.Portal.Backend.Keycloak.Library.Models.RealmsAdmin.IdentityProvider;
 


### PR DESCRIPTION
## Description

* adjust token handling for keycloak calls
* add refresh token handling
* reuse token when not expired yet

## Why

To gain some performance in the keycloak requests

## Issue

Refs: https://github.com/eclipse-tractusx/portal-iam/issues/238

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
