### PR TITLE
fix: adjust registration for processStepRepository

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/PortalRepositories.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/PortalRepositories.cs
@@ -58,7 +58,7 @@ public class PortalRepositories(PortalDbContext portalDbContext) :
         CreateTypeEntry<INetworkRepository>(context => new NetworkRepository(context)),
         CreateTypeEntry<IOfferRepository>(context => new OfferRepository(context)),
         CreateTypeEntry<IOfferSubscriptionsRepository>(context => new OfferSubscriptionsRepository(context)),
-        CreateTypeEntry<IPortalProcessStepRepository>(context => new ProcessStepRepository<Process, ProcessType<Process, ProcessTypeId>, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>, ProcessStepType<Process, ProcessTypeId, ProcessStepTypeId>, ProcessTypeId, ProcessStepTypeId>(new PortalProcessDbContextAccess(context))),
+        CreateTypeEntry<IPortalProcessStepRepository>(context => new PortalProcessStepRepository(new PortalProcessDbContextAccess(context))),
         CreateTypeEntry<IProcessStepRepository<ProcessTypeId, ProcessStepTypeId>>(context => new ProcessStepRepository<Process, ProcessType<Process, ProcessTypeId>, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>, ProcessStepType<Process, ProcessTypeId, ProcessStepTypeId>, ProcessTypeId, ProcessStepTypeId>(new PortalProcessDbContextAccess(context))),
         CreateTypeEntry<ITechnicalUserRepository>(context => new TechnicalUserRepository(context)),
         CreateTypeEntry<IStaticDataRepository>(context => new StaticDataRepository(context)),

--- a/src/portalbackend/PortalBackend.DBAccess/PortalRepositoriesStartupServiceExtensions.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/PortalRepositoriesStartupServiceExtensions.cs
@@ -20,6 +20,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Auditing;
 
@@ -30,6 +31,7 @@ public static class PortalRepositoriesStartupServiceExtensions
     public static IServiceCollection AddPortalRepositories(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddScoped<IPortalRepositories, PortalRepositories>()
+            .AddScoped<IRepositories, PortalRepositories>()
             .AddDbAuditing()
             .AddDbContext<PortalDbContext>(o => o
                     .UseNpgsql(configuration.GetConnectionString("PortalDB")))

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IPortalProcessStepRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IPortalProcessStepRepository.cs
@@ -17,10 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Concrete.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.DBAccess;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 
 public interface IPortalProcessStepRepository :
     IProcessStepRepository<ProcessTypeId, ProcessStepTypeId>;
+
+public class PortalProcessStepRepository(IProcessRepositoryContextAccess<Process, ProcessType<Process, ProcessTypeId>, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>, ProcessStepType<Process, ProcessTypeId, ProcessStepTypeId>, ProcessTypeId, ProcessStepTypeId> dbContext)
+    : ProcessStepRepository<Process, ProcessType<Process, ProcessTypeId>, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId>, ProcessStepType<Process, ProcessTypeId, ProcessStepTypeId>, ProcessTypeId, ProcessStepTypeId>(dbContext), IPortalProcessStepRepository;


### PR DESCRIPTION
## Description

Adjust the registration for PortalProcessStepRepository

## Why

The current registration couldn't be resolved by the dependency injection

## Issue

Refs: #1268

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
