### PR TITLE
feat(connector): Integrate the Gaia-X Tagus Updates

### DIFF
--- a/src/administration/Administration.Service/appsettings.json
+++ b/src/administration/Administration.Service/appsettings.json
@@ -323,7 +323,6 @@
       "Scope": "",
       "TokenAddress": "",
       "SdFactoryUrl": "https://sdfactory.example.org/selfdescription",
-      "SdFactoryIssuerBpn": "",
       "ClearinghouseConnectDisabled": false
     },
     "Dim": {

--- a/src/externalsystems/SdFactory.Library/Models/SdFactoryRequestModel.cs
+++ b/src/externalsystems/SdFactory.Library/Models/SdFactoryRequestModel.cs
@@ -46,10 +46,6 @@ public record ConnectorSdFactoryRequestModel(
     [property: JsonPropertyName("externalId")] string ExternalId,
     [property: JsonPropertyName("type"), JsonConverter(typeof(JsonStringEnumConverter))] SdFactoryRequestModelSdType Type,
     [property: JsonPropertyName("providedBy")] string ProvidedBy,
-    [property: JsonPropertyName("aggregationOf")] string? AggregationOf,
-    [property: JsonPropertyName("termsAndConditions")] string? TermsAndConditions,
-    [property: JsonPropertyName("policies")] string Policies,
-    [property: JsonPropertyName("issuer")] string Issuer,
     [property: JsonPropertyName("holder")] string Holder
 );
 

--- a/src/externalsystems/SdFactory.Library/SdFactoryService.cs
+++ b/src/externalsystems/SdFactory.Library/SdFactoryService.cs
@@ -43,10 +43,6 @@ public class SdFactoryService(ITokenService tokenService, IOptions<SdFactorySett
             connectorId.ToString(),
             SdFactoryRequestModelSdType.ServiceOffering,
             selfDescriptionDocumentUrl,
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            _settings.SdFactoryIssuerBpn,
             businessPartnerNumber);
 
         await httpClient.PostAsJsonAsync(default(string?), requestModel, cancellationToken)

--- a/src/externalsystems/SdFactory.Library/SdFactorySettings.cs
+++ b/src/externalsystems/SdFactory.Library/SdFactorySettings.cs
@@ -38,10 +38,4 @@ public class SdFactorySettings : KeyVaultAuthSettings
     /// </summary>
     [Required]
     public string SdFactoryUrl { get; set; } = null!;
-
-    /// <summary>
-    /// BPN of the issuer for the sd factory
-    /// </summary>
-    [Required]
-    public string SdFactoryIssuerBpn { get; set; } = null!;
 }

--- a/src/processes/Processes.Worker/appsettings.json
+++ b/src/processes/Processes.Worker/appsettings.json
@@ -334,7 +334,6 @@
       "Scope": "",
       "TokenAddress": "",
       "SdFactoryUrl": "https://sdfactory.example.org/selfdescription",
-      "SdFactoryIssuerBpn": "",
       "ClearinghouseConnectDisabled": false
     },
     "Clearinghouse":{

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
@@ -93,8 +93,7 @@ public class SdFactoryBusinessLogicTests
 
         _options = Options.Create(new SdFactorySettings
         {
-            SdFactoryUrl = "https://www.api.sdfactory.com",
-            SdFactoryIssuerBpn = "BPNL00000003CRHK"
+            SdFactoryUrl = "https://www.api.sdfactory.com"
         });
         _sut = new SdFactoryBusinessLogic(_service, _portalRepositories, _checklistService, _options);
     }
@@ -141,7 +140,6 @@ public class SdFactoryBusinessLogicTests
         var sut = new SdFactoryBusinessLogic(_service, _portalRepositories, _checklistService, Options.Create(new SdFactorySettings
         {
             SdFactoryUrl = "https://www.api.sdfactory.com",
-            SdFactoryIssuerBpn = "BPNL00000003CRHK",
             ClearinghouseConnectDisabled = clearinghouseConnectDisabled
         }));
 

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryServiceTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryServiceTests.cs
@@ -61,8 +61,7 @@ public class SdFactoryServiceTests
         _portalRepositories = A.Fake<IPortalRepositories>();
         _options = Options.Create(new SdFactorySettings
         {
-            SdFactoryUrl = "https://www.api.sdfactory.com",
-            SdFactoryIssuerBpn = "BPNL00000003CRHK"
+            SdFactoryUrl = "https://www.api.sdfactory.com"
         });
         _tokenService = A.Fake<ITokenService>();
         SetupRepositoryMethods();


### PR DESCRIPTION
## Description

Integration of Gaia-X Tagus release (v2) for Connector.

## Why

v1 will be retired as of March 2025. Any API v1 calls will fail with a 400 HTTP Status Code.

## Issue

Ref: #1288

Link to PR in other repository:
https://github.com/eclipse-tractusx/portal/pull/516

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
