### PR TITLE
bug(document): check for the documenttype added

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/DocumentRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/DocumentRepository.cs
@@ -119,7 +119,9 @@ public class DocumentRepository(PortalDbContext dbContext) : IDocumentRepository
 
     /// <inheritdoc />
     public Task<Document?> GetDocumentByIdAsync(Guid documentId) =>
-        dbContext.Documents.SingleOrDefaultAsync(x => x.Id == documentId);
+        dbContext.Documents
+        .Where(x => x.Id == documentId && x.DocumentTypeId == DocumentTypeId.COMMERCIAL_REGISTER_EXTRACT)
+        .SingleOrDefaultAsync();
 
     /// <inheritdoc />
     public Task<(Guid DocumentId, DocumentStatusId DocumentStatusId, bool IsSameApplicationUser, DocumentTypeId documentTypeId, bool IsQueriedApplicationStatus, IEnumerable<Guid> applicationId)> GetDocumentDetailsForApplicationUntrackedAsync(Guid documentId, Guid userCompanyId, IEnumerable<CompanyApplicationStatusId> applicationStatusIds) =>


### PR DESCRIPTION
## Description

Clicking on Document Backend API Endpoint failing 

## Why

Changes in GET: /api/administration/registration/documents/{documentId}
to limit the endpoint to display only document with the documenttype to be COMMERCIAL_REGISTER_EXTRACT

## Issue

#1252 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
