### PR TITLE
feat(SD Factory): Integrate the Tagus for SD Factory

### DIFF
--- a/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
+++ b/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
@@ -93,16 +93,21 @@ public class SdFactoryBusinessLogic(
             throw new ConflictException($"CompanyApplication {applicationId} is not in status SUBMITTED");
         }
 
-        var (companyId, businessPartnerNumber, countryCode, uniqueIdentifiers) = result;
+        var (companyId, legalName, businessPartnerNumber, countryCode, region, uniqueIdentifiers) = result;
 
         if (string.IsNullOrWhiteSpace(businessPartnerNumber))
         {
             throw new ConflictException(
                 $"BusinessPartnerNumber (bpn) for CompanyApplications {applicationId} company {companyId} is empty");
         }
+        if (string.IsNullOrWhiteSpace(countryCode) || string.IsNullOrWhiteSpace(region))
+        {
+            throw new ConflictException(
+                $"CountryCode or Region for CompanyApplications {applicationId} and Company {companyId} is empty. Expected value: DE-NW and Current value: {countryCode}-{region}");
+        }
 
         await sdFactoryService
-            .RegisterSelfDescriptionAsync(applicationId, uniqueIdentifiers, countryCode, businessPartnerNumber, cancellationToken)
+            .RegisterSelfDescriptionAsync(applicationId, legalName, uniqueIdentifiers, countryCode, region, businessPartnerNumber, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);
     }
 

--- a/src/externalsystems/SdFactory.Library/ISdFactoryService.cs
+++ b/src/externalsystems/SdFactory.Library/ISdFactoryService.cs
@@ -38,5 +38,5 @@ public interface ISdFactoryService
     /// <exception cref="ServiceException">throws an exception if the service call wasn't successfully</exception>
     Task RegisterConnectorAsync(Guid connectorId, string selfDescriptionDocumentUrl, string businessPartnerNumber, CancellationToken cancellationToken);
 
-    Task RegisterSelfDescriptionAsync(Guid externalId, IEnumerable<(UniqueIdentifierId Id, string Value)> uniqueIdentifiers, string countryCode, string businessPartnerNumber, CancellationToken cancellationToken);
+    Task RegisterSelfDescriptionAsync(Guid externalId, string legalName, IEnumerable<(UniqueIdentifierId Id, string Value)> uniqueIdentifiers, string countryCode, string region, string businessPartnerNumber, CancellationToken cancellationToken);
 }

--- a/src/externalsystems/SdFactory.Library/Models/SdFactoryRequestModel.cs
+++ b/src/externalsystems/SdFactory.Library/Models/SdFactoryRequestModel.cs
@@ -28,13 +28,12 @@ namespace Org.Eclipse.TractusX.Portal.Backend.SdFactory.Library.Models;
 /// </summary>
 public record SdFactoryRequestModel(
     [property: JsonPropertyName("externalId")] string ExternalId,
+    [property: JsonPropertyName("name")] string LegalName,
     [property: JsonPropertyName("registrationNumber")] IEnumerable<RegistrationNumber> RegistrationNumber,
-    [property: JsonPropertyName("headquarterAddress.country")] string HeadquarterCountry,
-    [property: JsonPropertyName("legalAddress.country")] string LegalCountry,
+    [property: JsonPropertyName("headquarterAddress.countrySubdivisionCode")] string HeadquarterCountrySubdivisionCode,
+    [property: JsonPropertyName("legalAddress.countrySubdivisionCode")] string LegalCountrySubdivisionCode,
     [property: JsonPropertyName("type"), JsonConverter(typeof(JsonStringEnumConverter))] SdFactoryRequestModelSdType Type,
-    [property: JsonPropertyName("bpn")] string Bpn,
-    [property: JsonPropertyName("holder")] string Holder,
-    [property: JsonPropertyName("issuer")] string Issuer);
+    [property: JsonPropertyName("holder")] string Holder);
 
 public record RegistrationNumber(
     [property: JsonPropertyName("type")] string Type,

--- a/src/externalsystems/SdFactory.Library/SdFactoryService.cs
+++ b/src/externalsystems/SdFactory.Library/SdFactoryService.cs
@@ -54,19 +54,19 @@ public class SdFactoryService(ITokenService tokenService, IOptions<SdFactorySett
     }
 
     /// <inheritdoc />
-    public async Task RegisterSelfDescriptionAsync(Guid externalId, IEnumerable<(UniqueIdentifierId Id, string Value)> uniqueIdentifiers, string countryCode, string businessPartnerNumber, CancellationToken cancellationToken)
+    public async Task RegisterSelfDescriptionAsync(Guid externalId, string legalName, IEnumerable<(UniqueIdentifierId Id, string Value)> uniqueIdentifiers, string countryCode, string region, string businessPartnerNumber, CancellationToken cancellationToken)
     {
         var httpClient = await tokenService.GetAuthorizedClient<SdFactoryService>(_settings, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);
+        var countrySubdivisionCode = string.Format("{0}-{1}", countryCode, region);
         var requestModel = new SdFactoryRequestModel(
             externalId.ToString(),
+            legalName,
             uniqueIdentifiers.Select(x => new RegistrationNumber(x.Id.GetSdUniqueIdentifierValue(), x.Value)),
-            countryCode,
-            countryCode,
+            countrySubdivisionCode,
+            countrySubdivisionCode,
             SdFactoryRequestModelSdType.LegalParticipant,
-            businessPartnerNumber,
-            businessPartnerNumber,
-            _settings.SdFactoryIssuerBpn);
+            businessPartnerNumber);
 
         await httpClient.PostAsJsonAsync(default(string?), requestModel, cancellationToken)
             .CatchingIntoServiceExceptionFor("sd-factory-selfdescription-post", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -227,14 +227,16 @@ public class ApplicationRepository(PortalDbContext portalDbContext)
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public Task<(Guid CompanyId, string? BusinessPartnerNumber, string Alpha2Code, IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers)> GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(Guid applicationId) =>
+    public Task<(Guid CompanyId, string legalName, string? BusinessPartnerNumber, string? Alpha2Code, string? Region, IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers)> GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(Guid applicationId) =>
         portalDbContext.CompanyApplications.Where(companyApplication =>
                 companyApplication.Id == applicationId &&
                 companyApplication.ApplicationStatusId == CompanyApplicationStatusId.SUBMITTED)
-            .Select(ca => new ValueTuple<Guid, string?, string, IEnumerable<(UniqueIdentifierId Id, string Value)>>(
+            .Select(ca => new ValueTuple<Guid, string, string?, string?, string?, IEnumerable<(UniqueIdentifierId Id, string Value)>>(
                 ca.CompanyId,
+                ca.Company!.Name,
                 ca.Company!.BusinessPartnerNumber,
                 ca.Company.Address!.Country!.Alpha2Code,
+                ca.Company.Address!.Region,
                 ca.Company.CompanyIdentifiers.Select(x => new ValueTuple<UniqueIdentifierId, string>(x.UniqueIdentifierId, x.Value))))
             .SingleOrDefaultAsync();
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -455,14 +455,16 @@ public class CompanyRepository(PortalDbContext context) : ICompanyRepository
             .Select(c => c.Id)
             .ToAsyncEnumerable();
 
-    public Task<(Guid Id, IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers, string? BusinessPartnerNumber, string CountryCode)> GetCompanyByProcessId(Guid processId) =>
+    public Task<(Guid Id, string LegalName, IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers, string? BusinessPartnerNumber, string? CountryCode, string? Region)> GetCompanyByProcessId(Guid processId) =>
         context.Companies
             .Where(c => c.SdCreationProcessId == processId)
-            .Select(c => new ValueTuple<Guid, IEnumerable<(UniqueIdentifierId Id, string Value)>, string?, string>(
+            .Select(c => new ValueTuple<Guid, string, IEnumerable<(UniqueIdentifierId Id, string Value)>, string?, string?, string?>(
                 c.Id,
+                c.Name,
                 c.CompanyIdentifiers.Select(ci => new ValueTuple<UniqueIdentifierId, string>(ci.UniqueIdentifierId, ci.Value)),
                 c.BusinessPartnerNumber,
-                c.Address!.Country!.Alpha2Code
+                c.Address!.Country!.Alpha2Code,
+                c.Address!.Region
             ))
             .SingleOrDefaultAsync();
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -48,7 +48,7 @@ public interface IApplicationRepository
     Task<(bool IsValidApplicationId, bool IsValidCompany, RegistrationData? Data)> GetRegistrationDataUntrackedAsync(Guid applicationId, Guid userCompanyId, IEnumerable<DocumentTypeId> documentTypes);
     Task<(string? Bpn, IEnumerable<ApplicationChecklistEntryTypeId> ExistingChecklistEntryTypeIds)> GetBpnAndChecklistCheckForApplicationIdAsync(Guid applicationId);
 
-    Task<(Guid CompanyId, string? BusinessPartnerNumber, string Alpha2Code, IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers)> GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(Guid applicationId);
+    Task<(Guid CompanyId, string legalName, string? BusinessPartnerNumber, string? Alpha2Code, string? Region, IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers)> GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(Guid applicationId);
 
     /// <summary>
     /// Gets the application status and the status of the application checklist entry of the given type

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -181,7 +181,7 @@ public interface ICompanyRepository
     void RemoveProviderCompanyDetails(Guid providerCompanyDetailId);
     Func<int, int, Task<Pagination.Source<CompanyMissingSdDocumentData>?>> GetCompaniesWithMissingSdDocument();
     IAsyncEnumerable<Guid> GetCompanyIdsWithMissingSelfDescription();
-    Task<(Guid Id, IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers, string? BusinessPartnerNumber, string CountryCode)> GetCompanyByProcessId(Guid processId);
+    Task<(Guid Id, string LegalName, IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers, string? BusinessPartnerNumber, string? CountryCode, string? Region)> GetCompanyByProcessId(Guid processId);
     Task<bool> IsExistingCompany(Guid companyId);
     Task<(bool Exists, Guid CompanyId, IEnumerable<Guid> SubmittedCompanyApplicationId)> GetCompanyIdByBpn(string bpn);
     Task<VerifyProcessData<ProcessTypeId, ProcessStepTypeId>?> GetSelfDescriptionProcessDataForCompanyId(Guid companyId);

--- a/tests/endtoend/InterfacePartnerHealthCheck/SdFactoryEndPointTests.cs
+++ b/tests/endtoend/InterfacePartnerHealthCheck/SdFactoryEndPointTests.cs
@@ -52,13 +52,12 @@ public class SdFactoryEndpointTests : EndToEndTestBase
         var body = DataHandleHelper.SerializeData(
             new SdFactoryRequestModel(
                 "TestAutomation",
+                "Legal Participant Company Name",
                 new List<RegistrationNumber> { new("local", "o12345678") },
-                "DE",
-                "DE",
+                "DE-NW",
+                "DE-NW",
                 SdFactoryRequestModelSdType.LegalParticipant,
-                "BPNL000000000000",
-                "BPNL000000000000",
-                "CAXSDUMMYCATENAZZ"
+                "BPNL000000000000"
             )
         );
 

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
@@ -42,6 +42,8 @@ public class SdFactoryBusinessLogicTests
     #region Initialization
 
     private const string CountryCode = "DE";
+    private const string Region = "NW";
+    private const string LegalName = "Legal Participant Company Name";
     private const string Bpn = "BPNL000000000009";
     private static readonly Guid ApplicationId = new("ac1cf001-7fbc-1f2f-817f-bce058020001");
     private readonly Process _process;
@@ -136,7 +138,7 @@ public class SdFactoryBusinessLogicTests
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(ApplicationId, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
         var entry = new ApplicationChecklistEntry(Guid.NewGuid(), ApplicationChecklistEntryTypeId.SELF_DESCRIPTION_LP, ApplicationChecklistEntryStatusId.TO_DO, DateTimeOffset.UtcNow);
         A.CallTo(() => _applicationRepository.GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(ApplicationId))
-            .Returns((CompanyId, Bpn, CountryCode, UniqueIdentifiers));
+            .Returns((CompanyId, LegalName, Bpn, CountryCode, Region, UniqueIdentifiers));
         var sut = new SdFactoryBusinessLogic(_service, _portalRepositories, _checklistService, Options.Create(new SdFactorySettings
         {
             SdFactoryUrl = "https://www.api.sdfactory.com",
@@ -148,7 +150,7 @@ public class SdFactoryBusinessLogicTests
         var result = await sut.StartSelfDescriptionRegistration(context, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _service.RegisterSelfDescriptionAsync(ApplicationId, UniqueIdentifiers, CountryCode, Bpn, A<CancellationToken>._))
+        A.CallTo(() => _service.RegisterSelfDescriptionAsync(ApplicationId, LegalName, UniqueIdentifiers, CountryCode, Region, Bpn, A<CancellationToken>._))
             .MustHaveHappened(clearinghouseConnectDisabled ? 0 : 1, Times.Exactly);
         result.Should().NotBeNull();
         result.ModifyChecklistEntry.Should().NotBeNull();
@@ -174,7 +176,7 @@ public class SdFactoryBusinessLogicTests
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(ApplicationId, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
         A.CallTo(() => _applicationRepository.GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(ApplicationId))
-            .Returns<(Guid, string?, string, IEnumerable<(UniqueIdentifierId, string)>)>(default);
+            .Returns<(Guid, string, string?, string?, string?, IEnumerable<(UniqueIdentifierId, string)>)>(default);
 
         // Act
         async Task Act() => await _sut.StartSelfDescriptionRegistration(context, CancellationToken.None);
@@ -182,7 +184,7 @@ public class SdFactoryBusinessLogicTests
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
         ex.Message.Should().Be($"CompanyApplication {ApplicationId} is not in status SUBMITTED");
-        A.CallTo(() => _service.RegisterSelfDescriptionAsync(ApplicationId, UniqueIdentifiers, CountryCode, Bpn, A<CancellationToken>._))
+        A.CallTo(() => _service.RegisterSelfDescriptionAsync(ApplicationId, LegalName, UniqueIdentifiers, CountryCode, Region, Bpn, A<CancellationToken>._))
             .MustNotHaveHappened();
     }
 
@@ -199,7 +201,7 @@ public class SdFactoryBusinessLogicTests
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(ApplicationId, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
         A.CallTo(() => _applicationRepository.GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(ApplicationId))
-            .Returns((CompanyId, null, CountryCode, Enumerable.Empty<(UniqueIdentifierId Id, string Value)>()));
+            .Returns((CompanyId, LegalName, null, CountryCode, Region, Enumerable.Empty<(UniqueIdentifierId Id, string Value)>()));
 
         // Act
         async Task Act() => await _sut.StartSelfDescriptionRegistration(context, CancellationToken.None);
@@ -207,7 +209,35 @@ public class SdFactoryBusinessLogicTests
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
         ex.Message.Should().Be($"BusinessPartnerNumber (bpn) for CompanyApplications {ApplicationId} company {CompanyId} is empty");
-        A.CallTo(() => _service.RegisterSelfDescriptionAsync(ApplicationId, UniqueIdentifiers, CountryCode, Bpn, A<CancellationToken>._))
+        A.CallTo(() => _service.RegisterSelfDescriptionAsync(ApplicationId, LegalName, UniqueIdentifiers, CountryCode, Region, Bpn, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Theory]
+    [InlineData(CountryCode, null)]
+    [InlineData(null, Region)]
+    [InlineData(null, null)]
+    public async Task StartSelfDescriptionRegistration_WithCountryOrRegionNotSet_ThrowsConflictException(string? countryCode, string? region)
+    {
+        // Arrange
+        var checklist = new Dictionary<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>
+            {
+                { ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE },
+                { ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE },
+            }
+            .ToImmutableDictionary();
+        var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(ApplicationId, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
+        A.CallTo(() => _applicationRepository.GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(ApplicationId))
+            .Returns((CompanyId, LegalName, Bpn, countryCode, region, Enumerable.Empty<(UniqueIdentifierId Id, string Value)>()));
+
+        // Act
+        async Task Act() => await _sut.StartSelfDescriptionRegistration(context, CancellationToken.None);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+        ex.Message.Should().Be($"CountryCode or Region for CompanyApplications {ApplicationId} and Company {CompanyId} is empty. Expected value: DE-NW and Current value: {countryCode}-{region}");
+        A.CallTo(() => _service.RegisterSelfDescriptionAsync(ApplicationId, LegalName, UniqueIdentifiers, CountryCode, Region, Bpn, A<CancellationToken>._))
             .MustNotHaveHappened();
     }
 
@@ -316,7 +346,7 @@ public class SdFactoryBusinessLogicTests
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(ApplicationId, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
         A.CallTo(() => _applicationRepository.GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(ApplicationId))
-            .Returns<(Guid, string?, string, IEnumerable<(UniqueIdentifierId, string)>)>(default);
+            .Returns<(Guid, string, string?, string?, string?, IEnumerable<(UniqueIdentifierId, string)>)>(default);
 
         // Act
         async Task Act() => await _sut.StartSelfDescriptionRegistration(context, CancellationToken.None);
@@ -339,7 +369,7 @@ public class SdFactoryBusinessLogicTests
             .ToImmutableDictionary();
         var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(ApplicationId, default, checklist, Enumerable.Empty<ProcessStepTypeId>());
         A.CallTo(() => _applicationRepository.GetCompanyAndApplicationDetailsWithUniqueIdentifiersAsync(ApplicationId))
-            .Returns((CompanyId, null, CountryCode, Enumerable.Empty<(UniqueIdentifierId Id, string Value)>()));
+            .Returns((CompanyId, LegalName, null, CountryCode, Region, Enumerable.Empty<(UniqueIdentifierId Id, string Value)>()));
 
         // Act
         async Task Act() => await _sut.StartSelfDescriptionRegistration(context, CancellationToken.None);

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryServiceTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryServiceTests.cs
@@ -33,6 +33,10 @@ public class SdFactoryServiceTests
 {
     #region Initialization
 
+    private const string CountryCode = "DE";
+    private const string Region = "NW";
+    private const string LegalName = "Legal Participant Company Name";
+    private const string Bpn = "BPNL000000000009";
     private static readonly IEnumerable<(UniqueIdentifierId Id, string Value)> UniqueIdentifiers = new List<(UniqueIdentifierId Id, string Value)>
     {
         new(UniqueIdentifierId.VAT_ID, "JUSTATEST")
@@ -73,13 +77,12 @@ public class SdFactoryServiceTests
     public async Task RegisterConnectorAsync_WithValidData_CreatesDocumentInDatabase()
     {
         // Arrange
-        const string bpn = "BPNL000000000009";
         var id = Guid.NewGuid();
         var httpMessageHandlerMock = new HttpMessageHandlerMock(HttpStatusCode.OK);
         using var httpClient = CreateHttpClient(httpMessageHandlerMock);
 
         // Act
-        await _service.RegisterConnectorAsync(id, "https://connect-tor.com", bpn, CancellationToken.None);
+        await _service.RegisterConnectorAsync(id, "https://connect-tor.com", Bpn, CancellationToken.None);
 
         // Assert
         _documents.Should().BeEmpty();
@@ -90,12 +93,11 @@ public class SdFactoryServiceTests
     {
         // Arrange
         var id = Guid.NewGuid();
-        const string bpn = "BPNL000000000009";
         var httpMessageHandlerMock = new HttpMessageHandlerMock(HttpStatusCode.BadRequest);
         using var httpClient = CreateHttpClient(httpMessageHandlerMock);
 
         // Act
-        async Task Action() => await _service.RegisterConnectorAsync(id, "https://connect-tor.com", bpn, CancellationToken.None);
+        async Task Action() => await _service.RegisterConnectorAsync(id, "https://connect-tor.com", Bpn, CancellationToken.None);
 
         // Assert
         var exception = await Assert.ThrowsAsync<ServiceException>(Action);
@@ -111,13 +113,12 @@ public class SdFactoryServiceTests
     public async Task RegisterSelfDescriptionAsync_WithValidData_CreatesDocumentInDatabase()
     {
         // Arrange
-        const string bpn = "BPNL000000000009";
         var applicationId = Guid.NewGuid();
         var httpMessageHandlerMock = new HttpMessageHandlerMock(HttpStatusCode.OK);
         using var httpClient = CreateHttpClient(httpMessageHandlerMock);
 
         // Act
-        await _service.RegisterSelfDescriptionAsync(applicationId, UniqueIdentifiers, "de", bpn, CancellationToken.None);
+        await _service.RegisterSelfDescriptionAsync(applicationId, LegalName, UniqueIdentifiers, CountryCode, Region, Bpn, CancellationToken.None);
 
         // Assert
         _documents.Should().BeEmpty();
@@ -128,12 +129,11 @@ public class SdFactoryServiceTests
     {
         // Arrange
         var applicationId = Guid.NewGuid();
-        const string bpn = "BPNL000000000009";
         var httpMessageHandlerMock = new HttpMessageHandlerMock(HttpStatusCode.BadRequest);
         using var httpClient = CreateHttpClient(httpMessageHandlerMock);
 
         // Act
-        async Task Action() => await _service.RegisterSelfDescriptionAsync(applicationId, UniqueIdentifiers, "de", bpn, CancellationToken.None);
+        async Task Action() => await _service.RegisterSelfDescriptionAsync(applicationId, LegalName, UniqueIdentifiers, CountryCode, Region, Bpn, CancellationToken.None);
 
         // Assert
         var exception = await Assert.ThrowsAsync<ServiceException>(Action);

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
@@ -326,8 +326,10 @@ public class ApplicationRepositoryTests(TestDbFixture testDbFixture)
 
         // Assert
         data.CompanyId.Should().Be(CompanyId);
+        data.legalName.Should().Be("CX-Test-Access");
         data.BusinessPartnerNumber.Should().NotBeNullOrEmpty().And.Be("BPNL00000003CRHL");
         data.Alpha2Code.Should().Be("DE");
+        data.Region.Should().Be("BY");
         data.UniqueIdentifiers.Should().HaveCount(1);
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/addresses.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/addresses.unittest.json
@@ -40,7 +40,7 @@
     "date_created": "2022-03-24 18:01:33.306000 +00:00",
     "date_last_changed": "2022-03-24 18:01:33.306000 +00:00",
     "city": "Munich",
-    "region": null,
+    "region": "BY",
     "streetadditional": null,
     "streetname": "Street",
     "streetnumber": "1",

--- a/tests/processes/SelfDescriptionCreation.Executor.Tests/SdCreationProcessTypeExecutorTests.cs
+++ b/tests/processes/SelfDescriptionCreation.Executor.Tests/SdCreationProcessTypeExecutorTests.cs
@@ -30,6 +30,10 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Processes.SelfDescriptionCreation.
 
 public class SdCreationProcessTypeExecutorTests
 {
+    private const string CountryCode = "DE";
+    private const string Region = "NW";
+    private const string LegalName = "Legal Participant Company Name";
+    private const string Bpn = "BPNL000000001TEST";
     private readonly ICompanyRepository _companyRepository;
     private readonly IConnectorsRepository _connectorsRepository;
     private readonly SdCreationProcessTypeExecutor _executor;
@@ -98,11 +102,13 @@ public class SdCreationProcessTypeExecutorTests
         initializationResult.ScheduleStepTypeIds.Should().BeNull();
 
         // Arrange
-        var company = new ValueTuple<Guid, IEnumerable<(UniqueIdentifierId Id, string Value)>, string?, string>(
+        var company = new ValueTuple<Guid, string, IEnumerable<(UniqueIdentifierId Id, string Value)>, string?, string?, string?>(
             Guid.NewGuid(),
+            LegalName,
             new List<(UniqueIdentifierId Id, string Value)> { new(UniqueIdentifierId.VAT_ID, "test") },
-            "BPNL000000001TEST",
-            "DE");
+            Bpn,
+            CountryCode,
+            Region);
         A.CallTo(() => _companyRepository.GetCompanyByProcessId(processId))
             .Returns(company);
 
@@ -115,7 +121,7 @@ public class SdCreationProcessTypeExecutorTests
             x => x == ProcessStepTypeId.RETRIGGER_AWAIT_SELF_DESCRIPTION_COMPANY_RESPONSE);
         result.ProcessStepStatusId.Should().Be(ProcessStepStatusId.DONE);
 
-        A.CallTo(() => _sdFactoryService.RegisterSelfDescriptionAsync(company.Item1, A<IEnumerable<(UniqueIdentifierId Id, string Value)>>._, A<string>._, A<string>._, A<CancellationToken>._))
+        A.CallTo(() => _sdFactoryService.RegisterSelfDescriptionAsync(company.Item1, A<string>._, A<IEnumerable<(UniqueIdentifierId Id, string Value)>>._, A<string>._, A<string>._, A<string>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -134,7 +140,7 @@ public class SdCreationProcessTypeExecutorTests
         // Arrange
         var connector = new ValueTuple<Guid, string, Guid>(
             Guid.NewGuid(),
-            "BPNL000000001TEST",
+            Bpn,
             Guid.NewGuid());
         A.CallTo(() => _connectorsRepository.GetConnectorForProcessId(processId))
             .Returns(connector);
@@ -148,7 +154,7 @@ public class SdCreationProcessTypeExecutorTests
             x => x == ProcessStepTypeId.RETRIGGER_AWAIT_SELF_DESCRIPTION_CONNECTOR_RESPONSE);
         result.ProcessStepStatusId.Should().Be(ProcessStepStatusId.DONE);
 
-        A.CallTo(() => _sdFactoryService.RegisterConnectorAsync(connector.Item1, A<string>._, "BPNL000000001TEST", A<CancellationToken>._))
+        A.CallTo(() => _sdFactoryService.RegisterConnectorAsync(connector.Item1, A<string>._, Bpn, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -167,16 +173,18 @@ public class SdCreationProcessTypeExecutorTests
         initializationResult.ScheduleStepTypeIds.Should().BeNull();
 
         // Arrange execute
-        var company = new ValueTuple<Guid, IEnumerable<(UniqueIdentifierId Id, string Value)>, string?, string>(
+        var company = new ValueTuple<Guid, string, IEnumerable<(UniqueIdentifierId Id, string Value)>, string?, string?, string?>(
             Guid.NewGuid(),
+            LegalName,
             new List<(UniqueIdentifierId Id, string Value)> { new(UniqueIdentifierId.VAT_ID, "test") },
-            "BPNL000000001TEST",
-            "DE");
+            Bpn,
+            CountryCode,
+            Region);
         A.CallTo(() => _companyRepository.GetCompanyByProcessId(processId))
             .Returns(company);
 
         var error = _fixture.Create<TestException>();
-        A.CallTo(() => _sdFactoryService.RegisterSelfDescriptionAsync(A<Guid>._, A<IEnumerable<(UniqueIdentifierId Id, string Value)>>._, A<string>._, A<string>._, A<CancellationToken>._))
+        A.CallTo(() => _sdFactoryService.RegisterSelfDescriptionAsync(A<Guid>._, A<string>._, A<IEnumerable<(UniqueIdentifierId Id, string Value)>>._, A<string>._, A<string>._, A<string>._, A<CancellationToken>._))
             .Throws(error);
 
         // Act execute
@@ -205,16 +213,18 @@ public class SdCreationProcessTypeExecutorTests
         initializationResult.ScheduleStepTypeIds.Should().BeNull();
 
         // Arrange execute
-        var company = new ValueTuple<Guid, IEnumerable<(UniqueIdentifierId Id, string Value)>, string?, string>(
+        var company = new ValueTuple<Guid, string, IEnumerable<(UniqueIdentifierId Id, string Value)>, string?, string?, string?>(
             Guid.NewGuid(),
+            LegalName,
             new List<(UniqueIdentifierId Id, string Value)> { new(UniqueIdentifierId.VAT_ID, "test") },
-            "BPNL000000001TEST",
-            "DE");
+            Bpn,
+            CountryCode,
+            Region);
         A.CallTo(() => _companyRepository.GetCompanyByProcessId(processId))
             .Returns(company);
 
         var error = new SystemException(_fixture.Create<string>());
-        A.CallTo(() => _sdFactoryService.RegisterSelfDescriptionAsync(A<Guid>._, A<IEnumerable<(UniqueIdentifierId Id, string Value)>>._, A<string>._, A<string>._, A<CancellationToken>._))
+        A.CallTo(() => _sdFactoryService.RegisterSelfDescriptionAsync(A<Guid>._, A<string>._, A<IEnumerable<(UniqueIdentifierId Id, string Value)>>._, A<string>._, A<string>._, A<string>._, A<CancellationToken>._))
             .Throws(error);
 
         // Act execute


### PR DESCRIPTION
## Description

Integration of Gaia-X Tagus release (v2) in company onboarding SD Factory.

## Why

v1 will be retired as of March 2025. Any API v1 calls will fail with a 400 HTTP Status Code.

## Issue

Ref: #1274 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas