### PR TITLE
fix(bulkUserUpload): Incorrect Success/Error Message Count

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
@@ -209,7 +209,7 @@ public class UserUploadBusinessLogic : IUserUploadBusinessLogic
                             _mailingProcessCreation.CreateMailProcess(creationData.UserCreationInfo.Email, "NewUserPasswordTemplate", mailParameters);
                         },
                         cancellationToken)
-                    .Select(x => (x.CompanyUserId != Guid.Empty, x.Error)),
+                    .Select(x => (x.Error == null, x.Error)),
             cancellationToken).ConfigureAwait(false);
 
         return new UserCreationStats(


### PR DESCRIPTION
## Description

The success/error message count displayed after bulk user upload is incorrect. When uploading a list of users, if some entries are duplicates, the popup message incorrectly indicates that all users were successfully uploaded, even though there were failed entries.

## Why

Because of incorrect Success/Error Message Count in the response of Bulk user upload API.

## Issue

Ref: #1225

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes