### PR TITLE
fix(errorHandling): adjust error structure for 401 and 403 errors

### DIFF
--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/BaseHttpExceptionHandler.cs
+++ b/src/framework/Framework.ErrorHandling.Web/BaseHttpExceptionHandler.cs
@@ -107,7 +107,7 @@ public class BaseHttpExceptionHandler(IErrorMessageService errorMessageService)
     protected IEnumerable<ErrorDetails> GetErrorDetails(Exception exception) =>
         exception is DetailException { HasDetails: true } detail
             ? detail.GetErrorDetails(errorMessageService)
-            : Enumerable.Empty<ErrorDetails>();
+            : [];
 
     protected static void LogErrorInformation(string errorId, Exception exception)
     {

--- a/src/framework/Framework.ErrorHandling.Web/CustomAuthorizationMiddleware.cs
+++ b/src/framework/Framework.ErrorHandling.Web/CustomAuthorizationMiddleware.cs
@@ -29,22 +29,39 @@ public class CustomAuthorizationMiddleware(IErrorMessageService errorMessageServ
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
         await next(context).ConfigureAwait(ConfigureAwaitOptions.None);
-        var errorId = Guid.NewGuid().ToString();
 
-        if (context.Response.StatusCode == (int)HttpStatusCode.Unauthorized)
+        switch (context.Response.StatusCode)
         {
-            context.Response.ContentType = "application/json";
-            context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-            const string UnauthorizedAccess = "Unauthorized access";
-            await context.Response.WriteAsJsonAsync(CreateErrorResponse(HttpStatusCode.Unauthorized, new UnauthorizedAccessException(), errorId, UnauthorizedAccess, Enumerable.Repeat(new ErrorDetails("UnauthorizedAccess", nameof(UnauthorizedAccessException), UnauthorizedAccess, []), 1), null), Options).ConfigureAwait(ConfigureAwaitOptions.None);
-        }
+            case (int)HttpStatusCode.Unauthorized:
+                context.Response.ContentType = "application/json";
+                const string UnauthorizedAccess = "Unauthorized access";
+                await context.Response.WriteAsJsonAsync(
+                    CreateErrorResponse(
+                        HttpStatusCode.Unauthorized,
+                        new UnauthorizedAccessException(),
+                        Guid.NewGuid().ToString(),
+                        UnauthorizedAccess,
+                        Enumerable.Repeat(new ErrorDetails("UnauthorizedAccess", nameof(UnauthorizedAccessException), UnauthorizedAccess, []), 1),
+                        null),
+                    Options).ConfigureAwait(ConfigureAwaitOptions.None);
+                break;
 
-        if (context.Response.StatusCode == (int)HttpStatusCode.Forbidden)
-        {
-            context.Response.ContentType = "application/json";
-            context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
-            const string ForbiddenAccess = "Access forbidden";
-            await context.Response.WriteAsJsonAsync(CreateErrorResponse(HttpStatusCode.Forbidden, new ForbiddenException(), errorId, ForbiddenAccess, Enumerable.Repeat(new ErrorDetails("ForbiddenAccess", nameof(ForbiddenException), ForbiddenAccess, []), 1), null), Options).ConfigureAwait(ConfigureAwaitOptions.None);
+            case (int)HttpStatusCode.Forbidden:
+                context.Response.ContentType = "application/json";
+                const string ForbiddenAccess = "Access forbidden";
+                await context.Response.WriteAsJsonAsync(
+                    CreateErrorResponse(
+                        HttpStatusCode.Forbidden,
+                        new ForbiddenException(),
+                        Guid.NewGuid().ToString(),
+                        ForbiddenAccess,
+                        Enumerable.Repeat(new ErrorDetails("ForbiddenAccess", nameof(ForbiddenException), ForbiddenAccess, []), 1),
+                        null),
+                    Options).ConfigureAwait(ConfigureAwaitOptions.None);
+                break;
+
+            default:
+                break;
         }
     }
 }

--- a/src/framework/Framework.ErrorHandling.Web/CustomAuthorizationMiddleware.cs
+++ b/src/framework/Framework.ErrorHandling.Web/CustomAuthorizationMiddleware.cs
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Microsoft.AspNetCore.Http;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using System.Net;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
+
+public class CustomAuthorizationMiddleware(IErrorMessageService errorMessageService) :
+    BaseHttpExceptionHandler(errorMessageService), IMiddleware
+{
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        await next(context).ConfigureAwait(ConfigureAwaitOptions.None);
+        var errorId = Guid.NewGuid().ToString();
+
+        if (context.Response.StatusCode == (int)HttpStatusCode.Unauthorized)
+        {
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+            const string UnauthorizedAccess = "Unauthorized access";
+            await context.Response.WriteAsJsonAsync(CreateErrorResponse(HttpStatusCode.Unauthorized, new UnauthorizedAccessException(), errorId, UnauthorizedAccess, Enumerable.Repeat(new ErrorDetails("UnauthorizedAccess", nameof(UnauthorizedAccessException), UnauthorizedAccess, []), 1), null), Options).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+
+        if (context.Response.StatusCode == (int)HttpStatusCode.Forbidden)
+        {
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+            const string ForbiddenAccess = "Access forbidden";
+            await context.Response.WriteAsJsonAsync(CreateErrorResponse(HttpStatusCode.Forbidden, new ForbiddenException(), errorId, ForbiddenAccess, Enumerable.Repeat(new ErrorDetails("ForbiddenAccess", nameof(ForbiddenException), ForbiddenAccess, []), 1), null), Options).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+    }
+}

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Identity/Directory.Build.props
+++ b/src/framework/Framework.Identity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
+++ b/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/StartupServiceExtensions.cs
+++ b/src/framework/Framework.Web/StartupServiceExtensions.cs
@@ -36,6 +36,7 @@ public static class StartupServiceExtensions
     public static IServiceCollection AddDefaultServices<TProgram>(this IServiceCollection services, IConfigurationRoot configuration, string version, string cookieName)
     {
         services.AddCors(options => options.SetupCors(configuration));
+        services.AddScoped<CustomAuthorizationMiddleware>();
 
         services.AddDistributedMemoryCache();
         services.AddSession(options =>

--- a/src/framework/Framework.Web/StartupServiceWebApplicationExtensions.cs
+++ b/src/framework/Framework.Web/StartupServiceWebApplicationExtensions.cs
@@ -21,6 +21,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Cors;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using Serilog;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
@@ -50,6 +51,7 @@ public static class StartupServiceWebApplicationExtensions
         app.UseSession();
 
         app.UseCors(CorsExtensions.AllowSpecificOrigins);
+        app.UseMiddleware<CustomAuthorizationMiddleware>();
         app.UseAuthentication();
         app.UseAuthorization();
 

--- a/tests/framework/Framework.ErrorHandling.Web.Tests/CustomAuthorizationMiddlewareTests.cs
+++ b/tests/framework/Framework.ErrorHandling.Web.Tests/CustomAuthorizationMiddlewareTests.cs
@@ -1,0 +1,97 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using AutoFixture;
+using AutoFixture.AutoFakeItEasy;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web.Tests;
+
+public class CustomAuthorizationMiddlewareTests
+{
+    private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+    private readonly CustomAuthorizationMiddleware _customAuthorizationMiddleware;
+
+    public CustomAuthorizationMiddlewareTests()
+    {
+        var fixture = new Fixture().Customize(new AutoFakeItEasyCustomization { ConfigureMembers = true });
+        fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
+            .ForEach(b => fixture.Behaviors.Remove(b));
+        fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+        var errorMessageService = A.Fake<IErrorMessageService>();
+        A.CallTo(() => errorMessageService.GetMessage(A<Type>._, A<int>._))
+            .ReturnsLazily((Type type, int code) => $"type: {type.Name} code: {code} first: {{first}} second: {{second}}");
+
+        _customAuthorizationMiddleware = new CustomAuthorizationMiddleware(errorMessageService);
+    }
+
+    [Fact]
+    public async Task Invoke_WithForbidden()
+    {
+        // Arrange
+        Task MockNextMiddleware(HttpContext _) => Task.CompletedTask;
+        using var body = new MemoryStream();
+        var httpContext = new DefaultHttpContext { Response = { Body = body, StatusCode = StatusCodes.Status403Forbidden } };
+
+        // Act
+        await _customAuthorizationMiddleware.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.Forbidden);
+
+        body.Position = 0;
+        var errorResponse = JsonSerializer.Deserialize<ErrorResponse>(body, Options);
+        errorResponse.Should().NotBeNull().And.BeOfType<ErrorResponse>().Which.Details.Should().ContainSingle().Which.Should().Match<ErrorDetails>(x =>
+            x.Type == "ForbiddenException" &&
+            x.ErrorCode == "ForbiddenAccess" &&
+            x.Message == "Access forbidden" &&
+            !x.Parameters.Any());
+    }
+
+    [Fact]
+    public async Task Invoke_WithUnauthorized()
+    {
+        // Arrange
+        Task MockNextMiddleware(HttpContext _) => Task.CompletedTask;
+        using var body = new MemoryStream();
+        var httpContext = new DefaultHttpContext { Response = { Body = body, StatusCode = StatusCodes.Status401Unauthorized } };
+
+        // Act
+        await _customAuthorizationMiddleware.InvokeAsync(httpContext, MockNextMiddleware);
+
+        // Assert
+        ((HttpStatusCode)httpContext.Response.StatusCode).Should().Be(HttpStatusCode.Unauthorized);
+
+        body.Position = 0;
+        var errorResponse = JsonSerializer.Deserialize<ErrorResponse>(body, Options);
+        errorResponse.Should().NotBeNull().And.BeOfType<ErrorResponse>().Which.Details.Should().ContainSingle().Which.Should().Match<ErrorDetails>(x =>
+            x.Type == "UnauthorizedAccessException" &&
+            x.ErrorCode == "UnauthorizedAccess" &&
+            x.Message == "Unauthorized access" &&
+            !x.Parameters.Any());
+    }
+}


### PR DESCRIPTION
## Description

Adding the new error message format for 401 and 403 errors

## Why

to return a json object for 401 and 403 errors

## Issue

Refs: #1282

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
