### PR TITLE
fix(BpdmService): cx-memberships call to expect custom api path

### DIFF
--- a/src/externalsystems/Bpdm.Library/BpdmService.cs
+++ b/src/externalsystems/Bpdm.Library/BpdmService.cs
@@ -191,7 +191,7 @@ public class BpdmService : IBpdmService
         async ValueTask<(bool, string?)> CreateErrorMessage(HttpResponseMessage errorResponse) =>
             (false, await errorResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None));
 
-        await httpClient.PutAsJsonAsync("v6/cx-memberships", requestData, Options, cancellationToken)
+        await httpClient.PutAsJsonAsync("cx-memberships", requestData, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("bpdm-put-cx-membership", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE, CreateErrorMessage).ConfigureAwait(false);
         return true;
     }

--- a/tests/externalsystems/Bpdm.Library/BpdmServiceTests.cs
+++ b/tests/externalsystems/Bpdm.Library/BpdmServiceTests.cs
@@ -675,7 +675,7 @@ public class BpdmServiceTests
         var httpMessageHandlerMock = new HttpMessageHandlerMock(HttpStatusCode.OK);
         using var httpClient = new HttpClient(httpMessageHandlerMock)
         {
-            BaseAddress = new Uri("https://business.partner.pool.base.address.com")
+            BaseAddress = new Uri("https://business.partner.pool.base.address.com/pool/v6/")
         };
         A.CallTo(() => _tokenService.GetAuthorizedClient(A<string>._, A<BpdmServiceSettings>._, A<CancellationToken>._))
             .Returns(httpClient);
@@ -689,7 +689,7 @@ public class BpdmServiceTests
             .And.Match<HttpRequestMessage>(x =>
                 x.Method == HttpMethod.Put &&
                 x.RequestUri != null &&
-                x.RequestUri.AbsoluteUri == "https://business.partner.pool.base.address.com/v6/cx-memberships"
+                x.RequestUri.AbsoluteUri == "https://business.partner.pool.base.address.com/pool/v6/cx-memberships"
         );
         httpMessageHandlerMock.RequestMessage!.Content
             .Should().NotBeNull()
@@ -716,7 +716,7 @@ public class BpdmServiceTests
         var httpMessageHandlerMock = new HttpMessageHandlerMock(HttpStatusCode.BadRequest);
         using var httpClient = new HttpClient(httpMessageHandlerMock)
         {
-            BaseAddress = new Uri("https://business.partner.pool.base.address.com")
+            BaseAddress = new Uri("https://business.partner.pool.base.address.com/pool/v6")
         };
         A.CallTo(() => _tokenService.GetAuthorizedClient(A<string>._, A<BpdmServiceSettings>._, A<CancellationToken>._))
             .Returns(httpClient);


### PR DESCRIPTION
## Description

Remove hardcoded v6 path in bpdm cx-memberships api call. BusinessPartnerPoolBaseAddress should contain base api path including version.

## Why

There is a customizable poolApiPath in portal values including API version. Calls are failing if the pool has any path.

## Issue

Refs: eclipse-tractusx/portal-backend#1299
Depends on: eclipse-tractusx/portal#518

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
