### PR TITLE
fix(migrations): add custom history repository

### DIFF
--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/CustomNpgsqlHistoryRepository.cs
+++ b/src/framework/Framework.DBAccess/CustomNpgsqlHistoryRepository.cs
@@ -1,0 +1,104 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
+
+#pragma warning disable EF1001
+public class CustomNpgsqlHistoryRepository(HistoryRepositoryDependencies dependencies) :
+    NpgsqlHistoryRepository(dependencies), IHistoryRepository
+{
+    protected override string ExistsSql => $"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = '{this.TableSchema}' AND table_name = '{this.TableName}');";
+
+    public override bool Exists()
+    {
+        return this.Dependencies.DatabaseCreator.Exists() &&
+               this.InterpretExistsResult(
+                   this.Dependencies.RawSqlCommandBuilder
+                       .Build(this.ExistsSql)
+                       .ExecuteScalar(new RelationalCommandParameterObject(this.Dependencies.Connection, null, null, this.Dependencies.CurrentContext.Context, this.Dependencies.CommandLogger, CommandSource.Migrations)));
+    }
+
+    public override async Task<bool> ExistsAsync(CancellationToken cancellationToken = new())
+    {
+        if (!await this.Dependencies.DatabaseCreator.ExistsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return false;
+        }
+
+        var existsCommand = await this.Dependencies.RawSqlCommandBuilder.Build(this.ExistsSql).ExecuteScalarAsync(new RelationalCommandParameterObject(this.Dependencies.Connection, null, null, this.Dependencies.CurrentContext.Context, this.Dependencies.CommandLogger, CommandSource.Migrations), cancellationToken).ConfigureAwait(false);
+        return this.InterpretExistsResult(existsCommand);
+    }
+
+    bool IHistoryRepository.CreateIfNotExists()
+    {
+        if (Exists())
+        {
+            return true;
+        }
+
+        try
+        {
+            return Dependencies.MigrationCommandExecutor.ExecuteNonQuery(GetCreateIfNotExistsCommands(), Dependencies.Connection, new MigrationExecutionState(), commitTransaction: true) != 0;
+        }
+        catch (PostgresException e) when (e.SqlState is PostgresErrorCodes.UniqueViolation
+                                              or PostgresErrorCodes.DuplicateTable
+                                              or PostgresErrorCodes.DuplicateObject)
+        {
+            return false;
+        }
+    }
+
+    async Task<bool> IHistoryRepository.CreateIfNotExistsAsync(CancellationToken cancellationToken)
+    {
+        if (await ExistsAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None))
+        {
+            return true;
+        }
+
+        try
+        {
+            return await Dependencies.MigrationCommandExecutor.ExecuteNonQueryAsync(
+                       GetCreateIfNotExistsCommands(), Dependencies.Connection, new MigrationExecutionState(),
+                       commitTransaction: true,
+                       cancellationToken: cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None)
+                   != 0;
+        }
+        catch (PostgresException e) when (e.SqlState is PostgresErrorCodes.UniqueViolation
+                                              or PostgresErrorCodes.DuplicateTable
+                                              or PostgresErrorCodes.DuplicateObject)
+        {
+            return false;
+        }
+    }
+
+    private IReadOnlyList<MigrationCommand> GetCreateIfNotExistsCommands()
+        => Dependencies.MigrationsSqlGenerator.Generate([new SqlOperation
+        {
+            Sql = GetCreateIfNotExistsScript(),
+            SuppressTransaction = true
+        }]);
+}
+#pragma warning enable EF1001

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Framework.DBAccess.csproj
+++ b/src/framework/Framework.DBAccess/Framework.DBAccess.csproj
@@ -57,6 +57,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Framework.ErrorHandling\Framework.ErrorHandling.csproj" />

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Identity/Directory.Build.props
+++ b/src/framework/Framework.Identity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
+++ b/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/portalbackend/PortalBackend.Migrations/Program.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Program.cs
@@ -20,11 +20,14 @@
 
 using Laraue.EfCoreTriggers.PostgreSql.Extensions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Logging;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding.DependencyInjection;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.Migrations;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Auditing;
 using Org.Eclipse.TractusX.Portal.Backend.Processes.ProcessIdentity.DependencyInjection;
@@ -44,7 +47,8 @@ try
                 .AddDbContext<PortalDbContext>(o =>
                     o.UseNpgsql(hostContext.Configuration.GetConnectionString("PortalDb"),
                         x => x.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name)
-                            .MigrationsHistoryTable("__efmigrations_history_portal"))
+                            .MigrationsHistoryTable("__efmigrations_history_portal", "public"))
+                    .ReplaceService<IHistoryRepository, CustomNpgsqlHistoryRepository>()
                     .UsePostgreSqlTriggers())
                 .AddDatabaseInitializer<PortalDbContext>(hostContext.Configuration.GetSection("Seeding"));
         })

--- a/src/provisioning/Provisioning.Migrations/Program.cs
+++ b/src/provisioning/Provisioning.Migrations/Program.cs
@@ -20,9 +20,11 @@
 // See https://aka.ms/new-console-template for more information
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Logging;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding.DependencyInjection;
 using Org.Eclipse.TractusX.Portal.Backend.Provisioning.ProvisioningEntities;
@@ -39,7 +41,9 @@ try
             services.AddDbContext<ProvisioningDbContext>(o =>
                     o.UseNpgsql(hostContext.Configuration.GetConnectionString("ProvisioningDb"),
             x => x.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name)
-                    .MigrationsHistoryTable("__efmigrations_history_provisioning", "public")))
+                    .MigrationsHistoryTable("__efmigrations_history_provisioning", "public"))
+                    .ReplaceService<IHistoryRepository, CustomNpgsqlHistoryRepository>()
+                )
                 .AddDatabaseInitializer<ProvisioningDbContext>(hostContext.Configuration.GetSection("Seeding"));
         })
         .AddLogging()

--- a/src/provisioning/Provisioning.Migrations/Provisioning.Migrations.csproj
+++ b/src/provisioning/Provisioning.Migrations/Provisioning.Migrations.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\framework\Framework.DBAccess\Framework.DBAccess.csproj" />
     <ProjectReference Include="..\..\framework\Framework.Logging\Framework.Logging.csproj" />
     <ProjectReference Include="..\..\framework\Framework.Seeding\Framework.Seeding.csproj" />
     <ProjectReference Include="..\Provisioning.ProvisioningEntities\Provisioning.ProvisioningEntities.csproj" />

--- a/src/provisioning/Provisioning.Migrations/ProvisioningDbContextFactory.cs
+++ b/src/provisioning/Provisioning.Migrations/ProvisioningDbContextFactory.cs
@@ -20,7 +20,9 @@
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 using System.Reflection;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.ProvisioningEntities;
@@ -37,7 +39,8 @@ public class ProvisioningDbContextFactory : IDesignTimeDbContextFactory<Provisio
         optionsBuilder.UseNpgsql(
             config.GetConnectionString("ProvisioningDb"),
             x => x.MigrationsAssembly(typeof(ProvisioningDbContextFactory).Assembly.GetName().Name)
-                  .MigrationsHistoryTable("__efmigrations_history_provisioning", "public"));
+                  .MigrationsHistoryTable("__efmigrations_history_provisioning", "public"))
+            .ReplaceService<IHistoryRepository, CustomNpgsqlHistoryRepository>();
 
         return new ProvisioningDbContext(optionsBuilder.Options);
     }


### PR DESCRIPTION
## Description

* add custom history repository

## Why

To overwrite the implementation of Npgsql which is skipping the existing check of the migration table, which leads to an error in our implementation, since the migration history tables are located in the public schema. Since the `portal` and `provisioning` user don't have the create grant the `create if not exists`statement of the nuget package fails. 

## Issue

Refs: #1262

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
