### PR TITLE
fix(docker): adjust portal migration docker image

### DIFF
--- a/docker/Dockerfile-portal-migrations
+++ b/docker/Dockerfile-portal-migrations
@@ -30,7 +30,7 @@ COPY /src/framework/Framework.ErrorHandling /src/framework/Framework.ErrorHandli
 COPY /src/framework/Framework.Seeding /src/framework/Framework.Seeding
 COPY /src/framework/Framework.DateTimeProvider /src/framework/Framework.DateTimeProvider
 COPY /src/framework/Framework.Processes.Library /src/framework/Framework.Processes.Library
-COPY /src/framework/Framework.ProcessIdentity /src/framework/Framework.ProcessIdentity
+COPY /src/framework/Framework.Processes.ProcessIdentity /src/framework/Framework.Processes.ProcessIdentity
 COPY /src/framework/Framework.Processes.Library.Concrete /src/framework/Framework.Processes.Library.Concrete
 COPY /src/processes/Processes.ProcessIdentity /src/processes/Processes.ProcessIdentity
 WORKDIR /src/portalbackend/PortalBackend.Migrations


### PR DESCRIPTION
## Description

Adjust the portal migration docker image

## Why

Currently a wrong directory is set in the portal migration docker image

## Issue

Refs: [#240](https://github.com/eclipse-tractusx/portal/issues/240)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
