### PR TITLE
feat(parameter): add displaytechnicaluser parameter in get service api

### DIFF
--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -2391,6 +2391,10 @@ components:
           type: string
           description: Contact email address.
           nullable: true
+        displayTechnicalUser:
+          type: boolean
+          description: Display Technical User.
+          nullable: true
         description:
           type: string
           description: The description of the service.

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -97,6 +97,7 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
             result.Provider,
             result.LeadPictureId,
             result.ContactEmail,
+            result.DisplayTechnicalUser,
             result.Description,
             result.LicenseTypeId,
             result.Price,

--- a/src/marketplace/Services.Service/ViewModels/ServiceDetailResponse.cs
+++ b/src/marketplace/Services.Service/ViewModels/ServiceDetailResponse.cs
@@ -31,6 +31,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.ViewModels;
 /// <param name="Provider">Provider of the app.</param>
 /// <param name="LeadPictureId">Lead picture Id.</param>
 /// <param name="ContactEmail">Contact email address.</param>
+/// <param name="DisplayTechnicalUser">Display Technical User.</param>
 /// <param name="Description">The description of the service.</param>
 /// <param name="LicenseType">LicenseType for offer</param>
 /// <param name="Price">Pricing information of the app.</param>
@@ -46,6 +47,7 @@ public record ServiceDetailResponse(
     string Provider,
     Guid? LeadPictureId,
     string? ContactEmail,
+    bool? DisplayTechnicalUser,
     string? Description,
     LicenseTypeId LicenseType,
     string Price,

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferDetailData.cs
@@ -63,6 +63,7 @@ public record ServiceDetailData(
     string Provider,
     Guid? LeadPictureId,
     string? ContactEmail,
+    bool? DisplayTechnicalUser,
     string? Description,
     string Price,
     string? ProviderUri,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
@@ -278,6 +278,7 @@ public class OfferRepository(PortalDbContext dbContext) : IOfferRepository
                 offer.ProviderCompany!.Name,
                 offer.Documents.Where(document => document.DocumentTypeId == DocumentTypeId.SERVICE_LEADIMAGE && document.DocumentStatusId != DocumentStatusId.INACTIVE).Select(document => document.Id).FirstOrDefault(),
                 offer.ContactEmail,
+                offer.DisplayTechnicalUser,
                 offer.OfferDescriptions.SingleOrDefault(d => d.LanguageShortName == languageShortName)!.DescriptionLong,
                 offer.OfferLicenses.FirstOrDefault()!.Licensetext,
                 offer.MarketingUrl,


### PR DESCRIPTION
## Description

add "displayTechnicalUser": "boolean" to be provided in the following api
/api/services/{serviceId}

## Why

As per request changes displayTechnicalUser Api added

## Issue

#1210 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
