### PR TITLE
fix: adjust removeRange calls

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/UserRolesBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserRolesBusinessLogic.cs
@@ -221,10 +221,10 @@ public class UserRolesBusinessLogic : IUserRolesBusinessLogic
 
     private async Task DeleteRoles(Guid companyUserId, IEnumerable<string> iamClientIds, IEnumerable<UserRoleModificationData> rolesToDelete, string iamUserId)
     {
+        var userRoleRepository = _portalRepositories.GetInstance<IUserRolesRepository>();
         var roleNamesToDelete = iamClientIds.ToDictionary(clientId => clientId, _ => rolesToDelete.Select(x => x.CompanyUserRoleText));
         await _provisioningManager.DeleteClientRolesFromCentralUserAsync(iamUserId, roleNamesToDelete)
             .ConfigureAwait(ConfigureAwaitOptions.None);
-        _portalRepositories.RemoveRange(rolesToDelete.Select(x =>
-            new IdentityAssignedRole(companyUserId, x.CompanyUserRoleId)));
+        userRoleRepository.RemoveIdentityAssignedRoles(rolesToDelete.Select(x => new IdentityAssignedRole(companyUserId, x.CompanyUserRoleId)));
     }
 }

--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/AbstractRepositories.cs
+++ b/src/framework/Framework.DBAccess/AbstractRepositories.cs
@@ -49,23 +49,9 @@ public abstract class AbstractRepositories<TDbContext>(TDbContext dbContext) : I
         return attachedEntity;
     }
 
-    public void AttachRange<TEntity>(IEnumerable<TEntity> entities, Action<TEntity> setOptionalParameters) where TEntity : class
-    {
-        foreach (var attachedEntity in entities.Select(entity => dbContext.Attach(entity).Entity))
-        {
-            setOptionalParameters.Invoke(attachedEntity);
-        }
-    }
-
-    public IEnumerable<TEntity> AttachRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class =>
-        entities.Select(entity => dbContext.Attach(entity).Entity);
-
     /// <inheritdoc />
     public TEntity Remove<TEntity>(TEntity entity) where TEntity : class
         => dbContext.Remove(entity).Entity;
-
-    public void RemoveRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class
-        => dbContext.RemoveRange(entities);
 
     public Task<int> SaveAsync()
     {

--- a/src/framework/Framework.DBAccess/CustomNpgsqlHistoryRepository.cs
+++ b/src/framework/Framework.DBAccess/CustomNpgsqlHistoryRepository.cs
@@ -108,4 +108,4 @@ public class CustomNpgsqlHistoryRepository(HistoryRepositoryDependencies depende
                 }
             ]);
 }
-#pragma warning enable EF1001
+#pragma warning restore EF1001

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/IRepositories.cs
+++ b/src/framework/Framework.DBAccess/IRepositories.cs
@@ -31,10 +31,6 @@ public interface IRepositories
     TEntity Attach<TEntity>(TEntity entity, Action<TEntity>? setOptionalParameters = null)
         where TEntity : class;
 
-    void AttachRange<TEntity>(IEnumerable<TEntity> entities, Action<TEntity> setOptionalParameters) where TEntity : class;
-
-    IEnumerable<TEntity> AttachRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class;
-
     /// <summary>
     /// Removes the given entity from the database
     /// </summary>
@@ -43,8 +39,6 @@ public interface IRepositories
     /// <returns>Returns the attached entity</returns>
     TEntity Remove<TEntity>(TEntity entity)
         where TEntity : class;
-
-    void RemoveRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class;
 
     T GetInstance<T>();
 

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Identity/Directory.Build.props
+++ b/src/framework/Framework.Identity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
+++ b/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRolesRepository.cs
@@ -47,7 +47,7 @@ public class CompanyRolesRepository : ICompanyRolesRepository
         _dbContext.AddRange(companyRoleIds.Select(companyRoleId => new CompanyAssignedRole(companyId, companyRoleId)));
 
     public void RemoveCompanyAssignedRoles(Guid companyId, IEnumerable<CompanyRoleId> companyRoleIds) =>
-        _dbContext.RemoveRange(companyRoleIds.Select(companyRoleId => new CompanyAssignedRole(companyId, companyRoleId)));
+        _dbContext.CompanyAssignedRoles.RemoveRange(companyRoleIds.Select(companyRoleId => new CompanyAssignedRole(companyId, companyRoleId)));
 
     public Task<CompanyRoleAgreementConsentData?> GetCompanyRoleAgreementConsentDataAsync(Guid applicationId) =>
         _dbContext.CompanyApplications

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConsentRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConsentRepository.cs
@@ -58,7 +58,7 @@ public class ConsentRepository : IConsentRepository
 
     /// <inheritdoc />
     public void RemoveConsents(IEnumerable<Consent> consents) =>
-        _portalDbContext.RemoveRange(consents);
+        _portalDbContext.Consents.RemoveRange(consents);
 
     ///<inheritdoc/>
     public ConsentAssignedOffer CreateConsentAssignedOffer(Guid consentId, Guid offerId) =>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
@@ -87,4 +87,5 @@ public interface IUserRolesRepository
     Task<(bool IsValid, bool IsProvider, IEnumerable<ActiveAppRoleDetails>? AppRoleDetails)> GetOfferProviderRolesAsync(Guid offerId, OfferTypeId offerTypeId, Guid companyId, string? languageShortName, string defaultLanguageShortName);
 
     IAsyncEnumerable<(Guid IdentityId, IEnumerable<(string ClientClientId, Guid UserRoleId, string UserRoleText)> InstanceRoleData)> GetUsersWithUserRolesForApplicationId(Guid applicationId, IEnumerable<string> iamClientIds);
+    void RemoveIdentityAssignedRoles(IEnumerable<IdentityAssignedRole> identityAssignedRoles);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IdentityProviderRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IdentityProviderRepository.cs
@@ -68,7 +68,7 @@ public class IdentityProviderRepository : IIdentityProviderRepository
         _context.Remove(new CompanyIdentityProvider(companyId, identityProviderId));
 
     public void DeleteCompanyIdentityProviderRange(IEnumerable<(Guid CompanyId, Guid IdentityProviderId)> companyIdentityProviderIds) =>
-        _context.RemoveRange(companyIdentityProviderIds.Select(x => new CompanyIdentityProvider(x.CompanyId, x.IdentityProviderId)));
+        _context.CompanyIdentityProviders.RemoveRange(companyIdentityProviderIds.Select(x => new CompanyIdentityProvider(x.CompanyId, x.IdentityProviderId)));
 
     public void CreateCompanyIdentityProviders(IEnumerable<(Guid CompanyId, Guid IdentityProviderId)> companyIdIdentityProviderIds) =>
         _context.CompanyIdentityProviders

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserProfileRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserProfileRepository.cs
@@ -59,7 +59,7 @@ public class TechnicalUserProfileRepository : ITechnicalUserProfileRepository
 
     /// <inheritdoc />
     public void RemoveTechnicalUserProfiles(IEnumerable<Guid> technicalUserProfileIds) =>
-        _context.RemoveRange(technicalUserProfileIds.Select(profileId => new TechnicalUserProfile(profileId, Guid.Empty)));
+        _context.TechnicalUserProfiles.RemoveRange(technicalUserProfileIds.Select(profileId => new TechnicalUserProfile(profileId, Guid.Empty)));
 
     /// <inheritdoc />
     public void RemoveTechnicalUserProfilesForOffer(Guid offerId)

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserBusinessPartnerRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserBusinessPartnerRepository.cs
@@ -46,7 +46,7 @@ public class UserBusinessPartnerRepository(PortalDbContext dbContext)
             )).Entity;
 
     public void DeleteCompanyUserAssignedBusinessPartners(IEnumerable<(Guid CompanyUserId, string BusinessPartnerNumber)> companyUserAssignedBusinessPartnerIds) =>
-        dbContext.RemoveRange(companyUserAssignedBusinessPartnerIds.Select(ids => new CompanyUserAssignedBusinessPartner(ids.CompanyUserId, ids.BusinessPartnerNumber)));
+        dbContext.CompanyUserAssignedBusinessPartners.RemoveRange(companyUserAssignedBusinessPartnerIds.Select(ids => new CompanyUserAssignedBusinessPartner(ids.CompanyUserId, ids.BusinessPartnerNumber)));
 
     public Task<(bool IsValidUser, bool IsAssignedBusinessPartner, bool IsSameCompany)> GetOwnCompanyUserWithAssignedBusinessPartnerNumbersAsync(Guid companyUserId, Guid userCompanyId, string businessPartnerNumber) =>
         dbContext.CompanyUsers

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/UserBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/UserBusinessLogicTests.cs
@@ -848,7 +848,7 @@ public class UserBusinessLogicTests
         await sut.ModifyAppUserRolesAsync(_validOfferId, _companyUserId, userRoles);
 
         // Assert
-        A.CallTo(() => _portalRepositories.RemoveRange(A<IEnumerable<IdentityAssignedRole>>.That.Matches(x => x.Count() == 1))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _userRolesRepository.RemoveIdentityAssignedRoles(A<IEnumerable<IdentityAssignedRole>>.That.Matches(x => x.Count() == 1))).MustHaveHappenedOnceExactly();
         notifications.Should().ContainSingle()
             .Which.Should().Match<Notification>(x =>
                 x.ReceiverUserId == _companyUserId &&
@@ -1676,7 +1676,7 @@ public class UserBusinessLogicTests
             .Invokes((Guid companyUserId, Guid companyUserRoleId) =>
                 _addedRoles.Add(new IdentityAssignedRole(companyUserId, companyUserRoleId)));
 
-        A.CallTo(() => _portalRepositories.RemoveRange(A<IEnumerable<IdentityAssignedRole>>._))
+        A.CallTo(() => _userRolesRepository.RemoveIdentityAssignedRoles(A<IEnumerable<IdentityAssignedRole>>._))
             .Invokes((IEnumerable<IdentityAssignedRole> roles) =>
             {
                 foreach (var role in roles)


### PR DESCRIPTION
## Description

adjust the removeRange call on dbContext to a table specific removeRange

## Why

EntityFramework seems to have problems casting the objects to the correct table

## Issue

Refs: #1287

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
