### PR TITLE
feat(auto-setup): adjust provider callbackurl handling

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/SubscriptionConfigurationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/SubscriptionConfigurationBusinessLogic.cs
@@ -21,6 +21,8 @@ using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Identity;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.IO;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
@@ -30,30 +32,26 @@ using Org.Eclipse.TractusX.Portal.Backend.Processes.OfferSubscription.Library.Ex
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Administration.Service.BusinessLogic;
 
-public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfigurationBusinessLogic
+public class SubscriptionConfigurationBusinessLogic(
+    IOfferSubscriptionProcessService offerSubscriptionProcessService,
+    IPortalRepositories portalRepositories,
+    IIdentityService identityService)
+    : ISubscriptionConfigurationBusinessLogic
 {
-    private readonly IOfferSubscriptionProcessService _offerSubscriptionProcessService;
-    private readonly IPortalRepositories _portalRepositories;
-    private readonly IIdentityData _identityData;
-
-    public SubscriptionConfigurationBusinessLogic(IOfferSubscriptionProcessService offerSubscriptionProcessService, IPortalRepositories portalRepositories, IIdentityService identityService)
-    {
-        _offerSubscriptionProcessService = offerSubscriptionProcessService;
-        _portalRepositories = portalRepositories;
-        _identityData = identityService.IdentityData;
-    }
+    private readonly IIdentityData _identityData = identityService.IdentityData;
 
     /// <inheritdoc />
     public async Task<ProviderDetailReturnData> GetProviderCompanyDetailsAsync()
     {
         var companyId = _identityData.CompanyId;
-        var result = await _portalRepositories.GetInstance<ICompanyRepository>()
+        var result = await portalRepositories.GetInstance<ICompanyRepository>()
             .GetProviderCompanyDetailAsync(CompanyRoleId.SERVICE_PROVIDER, companyId)
             .ConfigureAwait(ConfigureAwaitOptions.None);
         if (result == default)
         {
             throw ConflictException.Create(AdministrationSubscriptionConfigurationErrors.SUBSCRIPTION_CONFLICT_COMPANY_NOT_FOUND, new ErrorParameter[] { new(nameof(companyId), companyId.ToString()) });
         }
+
         if (!result.IsProviderCompany)
         {
             throw ForbiddenException.Create(AdministrationSubscriptionConfigurationErrors.SUBSCRIPTION_FORBIDDEN_COMPANY_NOT_SERVICE_PROVIDER, new ErrorParameter[] { new(nameof(companyId), companyId.ToString()) });
@@ -78,7 +76,7 @@ public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfiguration
 
     private async Task SetOfferProviderCompanyDetailsInternalAsync(ProviderDetailData data, Guid companyId)
     {
-        var companyRepository = _portalRepositories.GetInstance<ICompanyRepository>();
+        var companyRepository = portalRepositories.GetInstance<ICompanyRepository>();
         var providerDetailData = await companyRepository
             .GetProviderCompanyDetailsExistsForUser(companyId)
             .ConfigureAwait(ConfigureAwaitOptions.None);
@@ -92,9 +90,14 @@ public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfiguration
         {
             companyRepository.AttachAndModifyProviderCompanyDetails(
                 providerDetailData.ProviderCompanyDetailId,
-                details => { details.AutoSetupUrl = providerDetailData.Url; },
                 details =>
                 {
+                    details.AutoSetupUrl = providerDetailData.Url;
+                    details.AutoSetupCallbackUrl = providerDetailData.CallbackUrl;
+                },
+                details =>
+                {
+                    details.AutoSetupCallbackUrl = data.CallbackUrl;
                     details.AutoSetupUrl = data.Url;
                     details.DateLastChanged = DateTimeOffset.UtcNow;
                 });
@@ -106,9 +109,35 @@ public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfiguration
             hasChanges = true;
         }
 
+        if (providerDetailData.CallbackUrl is not null && data.CallbackUrl is null)
+        {
+            await HandleOfferSetupProcesses(companyId, companyRepository).ConfigureAwait(ConfigureAwaitOptions.None);
+            hasChanges = true;
+        }
+
         if (hasChanges)
         {
-            await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+            await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+    }
+
+    private async Task HandleOfferSetupProcesses(Guid companyId, ICompanyRepository companyRepository)
+    {
+        var processData = await companyRepository
+            .GetOfferSubscriptionProcessesForCompanyId(companyId)
+            .ToListAsync()
+            .ConfigureAwait(false);
+
+        foreach (var context in processData
+                     .Where(x => x.Process != null && x.ProcessSteps?.Any(ps => ps is
+                     {
+                         ProcessStepStatusId: ProcessStepStatusId.TODO,
+                         ProcessStepTypeId: ProcessStepTypeId.RETRIGGER_PROVIDER
+                     }) == true)
+                     .Select(data => data.CreateManualProcessData(ProcessStepTypeId.RETRIGGER_PROVIDER, portalRepositories, () => $"processId {data.Process!.Id}")))
+        {
+            context.FinalizeProcessStep();
+            context.ScheduleProcessSteps(Enumerable.Repeat(ProcessStepTypeId.AWAIT_START_AUTOSETUP, 1));
         }
     }
 
@@ -129,11 +158,7 @@ public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfiguration
 
         companyRepository.CreateProviderCompanyDetail(companyId, data.Url!, providerDetails =>
         {
-            if (data.CallbackUrl != null)
-            {
-                providerDetails.AutoSetupCallbackUrl = data.CallbackUrl;
-            }
-
+            providerDetails.AutoSetupCallbackUrl = data.CallbackUrl;
             providerDetails.DateLastChanged = DateTimeOffset.UtcNow;
         });
     }
@@ -158,18 +183,17 @@ public class SubscriptionConfigurationBusinessLogic : ISubscriptionConfiguration
     public Task RetriggerCreateDimTechnicalUser(Guid offerSubscriptionId) =>
         TriggerProcessStep(offerSubscriptionId, ProcessStepTypeId.RETRIGGER_OFFERSUBSCRIPTION_CREATE_DIM_TECHNICAL_USER, true);
 
-    /// <inheritdoc />
     private async Task TriggerProcessStep(Guid offerSubscriptionId, ProcessStepTypeId stepToTrigger, bool mustBePending)
     {
         var nextStep = stepToTrigger.GetOfferSubscriptionStepToRetrigger();
-        var context = await _offerSubscriptionProcessService.VerifySubscriptionAndProcessSteps(offerSubscriptionId, stepToTrigger, null, mustBePending)
+        var context = await offerSubscriptionProcessService.VerifySubscriptionAndProcessSteps(offerSubscriptionId, stepToTrigger, null, mustBePending)
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
-        _offerSubscriptionProcessService.FinalizeProcessSteps(context, Enumerable.Repeat(nextStep, 1));
-        await _portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+        offerSubscriptionProcessService.FinalizeProcessSteps(context, Enumerable.Repeat(nextStep, 1));
+        await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
     }
 
     /// <inheritdoc />
     public IAsyncEnumerable<ProcessStepData> GetProcessStepsForSubscription(Guid offerSubscriptionId) =>
-        _portalRepositories.GetInstance<IOfferSubscriptionsRepository>().GetProcessStepsForSubscription(offerSubscriptionId);
+        portalRepositories.GetInstance<IOfferSubscriptionsRepository>().GetProcessStepsForSubscription(offerSubscriptionId);
 }

--- a/src/administration/Administration.Service/BusinessLogic/SubscriptionConfigurationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/SubscriptionConfigurationBusinessLogic.cs
@@ -128,13 +128,8 @@ public class SubscriptionConfigurationBusinessLogic(
             .ToListAsync()
             .ConfigureAwait(false);
 
-        foreach (var context in processData
-                     .Where(x => x.Process != null && x.ProcessSteps?.Any(ps => ps is
-                     {
-                         ProcessStepStatusId: ProcessStepStatusId.TODO,
-                         ProcessStepTypeId: ProcessStepTypeId.RETRIGGER_PROVIDER
-                     }) == true)
-                     .Select(data => data.CreateManualProcessData(ProcessStepTypeId.RETRIGGER_PROVIDER, portalRepositories, () => $"processId {data.Process!.Id}")))
+        foreach (var context in processData.Select(data =>
+                     data.CreateManualProcessData(ProcessStepTypeId.RETRIGGER_PROVIDER, portalRepositories, () => $"processId {data.Process!.Id}")))
         {
             context.FinalizeProcessStep();
             context.ScheduleProcessSteps(Enumerable.Repeat(ProcessStepTypeId.AWAIT_START_AUTOSETUP, 1));

--- a/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
+++ b/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
@@ -193,7 +193,7 @@ public class SdFactoryBusinessLogic(
             companyRepository.AttachAndModifyCompany(data.ExternalId, null, c => { c.SelfDescriptionDocumentId = documentId; });
         }
 
-        var processData = await companyRepository.GetProcessDataForCompanyIdId(data.ExternalId).ConfigureAwait(ConfigureAwaitOptions.None);
+        var processData = await companyRepository.GetSelfDescriptionProcessDataForCompanyId(data.ExternalId).ConfigureAwait(ConfigureAwaitOptions.None);
         if (processData != null)
         {
             HandleSdCreationProcess(processData, data, ProcessStepTypeId.AWAIT_SELF_DESCRIPTION_COMPANY_RESPONSE, ProcessStepTypeId.RETRIGGER_AWAIT_SELF_DESCRIPTION_COMPANY_RESPONSE);

--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Identity/Directory.Build.props
+++ b/src/framework/Framework.Identity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
+++ b/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -487,8 +487,13 @@ public class CompanyRepository(PortalDbContext context) : ICompanyRepository
         context.Companies
             .Where(c => c.Id == companyId)
             .SelectMany(c => c.ProvidedOffers.SelectMany(po =>
-                po.OfferSubscriptions.Select(os =>
-                    new VerifyProcessData<ProcessTypeId, ProcessStepTypeId>(
+                po.OfferSubscriptions.Where(x =>
+                    x.Process != null &&
+                    x.Process!.ProcessSteps.Any(ps =>
+                        ps.ProcessStepStatusId == ProcessStepStatusId.TODO &&
+                        ps.ProcessStepTypeId == ProcessStepTypeId.RETRIGGER_PROVIDER
+                ))
+                .Select(os => new VerifyProcessData<ProcessTypeId, ProcessStepTypeId>(
                         os.Process,
                         os.Process!.ProcessSteps.Where(ps => ps.ProcessStepStatusId == ProcessStepStatusId.TODO)))))
             .ToAsyncEnumerable();

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -475,26 +475,11 @@ public class CompanyRepository(PortalDbContext context) : ICompanyRepository
             .Select(x => new ValueTuple<bool, Guid, IEnumerable<Guid>>(true, x.Id, x.CompanyApplications.Where(a => a.ApplicationStatusId == CompanyApplicationStatusId.SUBMITTED).Select(a => a.Id)))
             .SingleOrDefaultAsync();
 
-    public Task<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>?> GetProcessDataForCompanyIdId(Guid companyId) =>
+    public Task<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>?> GetSelfDescriptionProcessDataForCompanyId(Guid companyId) =>
         context.Companies
             .Where(c => c.Id == companyId && c.SdCreationProcess!.ProcessTypeId == ProcessTypeId.SELF_DESCRIPTION_CREATION)
             .Select(c => new VerifyProcessData<ProcessTypeId, ProcessStepTypeId>(
                 c.SdCreationProcess,
                 c.SdCreationProcess!.ProcessSteps.Where(step => step.ProcessStepStatusId == ProcessStepStatusId.TODO)))
             .SingleOrDefaultAsync();
-
-    public IAsyncEnumerable<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>> GetOfferSubscriptionProcessesForCompanyId(Guid companyId) =>
-        context.Companies
-            .Where(c => c.Id == companyId)
-            .SelectMany(c => c.ProvidedOffers.SelectMany(po =>
-                po.OfferSubscriptions.Where(x =>
-                    x.Process != null &&
-                    x.Process!.ProcessSteps.Any(ps =>
-                        ps.ProcessStepStatusId == ProcessStepStatusId.TODO &&
-                        ps.ProcessStepTypeId == ProcessStepTypeId.RETRIGGER_PROVIDER
-                ))
-                .Select(os => new VerifyProcessData<ProcessTypeId, ProcessStepTypeId>(
-                        os.Process,
-                        os.Process!.ProcessSteps.Where(ps => ps.ProcessStepStatusId == ProcessStepStatusId.TODO)))))
-            .ToAsyncEnumerable();
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -65,7 +65,7 @@ public interface ICompanyRepository
     /// <returns><c>true</c> if the company exists for the given user, otherwise <c>false</c></returns>
     Task<(bool IsValidCompanyId, bool IsCompanyRoleOwner)> IsValidCompanyRoleOwner(Guid companyId, IEnumerable<CompanyRoleId> companyRoleIds);
 
-    Task<(Guid ProviderCompanyDetailId, string Url)> GetProviderCompanyDetailsExistsForUser(Guid companyId);
+    Task<(Guid ProviderCompanyDetailId, string Url, string? CallbackUrl)> GetProviderCompanyDetailsExistsForUser(Guid companyId);
 
     /// <summary>
     /// Creates service provider company details
@@ -185,4 +185,5 @@ public interface ICompanyRepository
     Task<bool> IsExistingCompany(Guid companyId);
     Task<(bool Exists, Guid CompanyId, IEnumerable<Guid> SubmittedCompanyApplicationId)> GetCompanyIdByBpn(string bpn);
     Task<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>?> GetProcessDataForCompanyIdId(Guid companyId);
+    IAsyncEnumerable<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>> GetOfferSubscriptionProcessesForCompanyId(Guid companyId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -184,6 +184,5 @@ public interface ICompanyRepository
     Task<(Guid Id, IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers, string? BusinessPartnerNumber, string CountryCode)> GetCompanyByProcessId(Guid processId);
     Task<bool> IsExistingCompany(Guid companyId);
     Task<(bool Exists, Guid CompanyId, IEnumerable<Guid> SubmittedCompanyApplicationId)> GetCompanyIdByBpn(string bpn);
-    Task<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>?> GetProcessDataForCompanyIdId(Guid companyId);
-    IAsyncEnumerable<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>> GetOfferSubscriptionProcessesForCompanyId(Guid companyId);
+    Task<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>?> GetSelfDescriptionProcessDataForCompanyId(Guid companyId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -18,6 +18,7 @@
  ********************************************************************************/
 
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Concrete.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
@@ -73,7 +74,7 @@ public interface IOfferSubscriptionsRepository
     /// <returns>Returns the offer details.</returns>
     Task<OfferSubscriptionTransferData?> GetOfferDetailsAndCheckProviderCompany(Guid offerSubscriptionId, Guid providerCompanyId, OfferTypeId offerTypeId);
 
-    public Task<bool> CheckPendingOrActiveSubscriptionExists(Guid offerId, Guid companyId, OfferTypeId offerTypeId);
+    Task<bool> CheckPendingOrActiveSubscriptionExists(Guid offerId, Guid companyId, OfferTypeId offerTypeId);
 
     OfferSubscription AttachAndModifyOfferSubscription(Guid offerSubscriptionId, Action<OfferSubscription> setOptionalParameters);
 
@@ -182,4 +183,6 @@ public interface IOfferSubscriptionsRepository
     Task<bool> CheckOfferSubscriptionForProvider(Guid offerSubscriptionId, Guid providerCompanyId);
 
     Task<(string? Bpn, string? OfferName, Guid? ProcessId)> GetDimTechnicalUserDataForSubscriptionId(Guid offerSubscriptionId);
+
+    IAsyncEnumerable<(Process Process, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId> ProcessStep)> GetOfferSubscriptionRetriggerProcessesForCompanyId(Guid companyId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -21,6 +21,7 @@ using Microsoft.EntityFrameworkCore;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Identity;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Concrete.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
@@ -534,4 +535,15 @@ public class OfferSubscriptionsRepository(PortalDbContext dbContext) : IOfferSub
                 x.Offer!.Name,
                 x.ProcessId))
             .SingleOrDefaultAsync();
+
+    public IAsyncEnumerable<(Process, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>)> GetOfferSubscriptionRetriggerProcessesForCompanyId(Guid companyId) =>
+        dbContext.ProcessSteps
+            .AsNoTracking()
+            .Where(ps =>
+                ps.ProcessStepStatusId == ProcessStepStatusId.TODO &&
+                ps.ProcessStepTypeId == ProcessStepTypeId.RETRIGGER_PROVIDER &&
+                ps.Process!.OfferSubscription!.Offer!.ProviderCompanyId == companyId)
+            .OrderBy(ps => ps.ProcessId)
+            .Select(ps => new ValueTuple<Process, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>>(ps.Process!, ps))
+            .ToAsyncEnumerable();
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
@@ -236,10 +236,8 @@ public class SubscriptionConfigurationBusinessLogicTests
         // Arrange
         SetupProviderCompanyDetails();
         var providerCompanyId = Guid.NewGuid();
-        var process1Id = Guid.NewGuid();
-        var process2Id = Guid.NewGuid();
-        var processStep1Id = Guid.NewGuid();
-        var processStep2Id = Guid.NewGuid();
+        var processId = Guid.NewGuid();
+        var processStepId = Guid.NewGuid();
         var providerDetailData = new ProviderDetailData(null, null);
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
             .Returns((providerCompanyId, null!, null));
@@ -247,11 +245,8 @@ public class SubscriptionConfigurationBusinessLogicTests
             .Returns(new List<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>>
             {
                 new(
-                    new Process(process1Id, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
-                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStep1Id, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, process1Id, DateTimeOffset.UtcNow), 1)),
-                new(
-                    new Process(process2Id, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
-                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStep2Id, ProcessStepTypeId.AWAIT_START_AUTOSETUP, ProcessStepStatusId.TODO, process2Id, DateTimeOffset.UtcNow), 1))
+                    new Process(processId, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
+                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStepId, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, processId, DateTimeOffset.UtcNow), 1))
             }.ToAsyncEnumerable());
 
         // Act
@@ -270,10 +265,8 @@ public class SubscriptionConfigurationBusinessLogicTests
     {
         // Arrange
         SetupProviderCompanyDetails();
-        var process1Id = Guid.NewGuid();
-        var process2Id = Guid.NewGuid();
-        var processStep1Id = Guid.NewGuid();
-        var processStep2Id = Guid.NewGuid();
+        var processId = Guid.NewGuid();
+        var processStepId = Guid.NewGuid();
         var providerDetailData = new ProviderDetailData(null, null);
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
             .Returns((ExistingCompanyId, "https://example.org", "https://example.org/callback"));
@@ -281,11 +274,8 @@ public class SubscriptionConfigurationBusinessLogicTests
             .Returns(new List<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>>
             {
                 new(
-                    new Process(process1Id, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
-                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStep1Id, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, process1Id, DateTimeOffset.UtcNow), 1)),
-                new(
-                    new Process(process2Id, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
-                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStep2Id, ProcessStepTypeId.AWAIT_START_AUTOSETUP, ProcessStepStatusId.TODO, process2Id, DateTimeOffset.UtcNow), 1))
+                    new Process(processId, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
+                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStepId, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, processId, DateTimeOffset.UtcNow), 1)),
             }.ToAsyncEnumerable());
 
         // Act
@@ -296,7 +286,7 @@ public class SubscriptionConfigurationBusinessLogicTests
         A.CallTo(() => _companyRepository.CreateProviderCompanyDetail(A<Guid>._, A<string>._, A<Action<ProviderCompanyDetail>>._)).MustNotHaveHappened();
         A.CallTo(() => _companyRepository.AttachAndModifyProviderCompanyDetails(A<Guid>._, A<Action<ProviderCompanyDetail>>._, A<Action<ProviderCompanyDetail>>._)).MustNotHaveHappened();
         A.CallTo(() => _processStepRepository.AttachAndModifyProcessSteps(A<IEnumerable<(Guid ProcessStepId, Action<IProcessStep<ProcessStepTypeId>>? Initialize, Action<IProcessStep<ProcessStepTypeId>> Modify)>>._)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _processStepRepository.AttachAndModifyProcessSteps(A<IEnumerable<(Guid ProcessStepId, Action<IProcessStep<ProcessStepTypeId>>? Initialize, Action<IProcessStep<ProcessStepTypeId>> Modify)>>.That.Matches(x => x.Count() == 1 && x.Single().ProcessStepId == processStep1Id))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _processStepRepository.AttachAndModifyProcessSteps(A<IEnumerable<(Guid ProcessStepId, Action<IProcessStep<ProcessStepTypeId>>? Initialize, Action<IProcessStep<ProcessStepTypeId>> Modify)>>.That.Matches(x => x.Count() == 1 && x.Single().ProcessStepId == processStepId))).MustHaveHappenedOnceExactly();
         A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)>>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)>>.That.Matches(x => x.Count() == 1 && x.Single().ProcessStepTypeId == ProcessStepTypeId.AWAIT_START_AUTOSETUP))).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
@@ -22,6 +22,8 @@ using Org.Eclipse.TractusX.Portal.Backend.Administration.Service.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Identity;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Concrete.Entities;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.DBAccess;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
@@ -41,6 +43,7 @@ public class SubscriptionConfigurationBusinessLogicTests
     private readonly IIdentityData _identity;
 
     private readonly ICompanyRepository _companyRepository;
+    private readonly IProcessStepRepository<ProcessTypeId, ProcessStepTypeId> _processStepRepository;
     private readonly ICollection<ProviderCompanyDetail> _serviceProviderDetails;
 
     private static readonly Guid OfferSubscriptionId = Guid.NewGuid();
@@ -49,7 +52,6 @@ public class SubscriptionConfigurationBusinessLogicTests
     private readonly IPortalRepositories _portalRepositories;
     private readonly IFixture _fixture;
     private readonly ISubscriptionConfigurationBusinessLogic _sut;
-    private readonly IIdentityService _identityService;
 
     public SubscriptionConfigurationBusinessLogicTests()
     {
@@ -58,23 +60,25 @@ public class SubscriptionConfigurationBusinessLogicTests
 
         _offerSubscriptionsRepository = A.Fake<IOfferSubscriptionsRepository>();
         _companyRepository = A.Fake<ICompanyRepository>();
+        _processStepRepository = A.Fake<IPortalProcessStepRepository>();
         _portalRepositories = A.Fake<IPortalRepositories>();
         _offerSubscriptionProcessService = A.Fake<IOfferSubscriptionProcessService>();
 
         _serviceProviderDetails = new HashSet<ProviderCompanyDetail>();
 
         _identity = A.Fake<IIdentityData>();
-        _identityService = A.Fake<IIdentityService>();
+        var identityService = A.Fake<IIdentityService>();
         A.CallTo(() => _identity.IdentityId).Returns(Guid.NewGuid());
         A.CallTo(() => _identity.IdentityTypeId).Returns(IdentityTypeId.COMPANY_USER);
         A.CallTo(() => _identity.CompanyId).Returns(ExistingCompanyId);
-        A.CallTo(() => _identityService.IdentityData).Returns(_identity);
+        A.CallTo(() => identityService.IdentityData).Returns(_identity);
 
         A.CallTo(() => _portalRepositories.GetInstance<ICompanyRepository>()).Returns(_companyRepository);
+        A.CallTo(() => _portalRepositories.GetInstance<IProcessStepRepository<ProcessTypeId, ProcessStepTypeId>>()).Returns(_processStepRepository);
         A.CallTo(() => _portalRepositories.GetInstance<IOfferSubscriptionsRepository>())
             .Returns(_offerSubscriptionsRepository);
 
-        _sut = new SubscriptionConfigurationBusinessLogic(_offerSubscriptionProcessService, _portalRepositories, _identityService);
+        _sut = new SubscriptionConfigurationBusinessLogic(_offerSubscriptionProcessService, _portalRepositories, identityService);
     }
 
     #region GetProcessStepsForSubscription
@@ -192,9 +196,9 @@ public class SubscriptionConfigurationBusinessLogicTests
     {
         // Arrange
         SetupProviderCompanyDetails();
-        var providerDetailData = new ProviderDetailData("https://www.service-url.com", "https://www.test.com");
+        var providerDetailData = new ProviderDetailData("https://www.service-url.com", "https://example.org/callback");
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
-            .Returns((Guid.Empty, null!));
+            .Returns((Guid.Empty, null!, null));
 
         // Act
         await _sut.SetProviderCompanyDetailsAsync(providerDetailData);
@@ -213,7 +217,7 @@ public class SubscriptionConfigurationBusinessLogicTests
         SetupProviderCompanyDetails();
         var providerDetailData = new ProviderDetailData(null, null);
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
-            .Returns((Guid.Empty, null!));
+            .Returns((Guid.Empty, null!, null));
 
         // Act
         await _sut.SetProviderCompanyDetailsAsync(providerDetailData);
@@ -232,9 +236,23 @@ public class SubscriptionConfigurationBusinessLogicTests
         // Arrange
         SetupProviderCompanyDetails();
         var providerCompanyId = Guid.NewGuid();
+        var process1Id = Guid.NewGuid();
+        var process2Id = Guid.NewGuid();
+        var processStep1Id = Guid.NewGuid();
+        var processStep2Id = Guid.NewGuid();
         var providerDetailData = new ProviderDetailData(null, null);
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
-            .Returns((providerCompanyId, null!));
+            .Returns((providerCompanyId, null!, null));
+        A.CallTo(() => _companyRepository.GetOfferSubscriptionProcessesForCompanyId(providerCompanyId))
+            .Returns(new List<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>>
+            {
+                new(
+                    new Process(process1Id, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
+                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStep1Id, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, process1Id, DateTimeOffset.UtcNow), 1)),
+                new(
+                    new Process(process2Id, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
+                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStep2Id, ProcessStepTypeId.AWAIT_START_AUTOSETUP, ProcessStepStatusId.TODO, process2Id, DateTimeOffset.UtcNow), 1))
+            }.ToAsyncEnumerable());
 
         // Act
         await _sut.SetProviderCompanyDetailsAsync(providerDetailData);
@@ -243,6 +261,44 @@ public class SubscriptionConfigurationBusinessLogicTests
         A.CallTo(() => _companyRepository.RemoveProviderCompanyDetails(providerCompanyId)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _companyRepository.CreateProviderCompanyDetail(A<Guid>._, A<string>._, A<Action<ProviderCompanyDetail>>._)).MustNotHaveHappened();
         A.CallTo(() => _companyRepository.AttachAndModifyProviderCompanyDetails(A<Guid>._, A<Action<ProviderCompanyDetail>>._, A<Action<ProviderCompanyDetail>>._)).MustNotHaveHappened();
+        A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
+        _serviceProviderDetails.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SetProviderCompanyDetailsAsync_WithCallbackUrlChanged_HandlesProcessSteps()
+    {
+        // Arrange
+        SetupProviderCompanyDetails();
+        var process1Id = Guid.NewGuid();
+        var process2Id = Guid.NewGuid();
+        var processStep1Id = Guid.NewGuid();
+        var processStep2Id = Guid.NewGuid();
+        var providerDetailData = new ProviderDetailData(null, null);
+        A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
+            .Returns((ExistingCompanyId, "https://example.org", "https://example.org/callback"));
+        A.CallTo(() => _companyRepository.GetOfferSubscriptionProcessesForCompanyId(ExistingCompanyId))
+            .Returns(new List<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>>
+            {
+                new(
+                    new Process(process1Id, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
+                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStep1Id, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, process1Id, DateTimeOffset.UtcNow), 1)),
+                new(
+                    new Process(process2Id, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
+                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStep2Id, ProcessStepTypeId.AWAIT_START_AUTOSETUP, ProcessStepStatusId.TODO, process2Id, DateTimeOffset.UtcNow), 1))
+            }.ToAsyncEnumerable());
+
+        // Act
+        await _sut.SetProviderCompanyDetailsAsync(providerDetailData);
+
+        // Assert
+        A.CallTo(() => _companyRepository.RemoveProviderCompanyDetails(ExistingCompanyId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _companyRepository.CreateProviderCompanyDetail(A<Guid>._, A<string>._, A<Action<ProviderCompanyDetail>>._)).MustNotHaveHappened();
+        A.CallTo(() => _companyRepository.AttachAndModifyProviderCompanyDetails(A<Guid>._, A<Action<ProviderCompanyDetail>>._, A<Action<ProviderCompanyDetail>>._)).MustNotHaveHappened();
+        A.CallTo(() => _processStepRepository.AttachAndModifyProcessSteps(A<IEnumerable<(Guid ProcessStepId, Action<IProcessStep<ProcessStepTypeId>>? Initialize, Action<IProcessStep<ProcessStepTypeId>> Modify)>>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _processStepRepository.AttachAndModifyProcessSteps(A<IEnumerable<(Guid ProcessStepId, Action<IProcessStep<ProcessStepTypeId>>? Initialize, Action<IProcessStep<ProcessStepTypeId>> Modify)>>.That.Matches(x => x.Count() == 1 && x.Single().ProcessStepId == processStep1Id))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)>>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _processStepRepository.CreateProcessStepRange(A<IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId, Guid ProcessId)>>.That.Matches(x => x.Count() == 1 && x.Single().ProcessStepTypeId == ProcessStepTypeId.AWAIT_START_AUTOSETUP))).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         _serviceProviderDetails.Should().BeEmpty();
     }
@@ -261,7 +317,7 @@ public class SubscriptionConfigurationBusinessLogicTests
         ProviderCompanyDetail? modifyDetail = null;
 
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
-            .Returns((detailsId, existingUrl));
+            .Returns((detailsId, existingUrl, null));
 
         A.CallTo(() => _companyRepository.AttachAndModifyProviderCompanyDetails(A<Guid>._, A<Action<ProviderCompanyDetail>>._, A<Action<ProviderCompanyDetail>>._))
             .Invokes((Guid id, Action<ProviderCompanyDetail> initialize, Action<ProviderCompanyDetail> modifiy) =>
@@ -432,9 +488,9 @@ public class SubscriptionConfigurationBusinessLogicTests
             .Returns<(ProviderDetailReturnData, bool)>(default);
 
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(A<Guid>.That.Matches(x => x == ExistingCompanyId)))
-            .Returns((Guid.NewGuid(), _fixture.Create<string>()));
+            .Returns((Guid.NewGuid(), _fixture.Create<string>(), "https://example.org/callback"));
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(A<Guid>.That.Not.Matches(x => x == ExistingCompanyId)))
-            .Returns((Guid.Empty, null!));
+            .Returns((Guid.Empty, null!, null));
     }
 
     #endregion

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
@@ -241,12 +241,10 @@ public class SubscriptionConfigurationBusinessLogicTests
         var providerDetailData = new ProviderDetailData(null, null);
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
             .Returns((providerCompanyId, null!, null));
-        A.CallTo(() => _companyRepository.GetOfferSubscriptionProcessesForCompanyId(providerCompanyId))
-            .Returns(new List<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>>
+        A.CallTo(() => _offerSubscriptionsRepository.GetOfferSubscriptionRetriggerProcessesForCompanyId(providerCompanyId))
+            .Returns(new (Process, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>)[]
             {
-                new(
-                    new Process(processId, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
-                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStepId, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, processId, DateTimeOffset.UtcNow), 1))
+                (new(processId, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()), new(processStepId, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, processId, DateTimeOffset.UtcNow))
             }.ToAsyncEnumerable());
 
         // Act
@@ -270,12 +268,10 @@ public class SubscriptionConfigurationBusinessLogicTests
         var providerDetailData = new ProviderDetailData(null, null);
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailsExistsForUser(ExistingCompanyId))
             .Returns((ExistingCompanyId, "https://example.org", "https://example.org/callback"));
-        A.CallTo(() => _companyRepository.GetOfferSubscriptionProcessesForCompanyId(ExistingCompanyId))
-            .Returns(new List<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>>
+        A.CallTo(() => _offerSubscriptionsRepository.GetOfferSubscriptionRetriggerProcessesForCompanyId(ExistingCompanyId))
+            .Returns(new (Process, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>)[]
             {
-                new(
-                    new Process(processId, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()),
-                    Enumerable.Repeat(new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(processStepId, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, processId, DateTimeOffset.UtcNow), 1)),
+                (new(processId, ProcessTypeId.OFFER_SUBSCRIPTION, Guid.NewGuid()), new(processStepId, ProcessStepTypeId.RETRIGGER_PROVIDER, ProcessStepStatusId.TODO, processId, DateTimeOffset.UtcNow))
             }.ToAsyncEnumerable());
 
         // Act

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
@@ -364,7 +364,7 @@ public class SdFactoryBusinessLogicTests
         var processStep = new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(Guid.NewGuid(), ProcessStepTypeId.AWAIT_SELF_DESCRIPTION_CONNECTOR_RESPONSE, ProcessStepStatusId.TODO, processId, DateTimeOffset.UtcNow);
         var processSteps = new List<ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>>();
         SetupForProcessFinishForConnector(processId, connector, processStep, processSteps);
-        A.CallTo(() => _companyRepository.GetProcessDataForCompanyIdId(A<Guid>._))
+        A.CallTo(() => _companyRepository.GetSelfDescriptionProcessDataForCompanyId(A<Guid>._))
             .Returns<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>?>(null);
 
         // Act
@@ -482,7 +482,7 @@ public class SdFactoryBusinessLogicTests
                 _documents.Add(document);
             })
             .Returns(new Document(documentId, null!, null!, null!, default, default, default, default, default));
-        A.CallTo(() => _companyRepository.GetProcessDataForCompanyIdId(company.Id))
+        A.CallTo(() => _companyRepository.GetSelfDescriptionProcessDataForCompanyId(company.Id))
             .Returns<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>?>(null);
 
         const string contentJson = "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://github.com/eclipse-tractusx/sd-factory/raw/clearing-house/src/main/resources/verifiablecredentials.jsonld/sd-document-v22.10.jsonld\",\"https://w3id.org/vc/status-list/2021/v1\"],\"type\":[\"VerifiableCredential\",\"LegalPerson\"],\"issuer\":\"did:sov:12345\",\"issuanceDate\":\"2023-02-18T23:03:16Z\",\"expirationDate\":\"2023-05-19T23:03:16Z\",\"credentialSubject\":{\"bpn\":\"BPNL000000000000\",\"registrationNumber\":[{\"type\":\"local\",\"value\":\"o12345678\"}],\"headquarterAddress\":{\"countryCode\":\"DE\"},\"type\":\"LegalPerson\",\"legalAddress\":{\"countryCode\":\"DE\"},\"id\":\"did:sov:12345\"},\"credentialStatus\":{\"id\":\"https://managed-identity-wallets.int.demo.catena-x.net/api/credentials/status/123\",\"type\":\"StatusList2021Entry\",\"statusPurpose\":\"revocation\",\"statusListIndex\":\"58\",\"statusListCredential\":\"https://managed-identity-wallets.int.demo.catena-x.net/api/credentials/status/123\"},\"proof\":{\"type\":\"Ed25519Signature2018\",\"created\":\"2023-02-18T23:03:18Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:sov:12345#key-1\",\"jws\":\"test\"}}";
@@ -522,7 +522,7 @@ public class SdFactoryBusinessLogicTests
                 _documents.Add(document);
             })
             .Returns(new Document(documentId, null!, null!, null!, default, default, default, default, default));
-        A.CallTo(() => _companyRepository.GetProcessDataForCompanyIdId(company.Id))
+        A.CallTo(() => _companyRepository.GetSelfDescriptionProcessDataForCompanyId(company.Id))
             .Returns<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>?>(null);
 
         const string contentJson = "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://github.com/eclipse-tractusx/sd-factory/raw/clearing-house/src/main/resources/verifiablecredentials.jsonld/sd-document-v22.10.jsonld\",\"https://w3id.org/vc/status-list/2021/v1\"],\"type\":[\"VerifiableCredential\",\"LegalPerson\"],\"issuer\":\"did:sov:12345\",\"issuanceDate\":\"2023-02-18T23:03:16Z\",\"expirationDate\":\"2023-05-19T23:03:16Z\",\"credentialSubject\":{\"bpn\":\"BPNL000000000000\",\"registrationNumber\":[{\"type\":\"local\",\"value\":\"o12345678\"}],\"headquarterAddress\":{\"countryCode\":\"DE\"},\"type\":\"LegalPerson\",\"legalAddress\":{\"countryCode\":\"DE\"},\"id\":\"did:sov:12345\"},\"credentialStatus\":{\"id\":\"https://managed-identity-wallets.int.demo.catena-x.net/api/credentials/status/123\",\"type\":\"StatusList2021Entry\",\"statusPurpose\":\"revocation\",\"statusListIndex\":\"58\",\"statusListCredential\":\"https://managed-identity-wallets.int.demo.catena-x.net/api/credentials/status/123\"},\"proof\":{\"type\":\"Ed25519Signature2018\",\"created\":\"2023-02-18T23:03:18Z\",\"proofPurpose\":\"assertionMethod\",\"verificationMethod\":\"did:sov:12345#key-1\",\"jws\":\"test\"}}";
@@ -564,7 +564,7 @@ public class SdFactoryBusinessLogicTests
         var processStep = new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(Guid.NewGuid(), ProcessStepTypeId.AWAIT_SELF_DESCRIPTION_COMPANY_RESPONSE, ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow);
         var processSteps = new List<ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>>();
 
-        A.CallTo(() => _companyRepository.GetProcessDataForCompanyIdId(A<Guid>._))
+        A.CallTo(() => _companyRepository.GetSelfDescriptionProcessDataForCompanyId(A<Guid>._))
             .Returns(new VerifyProcessData<ProcessTypeId, ProcessStepTypeId>(process, Enumerable.Repeat(processStep, 1)));
         A.CallTo(() => _portalProcessStepRepository.AttachAndModifyProcessSteps(A<IEnumerable<ValueTuple<Guid, Action<IProcessStep<ProcessStepTypeId>>?, Action<IProcessStep<ProcessStepTypeId>>>>>._))
             .Invokes((IEnumerable<(Guid ProcessStepId, Action<IProcessStep<ProcessStepTypeId>>? Initialize, Action<IProcessStep<ProcessStepTypeId>> Modify)> processStepIdsInitializeModifyData) =>
@@ -625,7 +625,7 @@ public class SdFactoryBusinessLogicTests
         var processStep = new ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>(Guid.NewGuid(), ProcessStepTypeId.AWAIT_SELF_DESCRIPTION_COMPANY_RESPONSE, ProcessStepStatusId.TODO, process.Id, DateTimeOffset.UtcNow);
         var processSteps = new List<ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>>();
 
-        A.CallTo(() => _companyRepository.GetProcessDataForCompanyIdId(A<Guid>._))
+        A.CallTo(() => _companyRepository.GetSelfDescriptionProcessDataForCompanyId(A<Guid>._))
             .Returns(new VerifyProcessData<ProcessTypeId, ProcessStepTypeId>(process, Enumerable.Repeat(processStep, 1)));
         A.CallTo(() => _portalProcessStepRepository.AttachAndModifyProcessSteps(A<IEnumerable<ValueTuple<Guid, Action<IProcessStep<ProcessStepTypeId>>?, Action<IProcessStep<ProcessStepTypeId>>>>>._))
             .Invokes((IEnumerable<(Guid ProcessStepId, Action<IProcessStep<ProcessStepTypeId>>? Initialize, Action<IProcessStep<ProcessStepTypeId>> Modify)> processStepIdsInitializeModifyData) =>

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -19,7 +19,9 @@
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Concrete.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Tests.Setup;
@@ -1186,6 +1188,26 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         changedEntries.Single().Entity.Should().BeOfType<OfferSubscription>().Which.CompanyId.Should().Be(new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
         changedEntries.Single().Entity.Should().BeOfType<OfferSubscription>().Which.OfferSubscriptionStatusId.Should().Be(OfferSubscriptionStatusId.PENDING);
         changedEntries.Single().Entity.Should().BeOfType<OfferSubscription>().Which.RequesterId.Should().Be(new Guid("0dcd8209-85e2-4073-b130-ac094fb47106"));
+    }
+
+    #endregion
+
+    #region GetOfferSubscriptionRetriggerProcessesForCompanyId
+
+    [Fact]
+    public async Task GetOfferSubscriptionRetriggerProcessesForCompanyId_ReturnsExpectedResult()
+    {
+        // Arrange
+        var companyId = new Guid("3390c2d7-75c1-4169-aa27-6ce00e1f3cdd");
+        var (sut, _) = await CreateSut();
+
+        var result = await sut.GetOfferSubscriptionRetriggerProcessesForCompanyId(companyId).ToListAsync();
+
+        result.Should().ContainSingle()
+            .Which.Should().Match<(Process Process, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId> ProcessStep)>(x =>
+                x.Process.ProcessTypeId == ProcessTypeId.OFFER_SUBSCRIPTION &&
+                x.ProcessStep.ProcessStepTypeId == ProcessStepTypeId.RETRIGGER_PROVIDER &&
+                x.ProcessStep.ProcessStepStatusId == ProcessStepStatusId.TODO);
     }
 
     #endregion


### PR DESCRIPTION
## Description

When the provider callback url is removed the trigger provider callback steps are set to done and the await auto setup step is created

## Why

If a offer subscription process is in progress and the provider callback url is removed by the provider it might occur that the process is stuck since the next step would be to trigger the provider callback, which must not be triggered anymore 

## Issue

Refs: #1175

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
