### PR TITLE
fix: adjust technical user creation

### DIFF
--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -765,7 +765,9 @@ public class OfferService(
             .ToListAsync()
             .ConfigureAwait(false);
 
-        if (providerOnlyUserRoles.Except(data.SelectMany(ur => ur.UserRoleIds)).Any())
+        if (!data.All(entry =>
+                entry.UserRoleIds.All(id => providerOnlyUserRoles.Contains(id)) ||
+                entry.UserRoleIds.All(id => !providerOnlyUserRoles.Contains(id))))
         {
             throw ConflictException.Create(OfferServiceErrors.ROLES_MISSMATCH);
         }


### PR DESCRIPTION
## Description

adjust the check for providerOnlyRoles

## Why

currently only technical user with provider only roles can be created

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
