### PR TITLE
feat(techincaluser): add display techincal user parameter in update and status endpoint

### DIFF
--- a/docs/api/apps-service.yaml
+++ b/docs/api/apps-service.yaml
@@ -2794,6 +2794,10 @@ components:
           type: string
           description: contact number
           nullable: true
+        displayTechnicalUser:
+          type: boolean
+          description: Display Technical User
+          nullable: true
         documents:
           type: object
           properties:

--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -2794,6 +2794,9 @@ components:
         providerUri:
           type: string
           nullable: true
+        displayTechnicalUser:
+          type: boolean
+          nullable: true
       additionalProperties: false
     SubscriberSubscriptionDetailData:
       type: object

--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -1993,6 +1993,9 @@ components:
         contactNumber:
           type: string
           nullable: true
+        displayTechnicalUser:
+          type: boolean
+          nullable: true
         documents:
           type: object
           properties:
@@ -2656,6 +2659,10 @@ components:
         contactNumber:
           type: string
           description: contact number
+          nullable: true
+        displayTechnicalUser:
+          type: boolean
+          description: Display Technical User
           nullable: true
         documents:
           type: object

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -133,6 +133,7 @@ public class AppReleaseBusinessLogic(
             result.ProviderUri,
             result.ContactEmail,
             result.ContactNumber,
+            result.DisplayTechnicalUser,
             result.Documents,
             result.SalesManagerId,
             result.PrivacyPolicies,
@@ -278,6 +279,7 @@ public class AppReleaseBusinessLogic(
             app.SalesManagerId = appRequestModel.SalesManagerId;
             app.ContactEmail = appRequestModel.ContactEmail;
             app.ContactNumber = appRequestModel.ContactNumber;
+            app.DisplayTechnicalUser = appRequestModel.DisplayTechnicalUser;
             app.MarketingUrl = appRequestModel.ProviderUri;
         },
         app =>
@@ -286,6 +288,7 @@ public class AppReleaseBusinessLogic(
             app.SalesManagerId = appData.SalesManagerId;
             app.ContactEmail = appData.ContactEmail;
             app.ContactNumber = appData.ContactNumber;
+            app.DisplayTechnicalUser = appRequestModel.DisplayTechnicalUser;
             app.MarketingUrl = appData.MarketingUrl;
             app.DateLastChanged = DateTimeOffset.UtcNow;
         });

--- a/src/marketplace/Apps.Service/ViewModels/AppProviderResponse.cs
+++ b/src/marketplace/Apps.Service/ViewModels/AppProviderResponse.cs
@@ -40,6 +40,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Apps.Service.ViewModels;
 /// <param name="ProviderUri">the provider uri</param>
 /// <param name="ContactEmail">contact email</param>
 /// <param name="ContactNumber">contact number</param>
+/// <param name="DisplayTechnicalUser">Display Technical User</param>
 /// <param name="Documents">list of linked documents</param>
 /// <param name="SalesManagerId">id of the salesmanager</param>
 /// <param name="PrivacyPolicies">the privacy policies</param>
@@ -58,6 +59,7 @@ public record AppProviderResponse(
     string? ProviderUri,
     string? ContactEmail,
     string? ContactNumber,
+    bool? DisplayTechnicalUser,
     IDictionary<DocumentTypeId, IEnumerable<DocumentData>> Documents,
     Guid? SalesManagerId,
     IEnumerable<PrivacyPolicyId> PrivacyPolicies,

--- a/src/marketplace/Offers.Library/Models/OfferProviderResponse.cs
+++ b/src/marketplace/Offers.Library/Models/OfferProviderResponse.cs
@@ -39,6 +39,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 /// <param name="ProviderUri">the provider uri</param>
 /// <param name="ContactEmail">contact email</param>
 /// <param name="ContactNumber">contact number</param>
+/// <param name="DisplayTechnicalUser">Display Technical User</param>
 /// <param name="Documents">list of linked documents</param>
 /// <param name="SalesManagerId">id of the salesmanager</param>
 /// <param name="PrivacyPolicies">the privacy policies</param>
@@ -58,6 +59,7 @@ public record OfferProviderResponse(
     string? ProviderUri,
     string? ContactEmail,
     string? ContactNumber,
+    bool? DisplayTechnicalUser,
     IDictionary<DocumentTypeId, IEnumerable<DocumentData>> Documents,
     Guid? SalesManagerId,
     IEnumerable<PrivacyPolicyId> PrivacyPolicies,

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -271,6 +271,7 @@ public class OfferService(
             data.ProviderUri,
             data.ContactEmail,
             data.ContactNumber,
+            data.DisplayTechnicalUser,
             data.Documents.GroupBy(d => d.DocumentTypeId).ToDictionary(g => g.Key, g => g.Select(d => new DocumentData(d.DocumentId, d.DocumentName))),
             data.SalesManagerId,
             data.PrivacyPolicies,

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
@@ -123,6 +123,7 @@ public class ServiceReleaseBusinessLogic : IServiceReleaseBusinessLogic
             result.ProviderUri,
             result.ContactEmail,
             result.ContactNumber,
+            result.DisplayTechnicalUser,
             result.Documents,
             result.SalesManagerId,
             result.ServiceTypeIds,
@@ -202,6 +203,7 @@ public class ServiceReleaseBusinessLogic : IServiceReleaseBusinessLogic
                 offer.Name = data.Title;
                 offer.SalesManagerId = data.SalesManager;
                 offer.ContactEmail = data.ContactEmail;
+                offer.DisplayTechnicalUser = data.DisplayTechnicalUser;
                 offer.MarketingUrl = data.ProviderUri;
             },
             offer =>

--- a/src/marketplace/Services.Service/ViewModels/ServiceProviderResponse.cs
+++ b/src/marketplace/Services.Service/ViewModels/ServiceProviderResponse.cs
@@ -36,6 +36,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.ViewModels;
 /// <param name="ProviderUri">the provider uri</param>
 /// <param name="ContactEmail">contact email</param>
 /// <param name="ContactNumber">contact number</param>
+/// <param name="DisplayTechnicalUser">Display Technical User</param>
 /// <param name="Documents">list of linked documents</param>
 /// <param name="SalesManagerId">id of the salesmanager</param>
 /// <param name="ServiceTypeIds">ids of the service types</param>
@@ -50,6 +51,7 @@ public record ServiceProviderResponse(
     string? ProviderUri,
     string? ContactEmail,
     string? ContactNumber,
+    bool? DisplayTechnicalUser,
     IDictionary<DocumentTypeId, IEnumerable<DocumentData>> Documents,
     Guid? SalesManagerId,
     IEnumerable<ServiceTypeId> ServiceTypeIds,

--- a/src/marketplace/Services.Service/ViewModels/ServiceUpdateData.cs
+++ b/src/marketplace/Services.Service/ViewModels/ServiceUpdateData.cs
@@ -30,4 +30,5 @@ public record ServiceUpdateRequestData(
     string Price,
     string ContactEmail,
     Guid? SalesManager,
-    string? ProviderUri);
+    string? ProviderUri,
+    bool? DisplayTechnicalUser);

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferProviderData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferProviderData.cs
@@ -55,6 +55,7 @@ public record OfferProviderData(
     string? ProviderUri,
     string? ContactEmail,
     string? ContactNumber,
+    bool? DisplayTechnicalUser,
     IEnumerable<DocumentTypeData> Documents,
     Guid? SalesManagerId,
     IEnumerable<PrivacyPolicyId> PrivacyPolicies,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
@@ -372,6 +372,7 @@ public class OfferRepository(PortalDbContext dbContext) : IOfferRepository
                         x.Offer.MarketingUrl,
                         x.Offer.ContactEmail,
                         x.Offer.ContactNumber,
+                        x.Offer.DisplayTechnicalUser,
                         x.Offer.Documents.Select(d => new DocumentTypeData(d.DocumentTypeId, d.Id, d.DocumentName)),
                         x.Offer.SalesManagerId,
                         x.Offer.OfferAssignedPrivacyPolicies.Select(x => x.PrivacyPolicyId),

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
@@ -391,7 +391,7 @@ public class ServiceReleaseBusinessLogicTest
     {
         // Arrange
         SetupUpdateService();
-        var data = new ServiceUpdateRequestData("test", new List<LocalizedDescription>(), new List<ServiceTypeId>(), "123", "test@email.com", Guid.NewGuid(), null);
+        var data = new ServiceUpdateRequestData("test", new List<LocalizedDescription>(), new List<ServiceTypeId>(), "123", "test@email.com", Guid.NewGuid(), null, false);
 
         // Act
         async Task Act() => await _sut.UpdateServiceAsync(_notExistingServiceId, data);
@@ -406,7 +406,7 @@ public class ServiceReleaseBusinessLogicTest
     {
         // Arrange
         SetupUpdateService();
-        var data = new ServiceUpdateRequestData("test", new List<LocalizedDescription>(), new List<ServiceTypeId>(), "123", "test@email.com", Guid.NewGuid(), null);
+        var data = new ServiceUpdateRequestData("test", new List<LocalizedDescription>(), new List<ServiceTypeId>(), "123", "test@email.com", Guid.NewGuid(), null, false);
 
         // Act
         async Task Act() => await _sut.UpdateServiceAsync(_activeServiceId, data);
@@ -421,7 +421,7 @@ public class ServiceReleaseBusinessLogicTest
     {
         // Arrange
         SetupUpdateService();
-        var data = new ServiceUpdateRequestData("test", new List<LocalizedDescription>(), new List<ServiceTypeId>(), "123", "test@email.com", Guid.NewGuid(), null);
+        var data = new ServiceUpdateRequestData("test", new List<LocalizedDescription>(), new List<ServiceTypeId>(), "123", "test@email.com", Guid.NewGuid(), null, false);
 
         // Act
         async Task Act() => await _sut.UpdateServiceAsync(_differentCompanyServiceId, data);
@@ -449,7 +449,8 @@ public class ServiceReleaseBusinessLogicTest
             "43",
             "test@email.com",
             CompanyUserId,
-            null);
+            null,
+            true);
         var settings = new ServiceSettings
         {
             SalesManagerRoles = new[]


### PR DESCRIPTION
## Description

Implement a new parameter that defines if the technical user details created for an app/service should be visible for the subscriber.
This configuration will be set in the app release process.

## Why

add "displayTechnicalUser": "boolean" to be updated in the following api
/api/services/serviceRelease/{serviceId}
/api/apps/AppReleaseProcess/{appID}

add "displayTechnicalUser": "boolean" to be provided in the following api
/api/services/servicerelease/{serviceId}/serviceStatus
/api/apps/appreleaseprocess/{appID}/appStatus

## Issue

#1238 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [] I have commented my code, particularly in hard-to-understand areas
