### PR TITLE
feat(technicalUser): enhance technical user profile with AccessiblyByProviderOnly flag

### DIFF
--- a/docs/api/administration-service.yaml
+++ b/docs/api/administration-service.yaml
@@ -8083,6 +8083,8 @@ components:
           nullable: true
         roleType:
           $ref: '#/components/schemas/UserRoleType'
+        onlyAccessibleByProvider:
+          type: boolean
       additionalProperties: false
       description: Basic model for user role data needed to display user roles with description.
     UserRoleWithId:

--- a/docs/api/apps-service.yaml
+++ b/docs/api/apps-service.yaml
@@ -3841,6 +3841,8 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/UserRoleType'
+        accessiblyByProviderOnly:
+          type: boolean
       additionalProperties: false
     UserRoleType:
       enum:

--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -2950,6 +2950,8 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/UserRoleType'
+        accessiblyByProviderOnly:
+          type: boolean
       additionalProperties: false
     UserRoleType:
       enum:

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountSettings.cs
@@ -47,6 +47,10 @@ public class ServiceAccountSettings
     [Required]
     [DistinctValues("x => x.ClientId")]
     public IEnumerable<UserRoleConfig> DimUserRoles { get; set; } = null!;
+
+    [Required]
+    [DistinctValues("x => x.ClientId")]
+    public IEnumerable<UserRoleConfig> UserRolesAccessibleByProviderOnly { get; set; } = null!;
 }
 
 public static class ServiceAccountSettingsExtensions

--- a/src/administration/Administration.Service/Models/UserRoleWithDescription.cs
+++ b/src/administration/Administration.Service/Models/UserRoleWithDescription.cs
@@ -29,5 +29,6 @@ public record UserRoleWithDescription(
     [property: JsonPropertyName("roleId")] Guid UserRoleId,
     [property: JsonPropertyName("roleName")] string UserRoleText,
     [property: JsonPropertyName("roleDescription")] string? RoleDescription,
-    [property: JsonPropertyName("roleType")] UserRoleType RoleType
+    [property: JsonPropertyName("roleType")] UserRoleType RoleType,
+    [property: JsonPropertyName("onlyAccessibleByProvider")] bool ProviderOnly
 );

--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -250,7 +250,8 @@
     "EncryptionConfigIndex": 0,
     "EncryptionConfigs": [],
     "AuthServiceUrl": "",
-    "DimUserRoles": []
+    "DimUserRoles": [],
+    "UserRolesAccessibleByProviderOnly": []
   },
   "Connectors": {
     "MaxPageSize": 20,

--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/IQueryableExtensions.cs
+++ b/src/framework/Framework.DBAccess/IQueryableExtensions.cs
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using System.Linq.Expressions;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
+
+public static class IQueryableExtensions
+{
+    public static IQueryable<TQuery> JoinTuples<TQuery, TKey1, TKey2>(this IQueryable<TQuery> queryable, IEnumerable<ValueTuple<TKey1, TKey2>> criteria, Expression<Func<TQuery, TKey1>> queryableKey1Selector, Expression<Func<TQuery, TKey2>> queryableKey2Selector)
+    {
+        var paramSelect = Expression.Parameter(typeof(TQuery), "select");
+
+        var where = Expression.Lambda<Func<TQuery, bool>>(
+            criteria.Aggregate<(TKey1, TKey2), Expression>(
+                Expression.Constant(false),
+                (agg, crit) => Expression.OrElse(
+                    agg,
+                    Expression.AndAlso(
+                        Expression.Equal(Expression.Invoke(queryableKey1Selector, paramSelect), Expression.Constant(crit.Item1)),
+                        Expression.Equal(Expression.Invoke(queryableKey2Selector, paramSelect), Expression.Constant(crit.Item2))))),
+            paramSelect);
+
+        return queryable.Where(where);
+    }
+}

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Identity/Directory.Build.props
+++ b/src/framework/Framework.Identity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
+++ b/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -526,11 +526,11 @@ public class AppReleaseBusinessLogic(
 
     /// <inheritdoc />
     public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId) =>
-        offerService.GetTechnicalUserProfilesForOffer(offerId, OfferTypeId.APP, _settings.DimUserRoles);
+        offerService.GetTechnicalUserProfilesForOffer(offerId, OfferTypeId.APP, _settings.DimUserRoles, _settings.UserRolesAccessibleByProviderOnly);
 
     /// <inheritdoc />
     public Task UpdateTechnicalUserProfiles(Guid appId, IEnumerable<TechnicalUserProfileData> data) =>
-        offerService.UpdateTechnicalUserProfiles(appId, OfferTypeId.APP, data, _settings.TechnicalUserProfileClient);
+        offerService.UpdateTechnicalUserProfiles(appId, OfferTypeId.APP, data, _settings.TechnicalUserProfileClient, _settings.UserRolesAccessibleByProviderOnly);
 
     /// <inheritdoc />
     public async Task<IEnumerable<ActiveAppRoleDetails>> GetAppProviderRolesAsync(Guid appId, string? languageShortName)

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
@@ -237,6 +237,10 @@ public class AppsSettings
     [Required]
     [DistinctValues("x => x.ClientId")]
     public IEnumerable<UserRoleConfig> DimUserRoles { get; set; } = null!;
+
+    [Required]
+    [DistinctValues("x => x.ClientId")]
+    public IEnumerable<UserRoleConfig> UserRolesAccessibleByProviderOnly { get; set; } = null!;
 }
 
 /// <summary>

--- a/src/marketplace/Apps.Service/appsettings.json
+++ b/src/marketplace/Apps.Service/appsettings.json
@@ -77,7 +77,8 @@
     "SubmitAppDocumentTypeIds": [],
     "OfferSubscriptionAddress": "",
     "OfferDetailAddress": "",
-    "DimUserRoles": []
+    "DimUserRoles": [],
+    "UserRolesAccessibleByProviderOnly": []
   },
   "Provisioning": {
     "CentralRealm": "",

--- a/src/marketplace/Offers.Library/ErrorHandling/OfferServiceErrorMessageContainer.cs
+++ b/src/marketplace/Offers.Library/ErrorHandling/OfferServiceErrorMessageContainer.cs
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using System.Collections.Immutable;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Offers.Library.ErrorHandling;
+
+public class OfferServiceErrorMessageContainer : IErrorMessageContainer
+{
+    private static readonly IReadOnlyDictionary<int, string> _messageContainer = new Dictionary<OfferServiceErrors, string> {
+                { OfferServiceErrors.OFFER_NOTFOUND, "Offer {offerId} does not exist" },
+                { OfferServiceErrors.COMPANY_NOT_PROVIDER, "Company {companyId} is not the providing company" },
+                { OfferServiceErrors.NOT_EMPTY_ROLES_AND_PROFILES, "Technical User Profiles and Role IDs both should not be empty." },
+                { OfferServiceErrors.TECHNICAL_USERS_FOR_CONSULTANCY, "Technical User Profiles can't be set for CONSULTANCY_SERVICE" },
+                { OfferServiceErrors.ROLES_DOES_NOT_EXIST, "Roles {roleIds} do not exist" },
+                { OfferServiceErrors.ROLES_MISSMATCH, "Roles must either be provider only or visible for provider and subscriber" }
+            }.ToImmutableDictionary(x => (int)x.Key, x => x.Value);
+
+    public Type Type { get => typeof(OfferServiceErrors); }
+    public IReadOnlyDictionary<int, string> MessageContainer { get => _messageContainer; }
+}
+
+public enum OfferServiceErrors
+{
+    OFFER_NOTFOUND,
+    COMPANY_NOT_PROVIDER,
+    NOT_EMPTY_ROLES_AND_PROFILES,
+    TECHNICAL_USERS_FOR_CONSULTANCY,
+    ROLES_DOES_NOT_EXIST,
+    ROLES_MISSMATCH
+}

--- a/src/marketplace/Offers.Library/Models/TechnicalUserProfileData.cs
+++ b/src/marketplace/Offers.Library/Models/TechnicalUserProfileData.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW Group AG
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -18,9 +17,23 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using System.Text.Json.Serialization;
+
 namespace Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 
 public record TechnicalUserProfileData(
     Guid? TechnicalUserProfileId,
     IEnumerable<Guid> UserRoleIds
 );
+
+public record TechnicalUserProfileInformation(
+    [property: JsonPropertyName("technicalUserProfileId")] Guid TechnicalUserProfileId,
+    [property: JsonPropertyName("userRoles")] IEnumerable<UserRoleInformation> UserRoles
+);
+
+public record UserRoleInformation(
+    [property: JsonPropertyName("roleId")] Guid UserRoleId,
+    [property: JsonPropertyName("roleName")] string UserRoleText,
+    [property: JsonPropertyName("type")] UserRoleType RoleType,
+    [property: JsonPropertyName("accessiblyByProviderOnly")] bool AccessiblyByProviderOnly);

--- a/src/marketplace/Offers.Library/Service/IOfferService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferService.cs
@@ -202,9 +202,10 @@ public interface IOfferService
     /// </summary>
     /// <param name="offerId">Id of the offer</param>
     /// <param name="offerTypeId">Id of the offer type</param>
-    /// <param name="externalUserRoles">The ExternalUserRoles</param>
+    /// <param name="externalUserRolesConfig">The ExternalUserRoles</param>
+    /// <param name="userRolesAccessibleByProviderOnly">The user roles that make a technical user accessible only be the provider</param>
     /// <returns>IEnumerable with the technical user profile information</returns>
-    Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> externalUserRoles);
+    Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> externalUserRolesConfig, IEnumerable<UserRoleConfig> userRolesAccessibleByProviderOnly);
 
     /// <summary>
     /// Creates or updates the technical user profiles
@@ -213,7 +214,8 @@ public interface IOfferService
     /// <param name="offerTypeId">The OfferTypeId of the offer</param>
     /// <param name="data">The technical user profiles</param>
     /// <param name="technicalUserProfileClient">Client to get the technicalUserProfiles</param>
-    Task UpdateTechnicalUserProfiles(Guid offerId, OfferTypeId offerTypeId, IEnumerable<TechnicalUserProfileData> data, string technicalUserProfileClient);
+    /// <param name="userRolesAccessibleByProviderOnly">User roles which will make the technical user visible for only the provider</param>
+    Task UpdateTechnicalUserProfiles(Guid offerId, OfferTypeId offerTypeId, IEnumerable<TechnicalUserProfileData> data, string technicalUserProfileClient, IEnumerable<UserRoleConfig> userRolesAccessibleByProviderOnly);
 
     /// <summary>
     /// Gets the information for the subscription for the subscriber

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -24,6 +24,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Framework.Linq;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
+using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
@@ -699,22 +700,25 @@ public class OfferService(
         await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
     }
 
-    public async Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> externalUserRoles)
+    public async Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> externalUserRolesConfig, IEnumerable<UserRoleConfig> userRolesAccessibleByProviderOnly)
     {
         var companyId = _identityData.CompanyId;
-        var userRoles = await portalRepositories.GetInstance<IUserRolesRepository>().GetUserRoleIdsUntrackedAsync(externalUserRoles)
+        var externalUserRoles = await portalRepositories.GetInstance<IUserRolesRepository>().GetUserRoleIdsUntrackedAsync(externalUserRolesConfig)
+            .ToListAsync()
+            .ConfigureAwait(false);
+        var userRoles = await portalRepositories.GetInstance<IUserRolesRepository>().GetUserRoleIdsUntrackedAsync(userRolesAccessibleByProviderOnly)
             .ToListAsync()
             .ConfigureAwait(false);
         var result = await portalRepositories.GetInstance<ITechnicalUserProfileRepository>()
-            .GetTechnicalUserProfileInformation(offerId, companyId, offerTypeId, userRoles).ConfigureAwait(ConfigureAwaitOptions.None);
+            .GetTechnicalUserProfileInformation(offerId, companyId, offerTypeId, externalUserRoles).ConfigureAwait(ConfigureAwaitOptions.None);
         if (result == default)
         {
-            throw new NotFoundException($"Offer {offerId} does not exist");
+            throw NotFoundException.Create(OfferServiceErrors.OFFER_NOTFOUND, [new("offerId", offerId.ToString())]);
         }
 
         if (!result.IsUserOfProvidingCompany)
         {
-            throw new ForbiddenException($"Company {companyId} is not the providing company");
+            throw ForbiddenException.Create(OfferServiceErrors.COMPANY_NOT_PROVIDER, [new("companyId", companyId.ToString())]);
         }
 
         return result.Information
@@ -724,18 +728,19 @@ public class OfferService(
                     .Select(ur => new UserRoleInformation(
                         ur.UserRoleId,
                         ur.UserRoleText,
-                        ur.External ? UserRoleType.External : UserRoleType.Internal))
-            ));
+                        ur.External ? UserRoleType.External : UserRoleType.Internal,
+                        userRoles.Contains(ur.UserRoleId)))));
     }
 
     /// <inheritdoc />
-    public async Task UpdateTechnicalUserProfiles(Guid offerId, OfferTypeId offerTypeId, IEnumerable<TechnicalUserProfileData> data, string technicalUserProfileClient)
+    public async Task UpdateTechnicalUserProfiles(Guid offerId, OfferTypeId offerTypeId, IEnumerable<TechnicalUserProfileData> data, string technicalUserProfileClient, IEnumerable<UserRoleConfig> userRolesAccessibleByProviderOnly)
     {
         var companyId = _identityData.CompanyId;
         if (data.Any(x => x.TechnicalUserProfileId == null && !x.UserRoleIds.Any()))
         {
-            throw new ControllerArgumentException("Technical User Profiles and Role IDs both should not be empty.");
+            throw ControllerArgumentException.Create(OfferServiceErrors.NOT_EMPTY_ROLES_AND_PROFILES);
         }
+
         var technicalUserProfileRepository = portalRepositories.GetInstance<ITechnicalUserProfileRepository>();
         var offerProfileData = await technicalUserProfileRepository.GetOfferProfileData(offerId, offerTypeId, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
         var roles = await portalRepositories.GetInstance<IUserRolesRepository>()
@@ -743,25 +748,33 @@ public class OfferService(
             .ToListAsync()
             .ConfigureAwait(false);
 
+        var providerOnlyUserRoles = await portalRepositories.GetInstance<IUserRolesRepository>().GetUserRoleIdsUntrackedAsync(userRolesAccessibleByProviderOnly)
+            .ToListAsync()
+            .ConfigureAwait(false);
         if (offerProfileData == null)
         {
-            throw new NotFoundException($"Offer {offerTypeId} {offerId} does not exist");
+            throw NotFoundException.Create(OfferServiceErrors.OFFER_NOTFOUND, [new("offerId", offerId.ToString())]);
         }
 
         if (!offerProfileData.IsProvidingCompanyUser)
         {
-            throw new ForbiddenException($"Company {companyId} is not the providing company");
+            throw ForbiddenException.Create(OfferServiceErrors.COMPANY_NOT_PROVIDER, [new("companyId", companyId.ToString())]);
         }
 
         if (offerProfileData.ServiceTypeIds?.All(x => x == ServiceTypeId.CONSULTANCY_SERVICE) ?? false)
         {
-            throw new ConflictException("Technical User Profiles can't be set for CONSULTANCY_SERVICE");
+            throw ConflictException.Create(OfferServiceErrors.TECHNICAL_USERS_FOR_CONSULTANCY);
         }
 
         var notExistingRoles = data.SelectMany(ur => ur.UserRoleIds).Except(roles);
         if (notExistingRoles.Any())
         {
-            throw new ConflictException($"Roles {string.Join(",", notExistingRoles)} do not exist");
+            throw ConflictException.Create(OfferServiceErrors.ROLES_DOES_NOT_EXIST, [new("roleIds", string.Join(",", notExistingRoles))]);
+        }
+
+        if (providerOnlyUserRoles.Except(data.SelectMany(ur => ur.UserRoleIds)).Any())
+        {
+            throw ConflictException.Create(OfferServiceErrors.ROLES_MISSMATCH);
         }
 
         technicalUserProfileRepository.CreateDeleteTechnicalUserProfileAssignedRoles(
@@ -876,8 +889,10 @@ public class OfferService(
                             item.OfferSubscriptionId,
                             item.DocumentId == Guid.Empty ? null : item.DocumentId)));
         }
+
         return await Pagination.CreateResponseAsync(page, size, 15, GetCompanySubscribedOfferSubscriptionStatusesData).ConfigureAwait(ConfigureAwaitOptions.None);
     }
+
     /// <inheritdoc/>
     public async Task UnsubscribeOwnCompanySubscriptionAsync(Guid subscriptionId)
     {

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceReleaseBusinessLogic.cs
@@ -258,9 +258,9 @@ public class ServiceReleaseBusinessLogic : IServiceReleaseBusinessLogic
 
     /// <inheritdoc />
     public Task<IEnumerable<TechnicalUserProfileInformation>> GetTechnicalUserProfilesForOffer(Guid offerId) =>
-        _offerService.GetTechnicalUserProfilesForOffer(offerId, OfferTypeId.SERVICE, _settings.DimUserRoles);
+        _offerService.GetTechnicalUserProfilesForOffer(offerId, OfferTypeId.SERVICE, _settings.DimUserRoles, _settings.UserRolesAccessibleByProviderOnly);
 
     /// <inheritdoc />
     public Task UpdateTechnicalUserProfiles(Guid serviceId, IEnumerable<TechnicalUserProfileData> data) =>
-        _offerService.UpdateTechnicalUserProfiles(serviceId, OfferTypeId.SERVICE, data, _settings.TechnicalUserProfileClient);
+        _offerService.UpdateTechnicalUserProfiles(serviceId, OfferTypeId.SERVICE, data, _settings.TechnicalUserProfileClient, _settings.UserRolesAccessibleByProviderOnly);
 }

--- a/src/marketplace/Services.Service/ServiceSettings.cs
+++ b/src/marketplace/Services.Service/ServiceSettings.cs
@@ -177,6 +177,10 @@ public class ServiceSettings
 
     [Required(AllowEmptyStrings = true)]
     public string BpnDidResolverUrl { get; set; } = null!;
+
+    [Required]
+    [DistinctValues("x => x.ClientId")]
+    public IEnumerable<UserRoleConfig> UserRolesAccessibleByProviderOnly { get; set; } = null!;
 }
 
 public static class ServiceSettingsExtension

--- a/src/marketplace/Services.Service/appsettings.json
+++ b/src/marketplace/Services.Service/appsettings.json
@@ -74,7 +74,8 @@
     "TechnicalUserProfileClient": "",
     "OfferSubscriptionAddress": "",
     "OfferDetailAddress": "",
-    "DimUserRoles": []
+    "DimUserRoles": [],
+    "UserRolesAccessibleByProviderOnly": []
   },
   "Provisioning": {
     "CentralRealm": "",

--- a/src/portalbackend/PortalBackend.DBAccess/Models/TechnicalUserProfileInformation.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/TechnicalUserProfileInformation.cs
@@ -17,14 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using System.Text.Json.Serialization;
-
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
-
-public record TechnicalUserProfileInformation(
-    [property: JsonPropertyName("technicalUserProfileId")] Guid TechnicalUserProfileId,
-    [property: JsonPropertyName("userRoles")] IEnumerable<UserRoleInformation> UserRoles
-);
 
 public record TechnicalUserProfileInformationTransferData(
     Guid TechnicalUserProfileId,
@@ -33,5 +26,5 @@ public record TechnicalUserProfileInformationTransferData(
 
 public record UserRoleInformationTransferData(
     Guid UserRoleId,
-    string UserRoleText,
-    bool External);
+    string UserRoleText
+);

--- a/src/portalbackend/PortalBackend.DBAccess/Models/TechnicalUserProfileInformation.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/TechnicalUserProfileInformation.cs
@@ -26,5 +26,7 @@ public record TechnicalUserProfileInformationTransferData(
 
 public record UserRoleInformationTransferData(
     Guid UserRoleId,
-    string UserRoleText
+    string UserRoleText,
+    bool IsExternal,
+    bool IsProviderOnly
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
@@ -33,16 +33,18 @@ public record UserRoleData(
 /// Basic model for user role data needed to display user roles with description.
 /// </summary>
 public record UserRoleWithDescriptionTransferData(
-        Guid UserRoleId,
-        string UserRoleText,
-        string? RoleDescription,
-        bool External
+    Guid UserRoleId,
+    string UserRoleText,
+    string? RoleDescription,
+    bool External,
+    bool ProviderOnly
 );
 
 public record UserRoleInformation(
     [property: JsonPropertyName("roleId")] Guid UserRoleId,
     [property: JsonPropertyName("roleName")] string UserRoleText,
-    [property: JsonPropertyName("type")] UserRoleType RoleType);
+    [property: JsonPropertyName("type")] UserRoleType RoleType,
+    [property: JsonPropertyName("accessiblyByProviderOnly")] bool AccessiblyByProviderOnly);
 
 public enum UserRoleType
 {

--- a/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
@@ -35,16 +35,8 @@ public record UserRoleData(
 public record UserRoleWithDescriptionTransferData(
     Guid UserRoleId,
     string UserRoleText,
-    string? RoleDescription,
-    bool External,
-    bool ProviderOnly
+    string? RoleDescription
 );
-
-public record UserRoleInformation(
-    [property: JsonPropertyName("roleId")] Guid UserRoleId,
-    [property: JsonPropertyName("roleName")] string UserRoleText,
-    [property: JsonPropertyName("type")] UserRoleType RoleType,
-    [property: JsonPropertyName("accessiblyByProviderOnly")] bool AccessiblyByProviderOnly);
 
 public enum UserRoleType
 {

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserProfileRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserProfileRepository.cs
@@ -17,6 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
@@ -68,5 +69,5 @@ public interface ITechnicalUserProfileRepository
     /// <param name="offerTypeId">Id of the offertype</param>
     /// <param name="externalUserRoles">The external user roles</param>
     /// <returns>List of the technical user profile information</returns>
-    Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformationTransferData> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId);
+    Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformationTransferData> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId, IEnumerable<UserRoleConfig> externalRoles, IEnumerable<UserRoleConfig> providerOnlyRoles);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserProfileRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserProfileRepository.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW Group AG
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -69,5 +68,5 @@ public interface ITechnicalUserProfileRepository
     /// <param name="offerTypeId">Id of the offertype</param>
     /// <param name="externalUserRoles">The external user roles</param>
     /// <returns>List of the technical user profile information</returns>
-    Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformationTransferData> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId, IEnumerable<Guid> externalUserRoles);
+    Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformationTransferData> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
@@ -48,7 +48,7 @@ public interface IUserRolesRepository
     IAsyncEnumerable<OfferRoleInfo> GetAppRolesAsync(Guid offerId, Guid companyId, string languageShortName);
     IAsyncEnumerable<string> GetClientRolesCompositeAsync(string keyCloakClientId);
 
-    IAsyncEnumerable<UserRoleWithDescriptionTransferData> GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName);
+    IAsyncEnumerable<UserRoleWithDescriptionTransferData> GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName, IEnumerable<Guid> providerOnlyRoleIds);
 
     /// <summary>
     /// Gets all user role ids for the given offerId

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
@@ -48,7 +48,7 @@ public interface IUserRolesRepository
     IAsyncEnumerable<OfferRoleInfo> GetAppRolesAsync(Guid offerId, Guid companyId, string languageShortName);
     IAsyncEnumerable<string> GetClientRolesCompositeAsync(string keyCloakClientId);
 
-    IAsyncEnumerable<UserRoleWithDescriptionTransferData> GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName, IEnumerable<Guid> providerOnlyRoleIds);
+    IAsyncEnumerable<UserRoleWithDescriptionTransferData> GetServiceAccountRolesAsync(Guid companyId, string clientId, string languageShortName);
 
     /// <summary>
     /// Gets all user role ids for the given offerId

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserProfileRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserProfileRepository.cs
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW Group AG
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -69,7 +68,7 @@ public class TechnicalUserProfileRepository : ITechnicalUserProfileRepository
     }
 
     /// <inheritdoc />
-    public Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformationTransferData> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId, IEnumerable<Guid> externalUserRoles) =>
+    public Task<(bool IsUserOfProvidingCompany, IEnumerable<TechnicalUserProfileInformationTransferData> Information)> GetTechnicalUserProfileInformation(Guid offerId, Guid usersCompanyId, OfferTypeId offerTypeId) =>
         _context.Offers
             .Where(x => x.Id == offerId && x.OfferTypeId == offerTypeId)
             .Select(x => new ValueTuple<bool, IEnumerable<TechnicalUserProfileInformationTransferData>>(
@@ -79,7 +78,6 @@ public class TechnicalUserProfileRepository : ITechnicalUserProfileRepository
                     tup.TechnicalUserProfileAssignedUserRoles
                         .Select(ur => new UserRoleInformationTransferData(
                             ur.UserRole!.Id,
-                            ur.UserRole.UserRoleText,
-                            externalUserRoles.Contains(ur.UserRoleId)))))))
+                            ur.UserRole.UserRoleText))))))
             .SingleOrDefaultAsync();
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
@@ -215,7 +215,7 @@ public class UserRolesRepository : IUserRolesRepository
             .Select(userRole => userRole.UserRoleText)
             .AsAsyncEnumerable();
 
-    IAsyncEnumerable<UserRoleWithDescriptionTransferData> IUserRolesRepository.GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName, IEnumerable<Guid> providerOnlyRoleIds) =>
+    IAsyncEnumerable<UserRoleWithDescriptionTransferData> IUserRolesRepository.GetServiceAccountRolesAsync(Guid companyId, string clientId, string languageShortName) =>
         _dbContext.UserRoles
             .AsNoTracking()
             .Where(ur => ur.Offer!.AppInstances.Any(ai => ai.IamClient!.ClientClientId == clientId) &&
@@ -226,9 +226,7 @@ public class UserRolesRepository : IUserRolesRepository
                 userRole.Id,
                 userRole.UserRoleText,
                 userRole.UserRoleDescriptions.SingleOrDefault(desc =>
-                    desc.LanguageShortName == languageShortName)!.Description,
-                externalRoleIds.Contains(userRole.Id),
-                providerOnlyRoleIds.Contains(userRole.Id)
+                    desc.LanguageShortName == languageShortName)!.Description
                 ))
             .AsAsyncEnumerable();
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
@@ -215,7 +215,7 @@ public class UserRolesRepository : IUserRolesRepository
             .Select(userRole => userRole.UserRoleText)
             .AsAsyncEnumerable();
 
-    IAsyncEnumerable<UserRoleWithDescriptionTransferData> IUserRolesRepository.GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName) =>
+    IAsyncEnumerable<UserRoleWithDescriptionTransferData> IUserRolesRepository.GetServiceAccountRolesAsync(Guid companyId, string clientId, IEnumerable<Guid> externalRoleIds, string languageShortName, IEnumerable<Guid> providerOnlyRoleIds) =>
         _dbContext.UserRoles
             .AsNoTracking()
             .Where(ur => ur.Offer!.AppInstances.Any(ai => ai.IamClient!.ClientClientId == clientId) &&
@@ -227,7 +227,9 @@ public class UserRolesRepository : IUserRolesRepository
                 userRole.UserRoleText,
                 userRole.UserRoleDescriptions.SingleOrDefault(desc =>
                     desc.LanguageShortName == languageShortName)!.Description,
-                externalRoleIds.Contains(userRole.Id)))
+                externalRoleIds.Contains(userRole.Id),
+                providerOnlyRoleIds.Contains(userRole.Id)
+                ))
             .AsAsyncEnumerable();
 
     /// <inheritdoc />

--- a/src/provisioning/Provisioning.Library/Service/TechnicalUserCreation.cs
+++ b/src/provisioning/Provisioning.Library/Service/TechnicalUserCreation.cs
@@ -47,7 +47,8 @@ public class TechnicalUserCreation(
     private readonly ServiceAccountCreationSettings _settings = options.Value;
 
     /// <inheritdoc />
-    async Task<(bool HasExternalTechnicalUser, Guid? ProcessId, IEnumerable<CreatedServiceAccountData> TechnicalUsers)> ITechnicalUserCreation.CreateTechnicalUsersAsync(TechnicalUserCreationInfo creationData,
+    async Task<(bool HasExternalTechnicalUser, Guid? ProcessId, IEnumerable<CreatedServiceAccountData> TechnicalUsers)>
+        ITechnicalUserCreation.CreateTechnicalUsersAsync(TechnicalUserCreationInfo creationData,
             Guid companyId,
             IEnumerable<string> bpns,
             TechnicalUserTypeId technicalUserTypeId,
@@ -60,30 +61,63 @@ public class TechnicalUserCreation(
         var technicalUserRepository = portalRepositories.GetInstance<ITechnicalUserRepository>();
         var userRolesRepository = portalRepositories.GetInstance<IUserRolesRepository>();
 
-        var userRoleData = await GetAndValidateUserRoleData(userRolesRepository, userRoleIds).ConfigureAwait(ConfigureAwaitOptions.None);
-        var dimConfigRoles = _settings.DimUserRoles.SelectMany(x => x.UserRoleNames.Select(userRoleName => (x.ClientId, userRoleName)));
-        var userProviderRoles = _settings.UserRolesAccessibleByProviderOnly.SelectMany(x => x.UserRoleNames.Select(userRoleName => (x.ClientId, userRoleName)));
-
-        var userTypeId = technicalUserTypeId == TechnicalUserTypeId.MANAGED && userRoleData.IntersectBy(userProviderRoles, providerData => (providerData.ClientClientId, providerData.UserRoleText)).Any() ? TechnicalUserTypeId.PROVIDER_OWNED : technicalUserTypeId;
+        var userRoleData = await GetAndValidateUserRoleData(userRolesRepository, userRoleIds)
+            .ConfigureAwait(ConfigureAwaitOptions.None);
+        var dimConfigRoles =
+            _settings.DimUserRoles.SelectMany(x => x.UserRoleNames.Select(userRoleName => (x.ClientId, userRoleName)));
+        var userProviderRoles = _settings.UserRolesAccessibleByProviderOnly.SelectMany(x =>
+            x.UserRoleNames.Select(userRoleName => (x.ClientId, userRoleName)));
 
         var serviceAccounts = ImmutableList.CreateBuilder<CreatedServiceAccountData>();
+        if (technicalUserTypeId == TechnicalUserTypeId.MANAGED &&
+            userRoleData.IntersectBy(userProviderRoles, roleData => (roleData.ClientClientId, roleData.UserRoleText))
+                .IfAny(
+                    async roleData =>
+                    {
+                        var keycloakRoleData = roleData.ToImmutableList();
+                        var (clientId, enhancedName, serviceAccountData) =
+                            await CreateKeycloakServiceAccount(bpns, enhanceTechnicalUserName, enabled, name,
+                                description,
+                                iamClientAuthMethod, keycloakRoleData).ConfigureAwait(ConfigureAwaitOptions.None);
+                        var serviceAccountId = CreateDatabaseServiceAccount(companyId, UserStatusId.ACTIVE,
+                            TechnicalUserTypeId.PROVIDER_OWNED, TechnicalUserKindId.INTERNAL, name, clientId,
+                            description,
+                            keycloakRoleData, technicalUserRepository, userRolesRepository, setOptionalParameter);
+                        serviceAccounts.Add(new CreatedServiceAccountData(
+                            serviceAccountId,
+                            enhancedName,
+                            description,
+                            UserStatusId.ACTIVE,
+                            clientId,
+                            serviceAccountData,
+                            keycloakRoleData));
+                    }, out var kcRolesTask))
+        {
+            await kcRolesTask.ConfigureAwait(ConfigureAwaitOptions.None);
+        }
 
-        if (userRoleData.ExceptBy(dimConfigRoles, roleData => (roleData.ClientClientId, roleData.UserRoleText)).IfAny(
-            async roleData =>
-            {
-                var keycloakRoleData = roleData.ToImmutableList();
-                var (clientId, enhancedName, serviceAccountData) = await CreateKeycloakServiceAccount(bpns, enhanceTechnicalUserName, enabled, name, description, iamClientAuthMethod, keycloakRoleData).ConfigureAwait(ConfigureAwaitOptions.None);
-                var serviceAccountId = CreateDatabaseServiceAccount(companyId, UserStatusId.ACTIVE, userTypeId, TechnicalUserKindId.INTERNAL, name, clientId, description, keycloakRoleData, technicalUserRepository, userRolesRepository, setOptionalParameter);
-                serviceAccounts.Add(new CreatedServiceAccountData(
-                    serviceAccountId,
-                    enhancedName,
-                    description,
-                    UserStatusId.ACTIVE,
-                    clientId,
-                    serviceAccountData,
-                    keycloakRoleData));
-            },
-            out var keycloakRolesTask))
+        if (userRoleData
+            .ExceptBy(dimConfigRoles, roleData => (roleData.ClientClientId, roleData.UserRoleText))
+            .ExceptBy(userProviderRoles, roleData => (roleData.ClientClientId, roleData.UserRoleText)).IfAny(
+                async roleData =>
+                {
+                    var keycloakRoleData = roleData.ToImmutableList();
+                    var (clientId, enhancedName, serviceAccountData) =
+                        await CreateKeycloakServiceAccount(bpns, enhanceTechnicalUserName, enabled, name, description,
+                            iamClientAuthMethod, keycloakRoleData).ConfigureAwait(ConfigureAwaitOptions.None);
+                    var serviceAccountId = CreateDatabaseServiceAccount(companyId, UserStatusId.ACTIVE,
+                        technicalUserTypeId, TechnicalUserKindId.INTERNAL, name, clientId, description,
+                        keycloakRoleData, technicalUserRepository, userRolesRepository, setOptionalParameter);
+                    serviceAccounts.Add(new CreatedServiceAccountData(
+                        serviceAccountId,
+                        enhancedName,
+                        description,
+                        UserStatusId.ACTIVE,
+                        clientId,
+                        serviceAccountData,
+                        keycloakRoleData));
+                },
+                out var keycloakRolesTask))
         {
             await keycloakRolesTask.ConfigureAwait(ConfigureAwaitOptions.None);
         }
@@ -94,14 +128,18 @@ public class TechnicalUserCreation(
             {
                 var dimRoleData = roleData.ToImmutableList();
                 var dimSaName = $"dim-{name}";
-                var dimServiceAccountId = CreateDatabaseServiceAccount(companyId, UserStatusId.PENDING, technicalUserTypeId, TechnicalUserKindId.EXTERNAL, dimSaName, null, description, dimRoleData, technicalUserRepository, userRolesRepository, setOptionalParameter);
+                var dimServiceAccountId = CreateDatabaseServiceAccount(companyId, UserStatusId.PENDING,
+                    technicalUserTypeId, TechnicalUserKindId.EXTERNAL, dimSaName, null, description, dimRoleData,
+                    technicalUserRepository, userRolesRepository, setOptionalParameter);
                 var processStepRepository = portalRepositories.GetInstance<IPortalProcessStepRepository>();
                 if (processData?.ProcessTypeId is not null)
                 {
                     if (processData.ProcessId is null)
                     {
                         var process = processStepRepository.CreateProcess(processData.ProcessTypeId.Value);
-                        processStepRepository.CreateProcessStep(processData.ProcessTypeId.Value.GetInitialProcessStepTypeIdForSaCreation(), ProcessStepStatusId.TODO, process.Id);
+                        processStepRepository.CreateProcessStep(
+                            processData.ProcessTypeId.Value.GetInitialProcessStepTypeIdForSaCreation(),
+                            ProcessStepStatusId.TODO, process.Id);
                         processId = process.Id;
                     }
                     else
@@ -109,7 +147,8 @@ public class TechnicalUserCreation(
                         processId = processData.ProcessId.Value;
                     }
 
-                    portalRepositories.GetInstance<ITechnicalUserRepository>().CreateExternalTechnicalUserCreationData(dimServiceAccountId, processId.Value);
+                    portalRepositories.GetInstance<ITechnicalUserRepository>()
+                        .CreateExternalTechnicalUserCreationData(dimServiceAccountId, processId.Value);
                 }
 
                 serviceAccounts.Add(new CreatedServiceAccountData(

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/TechnicalUserBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/TechnicalUserBusinessLogicTests.cs
@@ -662,7 +662,7 @@ public class TechnicalUserBusinessLogicTests
         // Arrange
         var data = _fixture.CreateMany<UserRoleWithDescriptionTransferData>(15);
 
-        A.CallTo(() => _userRolesRepository.GetServiceAccountRolesAsync(A<Guid>._, A<string>._, A<IEnumerable<Guid>>._, A<string>._))
+        A.CallTo(() => _userRolesRepository.GetServiceAccountRolesAsync(A<Guid>._, A<string>._, A<IEnumerable<Guid>>._, A<string>._, A<IEnumerable<Guid>>._))
             .Returns(data.ToAsyncEnumerable());
 
         A.CallTo(() => _portalRepositories.GetInstance<IUserRolesRepository>()).Returns(_userRolesRepository);
@@ -673,14 +673,14 @@ public class TechnicalUserBusinessLogicTests
         var result = await sut.GetServiceAccountRolesAsync(null).ToListAsync();
 
         // Assert
-        A.CallTo(() => _userRolesRepository.GetServiceAccountRolesAsync(_identity.CompanyId, ClientId, A<IEnumerable<Guid>>._, A<string>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _userRolesRepository.GetServiceAccountRolesAsync(_identity.CompanyId, ClientId, A<IEnumerable<Guid>>._, A<string>._, A<IEnumerable<Guid>>._)).MustHaveHappenedOnceExactly();
 
         result.Should().NotBeNull();
         result.Should().HaveCount(15);
         // Sonar fix -> Return value of pure method is not used
         result.Should().AllSatisfy(ur =>
         {
-            var transferData = new UserRoleWithDescriptionTransferData(ur.UserRoleId, ur.UserRoleText, ur.RoleDescription, ur.RoleType == UserRoleType.External);
+            var transferData = new UserRoleWithDescriptionTransferData(ur.UserRoleId, ur.UserRoleText, ur.RoleDescription, ur.RoleType == UserRoleType.External, ur.ProviderOnly);
             data.Contains(transferData).Should().BeTrue();
         });
     }

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -1268,7 +1268,7 @@ public class AppReleaseBusinessLogicTest
             .UpdateTechnicalUserProfiles(appId, data);
 
         A.CallTo(() => _offerService.UpdateTechnicalUserProfiles(appId, OfferTypeId.APP,
-                A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5), clientProfile))
+                A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5), clientProfile, A<IEnumerable<UserRoleConfig>>._))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -1281,7 +1281,7 @@ public class AppReleaseBusinessLogicTest
     {
         // Arrange
         var appId = Guid.NewGuid();
-        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(appId, OfferTypeId.APP, A<IEnumerable<UserRoleConfig>>._))
+        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(appId, OfferTypeId.APP, A<IEnumerable<UserRoleConfig>>._, A<IEnumerable<UserRoleConfig>>._))
             .Returns(_fixture.CreateMany<TechnicalUserProfileInformation>(5));
         var sut = new AppReleaseBusinessLogic(null!, Options.Create(new AppsSettings()), _offerService, _offerDocumentService, null!, _identityService);
 

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -1825,7 +1825,7 @@ public class OfferServiceTests
         // Arrange
         var offerId = _fixture.Create<Guid>();
         var data = _fixture.CreateMany<TechnicalUserProfileInformationTransferData>(5);
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._))
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(A<Guid>._, A<Guid>._, A<OfferTypeId>._))
             .Returns((true, data));
 
         // Act
@@ -1833,7 +1833,7 @@ public class OfferServiceTests
 
         // Assert
         result.Should().HaveCount(5);
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId)).MustHaveHappenedOnceExactly();
     }
 
     [Theory]
@@ -1843,7 +1843,7 @@ public class OfferServiceTests
     {
         // Arrange
         var offerId = _fixture.Create<Guid>();
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._))
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(A<Guid>._, A<Guid>._, A<OfferTypeId>._))
             .Returns<(bool, IEnumerable<TechnicalUserProfileInformationTransferData>)>(default);
 
         // Act
@@ -1852,7 +1852,7 @@ public class OfferServiceTests
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
         ex.Message.Should().Be(OfferServiceErrors.OFFER_NOTFOUND.ToString());
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId)).MustHaveHappenedOnceExactly();
     }
 
     [Theory]
@@ -1862,7 +1862,7 @@ public class OfferServiceTests
     {
         // Arrange
         var offerId = _fixture.Create<Guid>();
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._))
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(A<Guid>._, A<Guid>._, A<OfferTypeId>._))
             .Returns((false, Enumerable.Empty<TechnicalUserProfileInformationTransferData>()));
 
         // Act
@@ -1871,7 +1871,7 @@ public class OfferServiceTests
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
         ex.Message.Should().Be(OfferServiceErrors.COMPANY_NOT_PROVIDER.ToString());
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId)).MustHaveHappenedOnceExactly();
     }
 
     #endregion

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -1825,7 +1825,7 @@ public class OfferServiceTests
         // Arrange
         var offerId = _fixture.Create<Guid>();
         var data = _fixture.CreateMany<TechnicalUserProfileInformationTransferData>(5);
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(A<Guid>._, A<Guid>._, A<OfferTypeId>._))
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(A<Guid>._, A<Guid>._, A<OfferTypeId>._, A<IEnumerable<UserRoleConfig>>._, A<IEnumerable<UserRoleConfig>>._))
             .Returns((true, data));
 
         // Act
@@ -1833,7 +1833,7 @@ public class OfferServiceTests
 
         // Assert
         result.Should().HaveCount(5);
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<UserRoleConfig>>._, A<IEnumerable<UserRoleConfig>>._)).MustHaveHappenedOnceExactly();
     }
 
     [Theory]
@@ -1843,7 +1843,7 @@ public class OfferServiceTests
     {
         // Arrange
         var offerId = _fixture.Create<Guid>();
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(A<Guid>._, A<Guid>._, A<OfferTypeId>._))
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(A<Guid>._, A<Guid>._, A<OfferTypeId>._, A<IEnumerable<UserRoleConfig>>._, A<IEnumerable<UserRoleConfig>>._))
             .Returns<(bool, IEnumerable<TechnicalUserProfileInformationTransferData>)>(default);
 
         // Act
@@ -1852,7 +1852,7 @@ public class OfferServiceTests
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
         ex.Message.Should().Be(OfferServiceErrors.OFFER_NOTFOUND.ToString());
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<UserRoleConfig>>._, A<IEnumerable<UserRoleConfig>>._)).MustHaveHappenedOnceExactly();
     }
 
     [Theory]
@@ -1862,7 +1862,7 @@ public class OfferServiceTests
     {
         // Arrange
         var offerId = _fixture.Create<Guid>();
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(A<Guid>._, A<Guid>._, A<OfferTypeId>._))
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(A<Guid>._, A<Guid>._, A<OfferTypeId>._, A<IEnumerable<UserRoleConfig>>._, A<IEnumerable<UserRoleConfig>>._))
             .Returns((false, Enumerable.Empty<TechnicalUserProfileInformationTransferData>()));
 
         // Act
@@ -1871,7 +1871,7 @@ public class OfferServiceTests
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
         ex.Message.Should().Be(OfferServiceErrors.COMPANY_NOT_PROVIDER.ToString());
-        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<UserRoleConfig>>._, A<IEnumerable<UserRoleConfig>>._)).MustHaveHappenedOnceExactly();
     }
 
     #endregion

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -22,6 +22,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Framework.Identity;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
+using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
@@ -1828,7 +1829,7 @@ public class OfferServiceTests
             .Returns((true, data));
 
         // Act
-        var result = await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId, Enumerable.Empty<UserRoleConfig>());
+        var result = await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId, Enumerable.Empty<UserRoleConfig>(), Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         result.Should().HaveCount(5);
@@ -1846,11 +1847,11 @@ public class OfferServiceTests
             .Returns<(bool, IEnumerable<TechnicalUserProfileInformationTransferData>)>(default);
 
         // Act
-        async Task Act() => await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId, Enumerable.Empty<UserRoleConfig>());
+        async Task Act() => await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId, Enumerable.Empty<UserRoleConfig>(), Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
-        ex.Message.Should().Be($"Offer {offerId} does not exist");
+        ex.Message.Should().Be(OfferServiceErrors.OFFER_NOTFOUND.ToString());
         A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._)).MustHaveHappenedOnceExactly();
     }
 
@@ -1865,11 +1866,11 @@ public class OfferServiceTests
             .Returns((false, Enumerable.Empty<TechnicalUserProfileInformationTransferData>()));
 
         // Act
-        async Task Act() => await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId, Enumerable.Empty<UserRoleConfig>());
+        async Task Act() => await _sut.GetTechnicalUserProfilesForOffer(offerId, offerTypeId, Enumerable.Empty<UserRoleConfig>(), Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
-        ex.Message.Should().Be($"Company {_companyId} is not the providing company");
+        ex.Message.Should().Be(OfferServiceErrors.COMPANY_NOT_PROVIDER.ToString());
         A.CallTo(() => _technicalUserProfileRepository.GetTechnicalUserProfileInformation(offerId, _companyId, offerTypeId, A<IEnumerable<Guid>>._)).MustHaveHappenedOnceExactly();
     }
 
@@ -1924,7 +1925,7 @@ public class OfferServiceTests
                 setOptionalParameters(existingOffer);
             });
         // Act
-        await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1");
+        await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1", Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         A.CallTo(() => _technicalUserProfileRepository.CreateTechnicalUserProfile(A<Guid>._, offerId))
@@ -1972,11 +1973,11 @@ public class OfferServiceTests
             .Returns(new Guid[] { userRole1Id, userRole2Id }.ToAsyncEnumerable());
 
         // Act
-        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1");
+        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1", Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be($"Roles {missingRoleId} do not exist");
+        ex.Message.Should().Be(OfferServiceErrors.ROLES_DOES_NOT_EXIST.ToString());
     }
 
     [Theory]
@@ -2002,11 +2003,11 @@ public class OfferServiceTests
             .Returns(new Guid[] { userRole1Id, userRole2Id }.ToAsyncEnumerable());
 
         // Act
-        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1");
+        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1", Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be("Technical User Profiles can't be set for CONSULTANCY_SERVICE");
+        ex.Message.Should().Be(OfferServiceErrors.TECHNICAL_USERS_FOR_CONSULTANCY.ToString());
     }
 
     [Theory]
@@ -2032,11 +2033,11 @@ public class OfferServiceTests
             .Returns(new Guid[] { userRole1Id, userRole2Id }.ToAsyncEnumerable());
 
         // Act
-        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1");
+        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1", Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
-        ex.Message.Should().Be($"Company {_companyId} is not the providing company");
+        ex.Message.Should().Be(OfferServiceErrors.COMPANY_NOT_PROVIDER.ToString());
     }
 
     [Theory]
@@ -2062,11 +2063,11 @@ public class OfferServiceTests
             .Returns(new Guid[] { userRole1Id, userRole2Id }.ToAsyncEnumerable());
 
         // Act
-        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1");
+        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1", Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
-        ex.Message.Should().Be($"Offer {offerTypeId} {offerId} does not exist");
+        ex.Message.Should().Be(OfferServiceErrors.OFFER_NOTFOUND.ToString());
     }
 
     [Theory]
@@ -2082,11 +2083,11 @@ public class OfferServiceTests
         };
 
         // Act
-        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1");
+        async Task Act() => await _sut.UpdateTechnicalUserProfiles(offerId, offerTypeId, data, "cl1", Enumerable.Empty<UserRoleConfig>());
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
-        ex.Message.Should().Be("Technical User Profiles and Role IDs both should not be empty.");
+        ex.Message.Should().Be(OfferServiceErrors.NOT_EMPTY_ROLES_AND_PROFILES.ToString());
     }
     #endregion
 

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
@@ -586,7 +586,7 @@ public class ServiceReleaseBusinessLogicTest
     public async Task GetTechnicalUserProfilesForOffer_ReturnsExpected()
     {
         // Arrange
-        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(_existingServiceId, OfferTypeId.SERVICE, A<IEnumerable<UserRoleConfig>>._))
+        A.CallTo(() => _offerService.GetTechnicalUserProfilesForOffer(_existingServiceId, OfferTypeId.SERVICE, A<IEnumerable<UserRoleConfig>>._, A<IEnumerable<UserRoleConfig>>._))
             .Returns(_fixture.CreateMany<TechnicalUserProfileInformation>(5));
         var sut = new ServiceReleaseBusinessLogic(null!, _offerService, _offerDocumentService, _identityService, Options.Create(new ServiceSettings()));
 
@@ -613,7 +613,7 @@ public class ServiceReleaseBusinessLogicTest
             .UpdateTechnicalUserProfiles(_existingServiceId, data);
 
         A.CallTo(() => _offerService.UpdateTechnicalUserProfiles(_existingServiceId, OfferTypeId.SERVICE,
-                A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5), clientProfile))
+                A<IEnumerable<TechnicalUserProfileData>>.That.Matches(x => x.Count() == 5), clientProfile, A<IEnumerable<UserRoleConfig>>._))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
@@ -251,14 +251,14 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         // Arrange
         var sut = await CreateSut();
         var externalRoleConfig = new[]{
-            new UserRoleConfig("Cl1-CX-Registration", new []
+            new UserRoleConfig("Cl2-CX-Portal", new []
             {
-                "Company Admin"
+                "test"
             })};
         var providerOnlyRoleConfig = new[]{
-            new UserRoleConfig("Cl1-CX-Registration", new []
+            new UserRoleConfig("https://catenax-int-dismantler-s66pftcc.authentication.eu10.hana.ondemand.com", new []
             {
-                "Company Admin"
+                "EarthCommerce.Advanced.BuyerRC_QAS2"
             })};
 
         // Act
@@ -267,7 +267,44 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         // Assert
         result.Should().NotBeNull();
         result.IsUserOfProvidingCompany.Should().BeTrue();
-        result.Information.Should().HaveCount(2);
+        result.Information.Should().HaveCount(2).And.Satisfy(
+            x => x.UserRoles.Count() == 2 &&
+                x.UserRoles.Where(ur => ur.UserRoleId == new Guid("aabcdfeb-6669-4c74-89f0-19cda090873e")).All(ur => ur.IsExternal && !ur.IsProviderOnly) &&
+                x.UserRoles.Where(ur => ur.UserRoleId == new Guid("aabcdfeb-6669-4c74-89f0-19cda090873f")).All(ur => !ur.IsExternal && ur.IsProviderOnly),
+            x => x.UserRoles.Count() == 1 &&
+                x.UserRoles.Where(ur => ur.UserRoleId == new Guid("aabcdfeb-6669-4c74-89f0-19cda090873e")).All(ur => ur.IsExternal && !ur.IsProviderOnly)
+        );
+    }
+
+    [Fact]
+    public async Task GetTechnicalUserProfileInformation_NoMatchingRoleConfig_ReturnsExpectedResult()
+    {
+        // Arrange
+        var sut = await CreateSut();
+        var externalRoleConfig = new[]{
+            new UserRoleConfig("Foo", new []
+            {
+                "deadbeef"
+            })};
+        var providerOnlyRoleConfig = new[]{
+            new UserRoleConfig("Bar", new []
+            {
+                "deadbeef"
+            })};
+
+        // Act
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.SERVICE, externalRoleConfig, providerOnlyRoleConfig);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsUserOfProvidingCompany.Should().BeTrue();
+        result.Information.Should().HaveCount(2).And.Satisfy(
+            x => x.UserRoles.Count() == 2 &&
+                x.UserRoles.Where(ur => ur.UserRoleId == new Guid("aabcdfeb-6669-4c74-89f0-19cda090873e")).All(ur => !ur.IsExternal && !ur.IsProviderOnly) &&
+                x.UserRoles.Where(ur => ur.UserRoleId == new Guid("aabcdfeb-6669-4c74-89f0-19cda090873f")).All(ur => !ur.IsExternal && !ur.IsProviderOnly),
+            x => x.UserRoles.Count() == 1 &&
+                x.UserRoles.Where(ur => ur.UserRoleId == new Guid("aabcdfeb-6669-4c74-89f0-19cda090873e")).All(ur => !ur.IsExternal && !ur.IsProviderOnly)
+        );
     }
 
     [Fact]
@@ -277,14 +314,14 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         var externalRoleConfig = new[]{
-            new UserRoleConfig("Cl1-CX-Registration", new []
+            new UserRoleConfig("technical_roles_management", new []
             {
-                "Company Admin"
+                "Identity Wallet Management"
             })};
         var providerOnlyRoleConfig = new[]{
-            new UserRoleConfig("Cl1-CX-Registration", new []
+            new UserRoleConfig("technical_roles_management", new []
             {
-                "Company Admin"
+                "Registration External"
             })};
 
         // Act
@@ -302,14 +339,14 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         var externalRoleConfig = new[]{
-            new UserRoleConfig("Cl1-CX-Registration", new []
+            new UserRoleConfig("technical_roles_management", new []
             {
-                "Company Admin"
+                "Identity Wallet Management"
             })};
         var providerOnlyRoleConfig = new[]{
-            new UserRoleConfig("Cl1-CX-Registration", new []
+            new UserRoleConfig("technical_roles_management", new []
             {
-                "Company Admin"
+                "Registration External"
             })};
 
         // Act
@@ -326,14 +363,14 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         var externalRoleConfig = new[]{
-            new UserRoleConfig("Cl1-CX-Registration", new []
+            new UserRoleConfig("technical_roles_management", new []
             {
-                "Company Admin"
+                "Identity Wallet Management"
             })};
         var providerOnlyRoleConfig = new[]{
-            new UserRoleConfig("Cl1-CX-Registration", new []
+            new UserRoleConfig("technical_roles_management", new []
             {
-                "Company Admin"
+                "Registration External"
             })};
 
         // Act

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
@@ -251,14 +251,12 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.SERVICE, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1));
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.SERVICE);
 
         // Assert
         result.Should().NotBeNull();
         result.IsUserOfProvidingCompany.Should().BeTrue();
-        result.Information.Should().HaveCount(2).And.Satisfy(
-            x => x.UserRoles.Count(x => !x.External) == 2,
-            x => x.UserRoles.Count(x => !x.External) == 1);
+        result.Information.Should().HaveCount(2);
     }
 
     [Fact]
@@ -268,7 +266,7 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, Guid.NewGuid(), OfferTypeId.SERVICE, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1));
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, Guid.NewGuid(), OfferTypeId.SERVICE);
 
         // Assert
         result.Should().NotBeNull();
@@ -282,7 +280,7 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(Guid.NewGuid(), _validCompanyId, OfferTypeId.SERVICE, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1));
+        var result = await sut.GetTechnicalUserProfileInformation(Guid.NewGuid(), _validCompanyId, OfferTypeId.SERVICE);
 
         // Assert
         result.Should().Be(default);
@@ -295,7 +293,7 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.APP, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1));
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.APP);
 
         // Assert
         result.Should().Be(default);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserProfileRepositoryTests.cs
@@ -18,6 +18,7 @@
  ********************************************************************************/
 
 using Microsoft.EntityFrameworkCore;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Tests.Setup;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
@@ -249,9 +250,19 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
     {
         // Arrange
         var sut = await CreateSut();
+        var externalRoleConfig = new[]{
+            new UserRoleConfig("Cl1-CX-Registration", new []
+            {
+                "Company Admin"
+            })};
+        var providerOnlyRoleConfig = new[]{
+            new UserRoleConfig("Cl1-CX-Registration", new []
+            {
+                "Company Admin"
+            })};
 
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.SERVICE);
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.SERVICE, externalRoleConfig, providerOnlyRoleConfig);
 
         // Assert
         result.Should().NotBeNull();
@@ -265,8 +276,19 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         // Arrange
         var sut = await CreateSut();
 
+        var externalRoleConfig = new[]{
+            new UserRoleConfig("Cl1-CX-Registration", new []
+            {
+                "Company Admin"
+            })};
+        var providerOnlyRoleConfig = new[]{
+            new UserRoleConfig("Cl1-CX-Registration", new []
+            {
+                "Company Admin"
+            })};
+
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, Guid.NewGuid(), OfferTypeId.SERVICE);
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, Guid.NewGuid(), OfferTypeId.SERVICE, externalRoleConfig, providerOnlyRoleConfig);
 
         // Assert
         result.Should().NotBeNull();
@@ -279,8 +301,19 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         // Arrange
         var sut = await CreateSut();
 
+        var externalRoleConfig = new[]{
+            new UserRoleConfig("Cl1-CX-Registration", new []
+            {
+                "Company Admin"
+            })};
+        var providerOnlyRoleConfig = new[]{
+            new UserRoleConfig("Cl1-CX-Registration", new []
+            {
+                "Company Admin"
+            })};
+
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(Guid.NewGuid(), _validCompanyId, OfferTypeId.SERVICE);
+        var result = await sut.GetTechnicalUserProfileInformation(Guid.NewGuid(), _validCompanyId, OfferTypeId.SERVICE, externalRoleConfig, providerOnlyRoleConfig);
 
         // Assert
         result.Should().Be(default);
@@ -292,8 +325,19 @@ public class TechnicalUserProfileRepositoryTests : IAssemblyFixture<TestDbFixtur
         // Arrange
         var sut = await CreateSut();
 
+        var externalRoleConfig = new[]{
+            new UserRoleConfig("Cl1-CX-Registration", new []
+            {
+                "Company Admin"
+            })};
+        var providerOnlyRoleConfig = new[]{
+            new UserRoleConfig("Cl1-CX-Registration", new []
+            {
+                "Company Admin"
+            })};
+
         // Act
-        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.APP);
+        var result = await sut.GetTechnicalUserProfileInformation(_validServiceId, _validCompanyId, OfferTypeId.APP, externalRoleConfig, providerOnlyRoleConfig);
 
         // Assert
         result.Should().Be(default);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -106,13 +106,15 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut();
 
         // Act
-        var data = await sut.GetServiceAccountRolesAsync(_validCompanyId, ClientId, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1), Constants.DefaultLanguage).ToListAsync();
+        var data = await sut.GetServiceAccountRolesAsync(_validCompanyId, ClientId, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1), Constants.DefaultLanguage, Enumerable.Repeat(new Guid("34c42896-a003-4653-af8f-ba06ca595752"), 1)).ToListAsync();
 
         // Assert
         data.Should().HaveCount(19);
         data.Should().OnlyHaveUniqueItems();
         data.Where(x => !x.External).Should().HaveCount(18);
         data.Where(x => x.External).Should().ContainSingle();
+        data.Where(x => !x.ProviderOnly).Should().HaveCount(18);
+        data.Where(x => x.ProviderOnly).Should().ContainSingle();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -106,15 +106,11 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         var sut = await CreateSut();
 
         // Act
-        var data = await sut.GetServiceAccountRolesAsync(_validCompanyId, ClientId, Enumerable.Repeat(new Guid("607818be-4978-41f4-bf63-fa8d2de51157"), 1), Constants.DefaultLanguage, Enumerable.Repeat(new Guid("34c42896-a003-4653-af8f-ba06ca595752"), 1)).ToListAsync();
+        var data = await sut.GetServiceAccountRolesAsync(_validCompanyId, ClientId, Constants.DefaultLanguage).ToListAsync();
 
         // Assert
         data.Should().HaveCount(19);
         data.Should().OnlyHaveUniqueItems();
-        data.Where(x => !x.External).Should().HaveCount(18);
-        data.Where(x => x.External).Should().ContainSingle();
-        data.Where(x => !x.ProviderOnly).Should().HaveCount(18);
-        data.Where(x => x.ProviderOnly).Should().ContainSingle();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -115,7 +115,7 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
-    #region GetUserRolesByClientId
+    #region GetUserRoleDataUntrackedAsync
 
     [Fact]
     public async Task GetUserRoleDataUntrackedAsync_WithValidData_ReturnsExpected()
@@ -156,6 +156,27 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         data.Should().BeEmpty();
     }
 
+    #endregion
+
+    #region GetUserRoleIdsUntrackedAsync
+
+    [Fact]
+    public async Task GetUserRoleIdsUntrackedAsync()
+    {
+        // Arrange
+        var userRoleConfig = new[]{
+            new UserRoleConfig("Cl1-CX-Registration", new []
+            {
+                "Company Admin"
+            })};
+        var sut = await CreateSut();
+
+        // Act
+        var data = await sut.GetUserRoleIdsUntrackedAsync(userRoleConfig).ToListAsync();
+
+        // Assert
+        data.Should().ContainSingle().Which.Should().Be(new Guid("7410693c-c893-409e-852f-9ee886ce94a6"));
+    }
     #endregion
 
     #region GetActiveOfferRoles


### PR DESCRIPTION
## Description

Add the accessibleByProviderOnly flag to the userRoles of a technical user profile to make it identifiable if the technical user will only be visible for the provider

## Why

To get information if the technical user will only be visible for the provider

## Issue

Refs: #1254

## Corresponding CD PR

https://github.com/eclipse-tractusx/portal/pull/501

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
