### PR TITLE
fix(auto-setup): added the callback url in GET

### DIFF
--- a/docs/api/administration-service.yaml
+++ b/docs/api/administration-service.yaml
@@ -7736,6 +7736,9 @@ components:
         url:
           type: string
           nullable: true
+        callbackUrl:
+          type: string
+          nullable: true
       additionalProperties: false
     Reason:
       type: object

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ProviderDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ProviderDetailData.cs
@@ -22,4 +22,4 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
 public record ProviderDetailData(string? Url, string? CallbackUrl);
 
-public record ProviderDetailReturnData(Guid? Id, Guid CompanyId, string? Url);
+public record ProviderDetailReturnData(Guid? Id, Guid CompanyId, string? Url, string? CallbackUrl);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -157,7 +157,8 @@ public class CompanyRepository(PortalDbContext context) : ICompanyRepository
                 new ProviderDetailReturnData(
                     company.ProviderCompanyDetail!.Id,
                     company.Id,
-                    company.ProviderCompanyDetail.AutoSetupUrl),
+                    company.ProviderCompanyDetail.AutoSetupUrl,
+                    company.ProviderCompanyDetail.AutoSetupCallbackUrl),
                 company.CompanyAssignedRoles.Any(assigned => assigned.CompanyRoleId == companyRoleId)))
             .SingleOrDefaultAsync();
 

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/SubscriptionConfigurationBusinessLogicTests.cs
@@ -438,7 +438,7 @@ public class SubscriptionConfigurationBusinessLogicTests
         //Arrange
         SetupProviderCompanyDetails();
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailAsync(CompanyRoleId.SERVICE_PROVIDER, ExistingCompanyId))
-            .Returns((new ProviderDetailReturnData(Guid.NewGuid(), Guid.NewGuid(), "https://new-test-service.de"), false));
+            .Returns((new ProviderDetailReturnData(Guid.NewGuid(), Guid.NewGuid(), "https://new-test-service.de", "https://new-test-service-callback.de"), false));
 
         //Act
         async Task Action() => await _sut.GetProviderCompanyDetailsAsync();
@@ -469,7 +469,7 @@ public class SubscriptionConfigurationBusinessLogicTests
             });
 
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailAsync(A<CompanyRoleId>.That.Matches(x => x == CompanyRoleId.SERVICE_PROVIDER), A<Guid>.That.Matches(x => x == ExistingCompanyId)))
-            .Returns((new ProviderDetailReturnData(Guid.NewGuid(), Guid.NewGuid(), "https://new-test-service.de"), true));
+            .Returns((new ProviderDetailReturnData(Guid.NewGuid(), Guid.NewGuid(), "https://new-test-service.de", "https://new-test-service-callback.de"), true));
         A.CallTo(() => _companyRepository.GetProviderCompanyDetailAsync(A<CompanyRoleId>.That.Matches(x => x == CompanyRoleId.SERVICE_PROVIDER), A<Guid>.That.Not.Matches(x => x == ExistingCompanyId)))
             .Returns<(ProviderDetailReturnData, bool)>(default);
 

--- a/tests/administration/Administration.Service.Tests/Controllers/SubscriptionConfigurationControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/SubscriptionConfigurationControllerTests.cs
@@ -124,7 +124,26 @@ public class SubscriptionConfigurationControllerTests
     {
         //Arrange
         var id = Guid.NewGuid();
-        var data = new ProviderDetailReturnData(id, CompanyId, "https://this-is-a-test.de");
+        var data = new ProviderDetailReturnData(id, CompanyId, "https://this-is-a-test.de", null);
+        A.CallTo(() => _logic.GetProviderCompanyDetailsAsync())
+            .Returns(data);
+
+        //Act
+        var result = await _controller.GetServiceProviderCompanyDetail();
+
+        //Assert
+        A.CallTo(() => _logic.GetProviderCompanyDetailsAsync()).MustHaveHappenedOnceExactly();
+        result.Should().BeOfType<ProviderDetailReturnData>();
+        result.Id.Should().Be(id);
+        result.CompanyId.Should().Be(CompanyId);
+    }
+
+    [Fact]
+    public async Task GetProviderCompanyDetail_WithValidCallback_ReturnsOk()
+    {
+        //Arrange
+        var id = Guid.NewGuid();
+        var data = new ProviderDetailReturnData(id, CompanyId, "https://this-is-a-test.de", "https://this-is-a-test-callback.de");
         A.CallTo(() => _logic.GetProviderCompanyDetailsAsync())
             .Returns(data);
 


### PR DESCRIPTION
## Description

Added the callback url in GET response of the api `api/administration/subscriptionconfiguration/owncompany`

## Why

User is not able to see the current callback url

## Issue

#1304

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
