### PR TITLE
fix(errorHandling): readd error handling middleware

### DIFF
--- a/src/administration/Administration.Service/.config/dotnet-tools.json
+++ b/src/administration/Administration.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "6.8.0",
+      "version": "7.2.0",
       "commands": [
         "swagger"
       ],

--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/BaseHttpExceptionHandler.cs
+++ b/src/framework/Framework.ErrorHandling.Web/BaseHttpExceptionHandler.cs
@@ -1,0 +1,119 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Microsoft.Extensions.Logging;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Serilog.Context;
+using System.Collections.Immutable;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
+
+public class BaseHttpExceptionHandler(ILogger<BaseHttpExceptionHandler> logger, IErrorMessageService errorMessageService)
+{
+    protected static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
+    protected static readonly IReadOnlyDictionary<HttpStatusCode, MetaData> Metadata = ImmutableDictionary.CreateRange(new[]
+    {
+        KeyValuePair.Create(HttpStatusCode.BadRequest, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.1", "One or more validation errors occurred.")),
+        KeyValuePair.Create(HttpStatusCode.Conflict, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.8", "The resorce is in conflict with the current request.")),
+        KeyValuePair.Create(HttpStatusCode.NotFound, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4", "Cannot find representation of target resource.")),
+        KeyValuePair.Create(HttpStatusCode.Forbidden, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3", "Access to requested resource is not permitted.")),
+        KeyValuePair.Create(HttpStatusCode.UnsupportedMediaType, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13", "The server cannot process this type of content")),
+        KeyValuePair.Create(HttpStatusCode.BadGateway, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.3", "Error accessing external resource.")),
+        KeyValuePair.Create(HttpStatusCode.ServiceUnavailable, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.4", "Service is currently unavailable.")),
+        KeyValuePair.Create(HttpStatusCode.InternalServerError, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1", "The server encountered an unexpected condition.")),
+    });
+
+    protected static KeyValuePair<Type, (HttpStatusCode HttpStatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel)> CreateErrorEntry<T>(
+            HttpStatusCode httpStatusCode,
+            Func<T, (string?, IEnumerable<string>)>? messageFunc = null,
+            LogLevel logLevel = LogLevel.Information
+        ) where T : class =>
+            KeyValuePair.Create<Type, (HttpStatusCode, Func<Exception, (string?, IEnumerable<string>)>?, LogLevel)>(
+                typeof(T),
+                (httpStatusCode,
+                messageFunc == null
+                    ? null
+                    : e => messageFunc.Invoke(e as T ?? throw new UnexpectedConditionException($"Exception type {e.GetType()} should always be of type {typeof(T)} here")),
+                logLevel));
+
+    protected static readonly IReadOnlyDictionary<Type, (HttpStatusCode StatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel)> ErrorTypes = ImmutableDictionary.CreateRange(new[]
+    {
+        CreateErrorEntry<ArgumentException>(HttpStatusCode.BadRequest, argumentException => (argumentException.ParamName, Enumerable.Repeat(argumentException.Message, 1))),
+        CreateErrorEntry<ControllerArgumentException>(HttpStatusCode.BadRequest, caException => (caException.ParamName, Enumerable.Repeat(caException.Message, 1))),
+        CreateErrorEntry<NotFoundException>(HttpStatusCode.NotFound),
+        CreateErrorEntry<ConflictException>(HttpStatusCode.Conflict),
+        CreateErrorEntry<ForbiddenException>(HttpStatusCode.Forbidden),
+        CreateErrorEntry<ServiceException>(HttpStatusCode.BadGateway, serviceException => (serviceException.Source, new[] { serviceException.StatusCode == null ? "remote service call failed" : $"remote service returned status code: {(int)serviceException.StatusCode} {serviceException.StatusCode}", serviceException.Message })),
+        CreateErrorEntry<UnsupportedMediaTypeException>(HttpStatusCode.UnsupportedMediaType),
+        CreateErrorEntry<ConfigurationException>(HttpStatusCode.InternalServerError, configurationException => (configurationException.Source, new[] { $"Invalid service configuration: {configurationException.Message}" }))
+    });
+
+    protected static (HttpStatusCode StatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel) GetErrorInformation(Exception error) =>
+        ErrorTypes.TryGetValue(error.GetType(), out var mapping)
+            ? mapping
+            : (HttpStatusCode.InternalServerError, null, LogLevel.Error);
+
+    protected ErrorResponse CreateErrorResponse(HttpStatusCode statusCode, Exception error, string errorId, string message, IEnumerable<ErrorDetails>? details, Func<Exception, (string?, IEnumerable<string>)>? getSourceAndMessages)
+    {
+        var meta = Metadata.GetValueOrDefault(statusCode, Metadata[HttpStatusCode.InternalServerError]);
+        var (source, messages) = getSourceAndMessages?.Invoke(error) ?? (error.Source, Enumerable.Repeat(message, 1));
+
+        var messageMap = new Dictionary<string, IEnumerable<string>> { { source ?? "unknown", messages } };
+        while (error.InnerException != null)
+        {
+            error = error.InnerException;
+            source = error.Source ?? "inner";
+
+            messageMap[source] = messageMap.TryGetValue(source, out messages)
+                ? messages.Append(GetErrorMessage(error))
+                : Enumerable.Repeat(GetErrorMessage(error), 1);
+        }
+
+        return new ErrorResponse(
+            meta.Url,
+            meta.Description,
+            (int)statusCode,
+            messageMap,
+            errorId,
+            details
+        );
+    }
+
+    protected string GetErrorMessage(Exception exception) =>
+        exception is DetailException { HasDetails: true } detail
+            ? detail.GetErrorMessage(errorMessageService)
+            : exception.Message;
+
+    protected IEnumerable<ErrorDetails> GetErrorDetails(Exception exception) =>
+        exception is DetailException { HasDetails: true } detail
+            ? detail.GetErrorDetails(errorMessageService)
+            : Enumerable.Empty<ErrorDetails>();
+
+    protected static void LogErrorInformation(string errorId, Exception exception)
+    {
+        LogContext.PushProperty("ErrorId", errorId);
+        LogContext.PushProperty("StackTrace", exception.StackTrace);
+    }
+
+    protected sealed record MetaData(string Url, string Description);
+}

--- a/src/framework/Framework.ErrorHandling.Web/BaseHttpExceptionHandler.cs
+++ b/src/framework/Framework.ErrorHandling.Web/BaseHttpExceptionHandler.cs
@@ -27,21 +27,21 @@ using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 
-public class BaseHttpExceptionHandler(ILogger<BaseHttpExceptionHandler> logger, IErrorMessageService errorMessageService)
+public class BaseHttpExceptionHandler(IErrorMessageService errorMessageService)
 {
     protected static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
 
-    protected static readonly IReadOnlyDictionary<HttpStatusCode, MetaData> Metadata = ImmutableDictionary.CreateRange(new[]
-    {
-        KeyValuePair.Create(HttpStatusCode.BadRequest, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.1", "One or more validation errors occurred.")),
-        KeyValuePair.Create(HttpStatusCode.Conflict, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.8", "The resorce is in conflict with the current request.")),
-        KeyValuePair.Create(HttpStatusCode.NotFound, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4", "Cannot find representation of target resource.")),
-        KeyValuePair.Create(HttpStatusCode.Forbidden, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3", "Access to requested resource is not permitted.")),
-        KeyValuePair.Create(HttpStatusCode.UnsupportedMediaType, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13", "The server cannot process this type of content")),
-        KeyValuePair.Create(HttpStatusCode.BadGateway, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.3", "Error accessing external resource.")),
-        KeyValuePair.Create(HttpStatusCode.ServiceUnavailable, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.4", "Service is currently unavailable.")),
-        KeyValuePair.Create(HttpStatusCode.InternalServerError, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1", "The server encountered an unexpected condition.")),
-    });
+    protected static readonly IReadOnlyDictionary<HttpStatusCode, MetaData> Metadata = ImmutableDictionary.CreateRange<HttpStatusCode, MetaData>(
+    [
+        new(HttpStatusCode.BadRequest, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.1", "One or more validation errors occurred.")),
+        new(HttpStatusCode.Conflict, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.8", "The resorce is in conflict with the current request.")),
+        new(HttpStatusCode.NotFound, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4", "Cannot find representation of target resource.")),
+        new(HttpStatusCode.Forbidden, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3", "Access to requested resource is not permitted.")),
+        new(HttpStatusCode.UnsupportedMediaType, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13", "The server cannot process this type of content")),
+        new(HttpStatusCode.BadGateway, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.3", "Error accessing external resource.")),
+        new(HttpStatusCode.ServiceUnavailable, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.4", "Service is currently unavailable.")),
+        new(HttpStatusCode.InternalServerError, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1", "The server encountered an unexpected condition.")),
+    ]);
 
     protected static KeyValuePair<Type, (HttpStatusCode HttpStatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel)> CreateErrorEntry<T>(
             HttpStatusCode httpStatusCode,
@@ -56,8 +56,8 @@ public class BaseHttpExceptionHandler(ILogger<BaseHttpExceptionHandler> logger, 
                     : e => messageFunc.Invoke(e as T ?? throw new UnexpectedConditionException($"Exception type {e.GetType()} should always be of type {typeof(T)} here")),
                 logLevel));
 
-    protected static readonly IReadOnlyDictionary<Type, (HttpStatusCode StatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel)> ErrorTypes = ImmutableDictionary.CreateRange(new[]
-    {
+    protected static readonly IReadOnlyDictionary<Type, (HttpStatusCode StatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel)> ErrorTypes = ImmutableDictionary.CreateRange(
+    [
         CreateErrorEntry<ArgumentException>(HttpStatusCode.BadRequest, argumentException => (argumentException.ParamName, Enumerable.Repeat(argumentException.Message, 1))),
         CreateErrorEntry<ControllerArgumentException>(HttpStatusCode.BadRequest, caException => (caException.ParamName, Enumerable.Repeat(caException.Message, 1))),
         CreateErrorEntry<NotFoundException>(HttpStatusCode.NotFound),
@@ -66,7 +66,7 @@ public class BaseHttpExceptionHandler(ILogger<BaseHttpExceptionHandler> logger, 
         CreateErrorEntry<ServiceException>(HttpStatusCode.BadGateway, serviceException => (serviceException.Source, new[] { serviceException.StatusCode == null ? "remote service call failed" : $"remote service returned status code: {(int)serviceException.StatusCode} {serviceException.StatusCode}", serviceException.Message })),
         CreateErrorEntry<UnsupportedMediaTypeException>(HttpStatusCode.UnsupportedMediaType),
         CreateErrorEntry<ConfigurationException>(HttpStatusCode.InternalServerError, configurationException => (configurationException.Source, new[] { $"Invalid service configuration: {configurationException.Message}" }))
-    });
+    ]);
 
     protected static (HttpStatusCode StatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel) GetErrorInformation(Exception error) =>
         ErrorTypes.TryGetValue(error.GetType(), out var mapping)

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/GeneralHttpExceptionFilter.cs
+++ b/src/framework/Framework.ErrorHandling.Web/GeneralHttpExceptionFilter.cs
@@ -21,58 +21,15 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
-using Serilog.Context;
-using System.Collections.Immutable;
-using System.Net;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 
 public class GeneralHttpExceptionFilter(
     ILogger<GeneralHttpExceptionFilter> logger,
     IErrorMessageService errorMessageService)
-    : IExceptionFilter
+    : BaseHttpExceptionHandler(logger, errorMessageService), IExceptionFilter
 {
-    private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
-
-    private static readonly IReadOnlyDictionary<HttpStatusCode, MetaData> Metadata = ImmutableDictionary.CreateRange(new[]
-    {
-        KeyValuePair.Create(HttpStatusCode.BadRequest, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.1", "One or more validation errors occurred.")),
-        KeyValuePair.Create(HttpStatusCode.Conflict, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.8", "The resorce is in conflict with the current request.")),
-        KeyValuePair.Create(HttpStatusCode.NotFound, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4", "Cannot find representation of target resource.")),
-        KeyValuePair.Create(HttpStatusCode.Forbidden, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3", "Access to requested resource is not permitted.")),
-        KeyValuePair.Create(HttpStatusCode.UnsupportedMediaType, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13", "The server cannot process this type of content")),
-        KeyValuePair.Create(HttpStatusCode.BadGateway, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.3", "Error accessing external resource.")),
-        KeyValuePair.Create(HttpStatusCode.ServiceUnavailable, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.4", "Service is currently unavailable.")),
-        KeyValuePair.Create(HttpStatusCode.InternalServerError, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1", "The server encountered an unexpected condition.")),
-    });
-
-    private static KeyValuePair<Type, (HttpStatusCode HttpStatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel)> CreateErrorEntry<T>(
-            HttpStatusCode httpStatusCode,
-            Func<T, (string?, IEnumerable<string>)>? messageFunc = null,
-            LogLevel logLevel = LogLevel.Information
-        ) where T : class =>
-            KeyValuePair.Create<Type, (HttpStatusCode, Func<Exception, (string?, IEnumerable<string>)>?, LogLevel)>(
-                typeof(T),
-                (httpStatusCode,
-                messageFunc == null
-                    ? null
-                    : e => messageFunc.Invoke(e as T ?? throw new UnexpectedConditionException($"Exception type {e.GetType()} should always be of type {typeof(T)} here")),
-                logLevel));
-
-    private static readonly IReadOnlyDictionary<Type, (HttpStatusCode StatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel)> ErrorTypes = ImmutableDictionary.CreateRange(new[]
-    {
-        CreateErrorEntry<ArgumentException>(HttpStatusCode.BadRequest, argumentException => (argumentException.ParamName, Enumerable.Repeat(argumentException.Message, 1))),
-        CreateErrorEntry<ControllerArgumentException>(HttpStatusCode.BadRequest, caException => (caException.ParamName, Enumerable.Repeat(caException.Message, 1))),
-        CreateErrorEntry<NotFoundException>(HttpStatusCode.NotFound),
-        CreateErrorEntry<ConflictException>(HttpStatusCode.Conflict),
-        CreateErrorEntry<ForbiddenException>(HttpStatusCode.Forbidden),
-        CreateErrorEntry<ServiceException>(HttpStatusCode.BadGateway, serviceException => (serviceException.Source, new[] { serviceException.StatusCode == null ? "remote service call failed" : $"remote service returned status code: {(int)serviceException.StatusCode} {serviceException.StatusCode}", serviceException.Message })),
-        CreateErrorEntry<UnsupportedMediaTypeException>(HttpStatusCode.UnsupportedMediaType),
-        CreateErrorEntry<ConfigurationException>(HttpStatusCode.InternalServerError, configurationException => (configurationException.Source, new[] { $"Invalid service configuration: {configurationException.Message}" }))
-    });
-
     public void OnException(ExceptionContext context)
     {
         var errorId = Guid.NewGuid().ToString();
@@ -84,58 +41,8 @@ public class GeneralHttpExceptionFilter(
         logger.Log(logLevel, error, "GeneralErrorHandler caught {Error} with errorId: {ErrorId} resulting in response status code {StatusCode}, message '{Message}'", error.GetType().Name, errorId, (int)statusCode, message);
         context.Result = new ContentResult
         {
-            Content = JsonSerializer.Serialize(
-                CreateErrorResponse(statusCode, error, errorId, message, details, messageFunc), Options),
+            Content = JsonSerializer.Serialize(CreateErrorResponse(statusCode, error, errorId, message, details, messageFunc), Options),
             StatusCode = (int)statusCode
         };
     }
-
-    private static (HttpStatusCode StatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel) GetErrorInformation(Exception error) =>
-        ErrorTypes.TryGetValue(error.GetType(), out var mapping)
-            ? mapping
-            : (HttpStatusCode.InternalServerError, null, LogLevel.Error);
-
-    private ErrorResponse CreateErrorResponse(HttpStatusCode statusCode, Exception error, string errorId, string message, IEnumerable<ErrorDetails>? details, Func<Exception, (string?, IEnumerable<string>)>? getSourceAndMessages)
-    {
-        var meta = Metadata.GetValueOrDefault(statusCode, Metadata[HttpStatusCode.InternalServerError]);
-        var (source, messages) = getSourceAndMessages?.Invoke(error) ?? (error.Source, Enumerable.Repeat(message, 1));
-
-        var messageMap = new Dictionary<string, IEnumerable<string>> { { source ?? "unknown", messages } };
-        while (error.InnerException != null)
-        {
-            error = error.InnerException;
-            source = error.Source ?? "inner";
-
-            messageMap[source] = messageMap.TryGetValue(source, out messages)
-                ? messages.Append(GetErrorMessage(error))
-                : Enumerable.Repeat(GetErrorMessage(error), 1);
-        }
-
-        return new ErrorResponse(
-            meta.Url,
-            meta.Description,
-            (int)statusCode,
-            messageMap,
-            errorId,
-            details
-        );
-    }
-
-    private string GetErrorMessage(Exception exception) =>
-        exception is DetailException { HasDetails: true } detail
-            ? detail.GetErrorMessage(errorMessageService)
-            : exception.Message;
-
-    private IEnumerable<ErrorDetails> GetErrorDetails(Exception exception) =>
-        exception is DetailException { HasDetails: true } detail
-            ? detail.GetErrorDetails(errorMessageService)
-            : Enumerable.Empty<ErrorDetails>();
-
-    private static void LogErrorInformation(string errorId, Exception exception)
-    {
-        LogContext.PushProperty("ErrorId", errorId);
-        LogContext.PushProperty("StackTrace", exception.StackTrace);
-    }
-
-    private sealed record MetaData(string Url, string Description);
 }

--- a/src/framework/Framework.ErrorHandling.Web/GeneralHttpExceptionFilter.cs
+++ b/src/framework/Framework.ErrorHandling.Web/GeneralHttpExceptionFilter.cs
@@ -28,7 +28,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 public class GeneralHttpExceptionFilter(
     ILogger<GeneralHttpExceptionFilter> logger,
     IErrorMessageService errorMessageService)
-    : BaseHttpExceptionHandler(logger, errorMessageService), IExceptionFilter
+    : BaseHttpExceptionHandler(errorMessageService), IExceptionFilter
 {
     public void OnException(ExceptionContext context)
     {

--- a/src/framework/Framework.ErrorHandling.Web/GeneralHttpExceptionMiddleware.cs
+++ b/src/framework/Framework.ErrorHandling.Web/GeneralHttpExceptionMiddleware.cs
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using System.Text.Json;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
+
+public class GeneralHttpExceptionMiddleware(ILogger<GeneralHttpExceptionMiddleware> logger, IErrorMessageService errorMessageService) :
+    BaseHttpExceptionHandler(logger, errorMessageService), IMiddleware
+{
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        try
+        {
+            await next(context).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+        catch (Exception exception)
+        {
+            var errorId = Guid.NewGuid().ToString();
+            var details = GetErrorDetails(exception);
+            var message = GetErrorMessage(exception);
+            LogErrorInformation(errorId, exception);
+            var (statusCode, messageFunc, logLevel) = GetErrorInformation(exception);
+            logger.Log(logLevel, exception, "GeneralErrorHandler caught {Error} with errorId: {ErrorId} resulting in response status code {StatusCode}, message '{Message}'", exception.GetType().Name, errorId, (int)statusCode, message);
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = (int)statusCode;
+            await context.Response.WriteAsync(JsonSerializer.Serialize(CreateErrorResponse(statusCode, exception, errorId, message, details, messageFunc), Options)).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+    }
+}

--- a/src/framework/Framework.ErrorHandling.Web/GeneralHttpExceptionMiddleware.cs
+++ b/src/framework/Framework.ErrorHandling.Web/GeneralHttpExceptionMiddleware.cs
@@ -25,7 +25,7 @@ using System.Text.Json;
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 
 public class GeneralHttpExceptionMiddleware(ILogger<GeneralHttpExceptionMiddleware> logger, IErrorMessageService errorMessageService) :
-    BaseHttpExceptionHandler(logger, errorMessageService), IMiddleware
+    BaseHttpExceptionHandler(errorMessageService), IMiddleware
 {
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Service/IErrorMessageContainer.cs
+++ b/src/framework/Framework.ErrorHandling/Service/IErrorMessageContainer.cs
@@ -21,6 +21,6 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
 
 public interface IErrorMessageContainer
 {
-    public Type Type { get; }
-    public IReadOnlyDictionary<int, string> MessageContainer { get; }
+    Type Type { get; }
+    IReadOnlyDictionary<int, string> MessageContainer { get; }
 }

--- a/src/framework/Framework.ErrorHandling/Service/IErrorMessageService.cs
+++ b/src/framework/Framework.ErrorHandling/Service/IErrorMessageService.cs
@@ -21,8 +21,8 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
 
 public interface IErrorMessageService
 {
-    public string GetMessage(Type type, int code);
-    public IEnumerable<ErrorMessageType> GetAllMessageTexts();
-    public record ErrorMessageType(string ErrorType, IEnumerable<ErrorMessageCode> ErrorMessages);
-    public record ErrorMessageCode(string ErrorCode, string Message);
+    string GetMessage(Type type, int code);
+    IEnumerable<ErrorMessageType> GetAllMessageTexts();
+    record ErrorMessageType(string ErrorType, IEnumerable<ErrorMessageCode> ErrorMessages);
+    record ErrorMessageCode(string ErrorCode, string Message);
 }

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Identity/Directory.Build.props
+++ b/src/framework/Framework.Identity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
+++ b/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/IProcessIdentityDataDetermination.cs
+++ b/src/framework/Framework.Processes.ProcessIdentity/IProcessIdentityDataDetermination.cs
@@ -24,5 +24,5 @@ public interface IProcessIdentityDataDetermination
     /// <summary>
     /// Initialize IdentityData
     /// </summary>
-    public Task GetIdentityData();
+    Task GetIdentityData();
 }

--- a/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/keycloak/Keycloak.Seeding/BusinessLogic/IRealmUpdater.cs
+++ b/src/keycloak/Keycloak.Seeding/BusinessLogic/IRealmUpdater.cs
@@ -21,5 +21,5 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Keycloak.Seeding.BusinessLogic;
 
 public interface IRealmUpdater
 {
-    public Task UpdateRealm(string keycloakInstanceName, CancellationToken cancellationToken);
+    Task UpdateRealm(string keycloakInstanceName, CancellationToken cancellationToken);
 }

--- a/src/marketplace/Apps.Service/.config/dotnet-tools.json
+++ b/src/marketplace/Apps.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "6.8.0",
+      "version": "7.2.0",
       "commands": [
         "swagger"
       ],

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppChangeBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppChangeBusinessLogic.cs
@@ -62,7 +62,7 @@ public interface IAppChangeBusinessLogic
     /// Deactivate Offer Status by appId
     /// </summary>
     /// <param name="appId">Id of the app</param>
-    public Task DeactivateOfferByAppIdAsync(Guid appId);
+    Task DeactivateOfferByAppIdAsync(Guid appId);
 
     /// <summary>
     /// Updates the url of the subscription

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -36,13 +36,13 @@ public interface IAppsBusinessLogic
     /// </summary>
     /// <param name="languageShortName">Optional two character language specifier for the app description. No description if not provided.</param>
     /// <returns>List of active marketplace apps.</returns>
-    public IAsyncEnumerable<AppData> GetAllActiveAppsAsync(string? languageShortName);
+    IAsyncEnumerable<AppData> GetAllActiveAppsAsync(string? languageShortName);
 
     /// <summary>
     /// Get all apps that a user has been assigned roles in.
     /// </summary>
     /// <returns>List of available apps for user.</returns>
-    public IAsyncEnumerable<BusinessAppData> GetAllUserUserBusinessAppsAsync();
+    IAsyncEnumerable<BusinessAppData> GetAllUserUserBusinessAppsAsync();
 
     /// <summary>
     /// Get detailed application data for a single app by id.
@@ -50,25 +50,25 @@ public interface IAppsBusinessLogic
     /// <param name="appId">Persistence ID of the application to be retrieved.</param>
     /// <param name="languageShortName">Optional two character language specifier for the localization of the app description. No description if not provided.</param>
     /// <returns>AppDetailsViewModel of the requested application.</returns>
-    public Task<AppDetailResponse> GetAppDetailsByIdAsync(Guid appId, string? languageShortName = null);
+    Task<AppDetailResponse> GetAppDetailsByIdAsync(Guid appId, string? languageShortName = null);
 
     /// <summary>
     /// Get IDs of all favourite apps of the user by ID.
     /// </summary>
     /// <returns>List of IDs of user's favourite apps.</returns>
-    public IAsyncEnumerable<Guid> GetAllFavouriteAppsForUserAsync();
+    IAsyncEnumerable<Guid> GetAllFavouriteAppsForUserAsync();
 
     /// <summary>
     /// Adds an app to a user's favourites.
     /// </summary>
     /// <param name="appId">ID of the app to add to user's favourites.</param>
-    public Task AddFavouriteAppForUserAsync(Guid appId);
+    Task AddFavouriteAppForUserAsync(Guid appId);
 
     /// <summary>
     /// Removes an app from a user's favourites.
     /// </summary>
     /// <param name="appId">ID of the app to remove from user's favourites.</param>
-    public Task RemoveFavouriteAppForUserAsync(Guid appId);
+    Task RemoveFavouriteAppForUserAsync(Guid appId);
 
     /// <summary>
     /// Retrieves subscription statuses of subscribed apps of the provided user's company.
@@ -78,7 +78,7 @@ public interface IAppsBusinessLogic
     /// <param name="statusId"></param>
     /// <param name="name"></param>
     /// <returns>Returns the details of the subscription status for App user</returns>
-    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId, string? name);
+    Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, OfferSubscriptionStatusId? statusId, string? name);
 
     /// <summary>
     /// Retrieves subscription statuses of provided apps of the provided user's company.
@@ -90,32 +90,32 @@ public interface IAppsBusinessLogic
     /// <param name="offerId"></param>
     /// <param name="companyName"></param>
     /// <returns>Async enumberable of user's company's provided apps' statuses.</returns>
-    public Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName);
+    Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId, string? companyName);
 
     /// <summary>
     /// Adds a subscription relation between an application and a user's company.
     /// </summary>
     /// <param name="appId">ID of the app to subscribe to.</param>
     /// <param name="offerAgreementConsentData">The agreement consent data</param>
-    public Task<Guid> AddOwnCompanyAppSubscriptionAsync(Guid appId, IEnumerable<OfferAgreementConsentData> offerAgreementConsentData);
+    Task<Guid> AddOwnCompanyAppSubscriptionAsync(Guid appId, IEnumerable<OfferAgreementConsentData> offerAgreementConsentData);
 
     /// <summary>
     /// Declines a pending app subscription of an app, provided by the current user's company.
     /// </summary>
     /// <param name="subscriptionId">ID of the pending app to be declined.</param>
-    public Task DeclineAppSubscriptionAsync(Guid subscriptionId);
+    Task DeclineAppSubscriptionAsync(Guid subscriptionId);
 
     /// <summary>
     /// Activates a pending app subscription for an app provided by the current user's company.
     /// </summary>
     /// <param name="subscriptionId">ID of the pending app to be activated.</param>
-    public Task TriggerActivateOfferSubscription(Guid subscriptionId);
+     Task TriggerActivateOfferSubscription(Guid subscriptionId);
 
     /// <summary>
     /// Unsubscribes an app for the current users company.
     /// </summary>
     /// <param name="subscriptionId">ID of the subscription to unsubscribe from.</param>
-    public Task UnsubscribeOwnCompanyAppSubscriptionAsync(Guid subscriptionId);
+    Task UnsubscribeOwnCompanyAppSubscriptionAsync(Guid subscriptionId);
 
     /// <summary>
     /// Retrieve Company Owned App Data

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -104,12 +104,11 @@ public interface IAppsBusinessLogic
     /// </summary>
     /// <param name="subscriptionId">ID of the pending app to be declined.</param>
     Task DeclineAppSubscriptionAsync(Guid subscriptionId);
-
     /// <summary>
     /// Activates a pending app subscription for an app provided by the current user's company.
     /// </summary>
     /// <param name="subscriptionId">ID of the pending app to be activated.</param>
-     Task TriggerActivateOfferSubscription(Guid subscriptionId);
+    Task TriggerActivateOfferSubscription(Guid subscriptionId);
 
     /// <summary>
     /// Unsubscribes an app for the current users company.

--- a/src/marketplace/Services.Service/.config/dotnet-tools.json
+++ b/src/marketplace/Services.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "6.8.0",
+      "version": "7.2.0",
       "commands": [
         "swagger"
       ],

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
@@ -48,7 +48,7 @@ public interface IServiceBusinessLogic
     /// Declines a pending service subscription of a service, provided by the current user's company.
     /// </summary>
     /// <param name="subscriptionId">ID of the pending service to be declined.</param>
-    public Task DeclineServiceSubscriptionAsync(Guid subscriptionId);
+    Task DeclineServiceSubscriptionAsync(Guid subscriptionId);
 
     /// <summary>
     /// Gets the service detail data for the given service
@@ -154,12 +154,11 @@ public interface IServiceBusinessLogic
     /// Unsubscribes an Service for the current users company.
     /// </summary>
     /// <param name="subscriptionId">ID of the subscription to unsubscribe from.</param>
-    public Task UnsubscribeOwnCompanyServiceSubscriptionAsync(Guid subscriptionId);
+    Task UnsubscribeOwnCompanyServiceSubscriptionAsync(Guid subscriptionId);
 
     /// <summary>
     /// Activates a pending service subscription for an service provided by the current user's company.
     /// </summary>
     /// <param name="subscriptionId">ID of the pending service to be activated.</param>
-    public Task TriggerActivateOfferSubscription(Guid subscriptionId);
-
+    Task TriggerActivateOfferSubscription(Guid subscriptionId);
 }

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceChangeBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceChangeBusinessLogic.cs
@@ -29,5 +29,5 @@ public interface IServiceChangeBusinessLogic
     /// Deactivate Offer Status by serviceId
     /// </summary>
     /// <param name="serviceId">Id of the service</param>
-    public Task DeactivateOfferByServiceIdAsync(Guid serviceId);
+    Task DeactivateOfferByServiceIdAsync(Guid serviceId);
 }

--- a/src/notifications/Notifications.Service/.config/dotnet-tools.json
+++ b/src/notifications/Notifications.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "6.8.0",
+      "version": "7.2.0",
       "commands": [
         "swagger"
       ],

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
@@ -44,7 +44,7 @@ public interface IConnectorsRepository
     /// <returns>Pagination.Source of connectors that allows transformation.</returns>
     Func<int, int, Task<Pagination.Source<ManagedConnectorData>?>> GetManagedConnectorsForCompany(Guid companyId);
 
-    public Task<(ConnectorData ConnectorData, bool IsProvidingOrHostCompany)> GetConnectorByIdForCompany(Guid connectorId, Guid companyId);
+    Task<(ConnectorData ConnectorData, bool IsProvidingOrHostCompany)> GetConnectorByIdForCompany(Guid connectorId, Guid companyId);
 
     Task<(ConnectorInformationData ConnectorInformationData, bool IsProviderUser)> GetConnectorInformationByIdForIamUser(Guid connectorId, Guid userCompanyId);
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IInvitationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IInvitationRepository.cs
@@ -24,7 +24,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositorie
 
 public interface IInvitationRepository
 {
-    public IAsyncEnumerable<(InvitationStatusId InvitationStatus, string? EmailId, IEnumerable<string> Roles)> GetInvitedUserDetailsUntrackedAsync(Guid applicationId);
+    IAsyncEnumerable<(InvitationStatusId InvitationStatus, string? EmailId, IEnumerable<string> Roles)> GetInvitedUserDetailsUntrackedAsync(Guid applicationId);
     Task<Invitation?> GetInvitationStatusAsync(Guid companyUserId);
     void AttachAndModifyInvitations(IEnumerable<(Guid InvitationId, Action<Invitation>? Initialize, Action<Invitation> Modify)> invitations);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferRepository.cs
@@ -35,7 +35,7 @@ public interface IOfferRepository
     /// <param name="offerId">ID of the app.</param>
     /// <param name="offerTypeId">Id of the offer type.</param>
     /// <returns>Tuple of provider company details.</returns>
-    public Task<OfferProviderDetailsData?> GetOfferProviderDetailsAsync(Guid offerId, OfferTypeId offerTypeId);
+    Task<OfferProviderDetailsData?> GetOfferProviderDetailsAsync(Guid offerId, OfferTypeId offerTypeId);
 
     /// <summary>
     /// Adds an app to the database
@@ -490,5 +490,5 @@ public interface IOfferRepository
     /// <param name="offerTypeId"></param>
     /// <param name="documentId"></param>
     /// <returns></returns>
-    public Task<(bool IsStatusActive, bool IsUserOfProvider, DocumentTypeId DocumentTypeId, DocumentStatusId DocumentStatusId)> GetOfferAssignedAppDocumentsByIdAsync(Guid offerId, Guid userCompanyId, OfferTypeId offerTypeId, Guid documentId);
+    Task<(bool IsStatusActive, bool IsUserOfProvider, DocumentTypeId DocumentTypeId, DocumentStatusId DocumentStatusId)> GetOfferAssignedAppDocumentsByIdAsync(Guid offerId, Guid userCompanyId, OfferTypeId offerTypeId, Guid documentId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -73,7 +73,7 @@ public interface IOfferSubscriptionsRepository
     /// <returns>Returns the offer details.</returns>
     Task<OfferSubscriptionTransferData?> GetOfferDetailsAndCheckProviderCompany(Guid offerSubscriptionId, Guid providerCompanyId, OfferTypeId offerTypeId);
 
-    public Task<bool> CheckPendingOrActiveSubscriptionExists(Guid offerId, Guid companyId, OfferTypeId offerTypeId);
+    Task<bool> CheckPendingOrActiveSubscriptionExists(Guid offerId, Guid companyId, OfferTypeId offerTypeId);
 
     OfferSubscription AttachAndModifyOfferSubscription(Guid offerSubscriptionId, Action<OfferSubscription> setOptionalParameters);
 

--- a/src/registration/Registration.Service/.config/dotnet-tools.json
+++ b/src/registration/Registration.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "6.8.0",
+      "version": "7.2.0",
       "commands": [
         "swagger"
       ],

--- a/tests/framework/Framework.ErrorHandling.Web.Tests/GeneralHttpExceptionMiddlewareTests.cs
+++ b/tests/framework/Framework.ErrorHandling.Web.Tests/GeneralHttpExceptionMiddlewareTests.cs
@@ -1,0 +1,277 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using AutoFixture;
+using AutoFixture.AutoFakeItEasy;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Tests.Shared;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web.Tests;
+
+public class GeneralHttpExceptionMiddlewareTests
+{
+    private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+    private readonly IMockLogger<GeneralHttpExceptionMiddleware> _mockLogger;
+    private readonly GeneralHttpExceptionMiddleware _generalHttpErrorHandler;
+
+    public GeneralHttpExceptionMiddlewareTests()
+    {
+        var fixture = new Fixture().Customize(new AutoFakeItEasyCustomization { ConfigureMembers = true });
+        fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
+            .ForEach(b => fixture.Behaviors.Remove(b));
+        fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+        _mockLogger = A.Fake<IMockLogger<GeneralHttpExceptionMiddleware>>();
+        var logger = new MockLogger<GeneralHttpExceptionMiddleware>(_mockLogger);
+
+        var errorMessageService = A.Fake<IErrorMessageService>();
+        A.CallTo(() => errorMessageService.GetMessage(A<Type>._, A<int>._))
+            .ReturnsLazily((Type type, int code) => $"type: {type.Name} code: {code} first: {{first}} second: {{second}}");
+
+        _generalHttpErrorHandler = new GeneralHttpExceptionMiddleware(logger, errorMessageService);
+    }
+
+    [Fact]
+    public async Task Invoke_WithArgumentException_ContentStatusCodeIs400()
+    {
+        // Arrange
+        var expectedException = new ArgumentException("That's a test");
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Invoke_WithForbiddenException_ContentStatusCodeIs403()
+    {
+        // Arrange
+        var expectedException = new ForbiddenException("That's a test");
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Invoke_WithNotFoundException_ContentStatusCodeIs404()
+    {
+        // Arrange
+        var expectedException = new NotFoundException("That's a test");
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Invoke_WithUnsupportedMediaTypeException_ContentStatusCodeIs415()
+    {
+        // Arrange
+        var expectedException = new UnsupportedMediaTypeException("That's a test");
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.UnsupportedMediaType);
+    }
+
+    [Fact]
+    public async Task Invoke_WithConflictException_ContentStatus409()
+    {
+        // Arrange
+        var expectedException = new ConflictException("That's a test");
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Invoke_WithServiceException_ContentStatusCodeIs502()
+    {
+        // Arrange
+        var expectedException = new ServiceException("That's a test");
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.BadGateway);
+    }
+
+    [Fact]
+    public async Task Invoke_WithConfigurationException_ContentStatusCodeIs500()
+    {
+        // Arrange
+        var expectedException = new ConfigurationException("That's a test");
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.InternalServerError);
+    }
+
+    [Fact]
+    public async Task Invoke_WithControllerArgumentException_ContentStatusCodeIs400()
+    {
+        // Arrange
+        var expectedException = new ControllerArgumentException("That's a test", "testParam");
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Invoke_WithUnhandledSpecificException_ContentStatusCodeIs500()
+    {
+        // Arrange
+        var expectedException = new AggregateException("That's a test");
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.InternalServerError);
+    }
+
+    [Fact]
+    public async Task Invoke_WithDetailedException()
+    {
+        // Arrange
+        var expectedException = ConflictException.Create(TestErrors.FIRST_ERROR, new ErrorParameter[] { new("first", "foo"), new("second", "bar") });
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        using var body = new MemoryStream();
+        var httpContext = new DefaultHttpContext { Response = { Body = body } };
+
+        var mockLogger = A.Fake<IMockLogger<GeneralHttpExceptionMiddleware>>();
+        var logger = new MockLogger<GeneralHttpExceptionMiddleware>(mockLogger);
+
+        var errorMessageService = A.Fake<IErrorMessageService>();
+        A.CallTo(() => errorMessageService.GetMessage(A<Type>._, A<int>._))
+            .ReturnsLazily((Type type, int code) => $"type: {type.Name} code: {code} first: {{first}} second: {{second}}");
+
+        var generalHttpErrorHandler = new GeneralHttpExceptionMiddleware(logger, errorMessageService);
+
+        // Act
+        await generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.Conflict);
+        A.CallTo(() => mockLogger.Log(
+                A<LogLevel>.That.IsEqualTo(LogLevel.Information),
+                expectedException,
+                A<string>.That.Matches(x =>
+                    x.StartsWith("GeneralErrorHandler caught ConflictException with errorId:") &&
+                    x.EndsWith("resulting in response status code 409, message 'type: TestErrors code: 1 first: foo second: bar'"))))
+            .MustHaveHappenedOnceExactly();
+
+        body.Position = 0;
+        var errorResponse = JsonSerializer.Deserialize<ErrorResponse>(body, Options);
+        errorResponse.Should().NotBeNull().And.BeOfType<ErrorResponse>().Which.Details.Should().ContainSingle().Which.Should().Match<ErrorDetails>(x =>
+            x.Type == "TestErrors" &&
+            x.ErrorCode == "FIRST_ERROR" &&
+            x.Message == "type: TestErrors code: 1 first: {first} second: {second}" &&
+            x.Parameters.Count() == 2 &&
+            x.Parameters.First(p => p.Name == "first").Value == "foo" &&
+            x.Parameters.First(p => p.Name == "second").Value == "bar");
+    }
+
+    [Fact]
+    public async Task Invoke_WithInnerException()
+    {
+        // Arrange
+        var expectedException = ServiceException.Create(TestErrors.FIRST_ERROR, new ErrorParameter[] { new("first", "foo"), new("second", "bar") }, new ForbiddenException("You don't have access to this resource", new UnauthorizedAccessException("No access")));
+        Task MockNextMiddleware(HttpContext _) => Task.FromException(expectedException);
+        using var body = new MemoryStream();
+        var httpContext = new DefaultHttpContext { Response = { Body = body } };
+
+        // Act
+        await _generalHttpErrorHandler.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.BadGateway);
+        A.CallTo(() => _mockLogger.Log(
+                A<LogLevel>.That.IsEqualTo(LogLevel.Information),
+                expectedException,
+                A<string>.That.Matches(x =>
+                    x.StartsWith("GeneralErrorHandler caught ServiceException with errorId:") &&
+                    x.EndsWith("resulting in response status code 502, message 'type: TestErrors code: 1 first: foo second: bar'"))))
+            .MustHaveHappenedOnceExactly();
+
+        body.Position = 0;
+        var errorResponse = JsonSerializer.Deserialize<ErrorResponse>(body, Options);
+        errorResponse.Should().NotBeNull().And.BeOfType<ErrorResponse>();
+        errorResponse!.Errors.Should().HaveCount(2).And.Satisfy(
+            x => x.Key == "System.Private.CoreLib",
+            x => x.Key == "inner");
+        errorResponse.Details.Should().ContainSingle().Which.Should().Match<ErrorDetails>(x =>
+            x.Type == "TestErrors" &&
+            x.ErrorCode == "FIRST_ERROR" &&
+            x.Message == "type: TestErrors code: 1 first: {first} second: {second}" &&
+            x.Parameters.Count() == 2 &&
+            x.Parameters.First(p => p.Name == "first").Value == "foo" &&
+            x.Parameters.First(p => p.Name == "second").Value == "bar");
+    }
+
+    private enum TestErrors
+    {
+        FIRST_ERROR = 1,
+        SECOND_ERROR = 2
+    }
+}


### PR DESCRIPTION
## Description

Readd the error handling middleware for minimal apis

## Why

minimal apis don't work with the `IExceptionFilter` therefor the middleware has been readied

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
