### PR TITLE
feat(VAT_ID): Concatenate countryCode with vatId identifier

### DIFF
--- a/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
+++ b/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
@@ -100,7 +100,11 @@ public class ClearinghouseBusinessLogic(
                     string.IsNullOrEmpty(data.Address.Streetnumber)
                         ? data.Address.Streetname
                         : string.Format("{0} {1}", data.Address.Streetname, data.Address.Streetnumber)),
-                data.Identifiers.Select(ci => new UniqueIdData(ci.UniqueIdentifierId.GetUniqueIdentifierValue(), ci.Value))),
+                data.Identifiers.Select(ci =>
+                    new UniqueIdData(
+                        ci.UniqueIdentifierId.GetUniqueIdentifierId(),
+                        ci.Value.GetUniqueIdentifierValue(ci.UniqueIdentifierId, data.Address.CountryAlpha2Code))
+                    )),
             validationMode,
             new CallBack(_settings.CallbackUrl, headers)
         );

--- a/src/portalbackend/PortalBackend.DBAccess/Extensions/UniqueIdentifiersExtension.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Extensions/UniqueIdentifiersExtension.cs
@@ -23,7 +23,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Extensions;
 
 public static class UniqueIdentifiersExtension
 {
-    public static string GetUniqueIdentifierValue(this UniqueIdentifierId uniqueIdentifierId) =>
+    public static string GetUniqueIdentifierId(this UniqueIdentifierId uniqueIdentifierId) =>
         uniqueIdentifierId switch
         {
             UniqueIdentifierId.COMMERCIAL_REG_NUMBER => "schema:taxID",
@@ -32,5 +32,17 @@ public static class UniqueIdentifiersExtension
             UniqueIdentifierId.VIES => "EUID",
             UniqueIdentifierId.EORI => "gx:eori",
             _ => throw new ArgumentOutOfRangeException(nameof(uniqueIdentifierId), uniqueIdentifierId, "Unique Identifier not found for Clearing House Conversion")
+        };
+
+    public static string GetUniqueIdentifierValue(this string uniqueIdentifierValue, UniqueIdentifierId uniqueIdentifierId, string countryCode) =>
+        // Purpose of adding switch case here is to have a possibility in the future to format other identifier's values as well
+        uniqueIdentifierId switch
+        {
+            UniqueIdentifierId.COMMERCIAL_REG_NUMBER => uniqueIdentifierValue,
+            UniqueIdentifierId.VAT_ID when !uniqueIdentifierValue.Contains(countryCode) => string.Format("{0}{1}", countryCode, uniqueIdentifierValue),
+            UniqueIdentifierId.LEI_CODE => uniqueIdentifierValue,
+            UniqueIdentifierId.VIES => uniqueIdentifierValue,
+            UniqueIdentifierId.EORI => uniqueIdentifierValue,
+            _ => uniqueIdentifierValue
         };
 }

--- a/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
+++ b/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
@@ -27,6 +27,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Concrete.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Repositories;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
@@ -37,6 +38,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Clearinghouse.Library.Tests;
 
 public class ClearinghouseBusinessLogicTests
 {
+    private static readonly Guid IdWithoutCountryCodeVatId = new("0a9bd7b1-e692-483e-8128-dbf52759c7a5");
     private static readonly Guid IdWithoutBpn = new("0a9bd7b1-e692-483e-8128-dbf52759c7a5");
     private static readonly Guid IdWithApplicationCreated = new("7a8f5cb6-6ad2-4b88-a765-ff1888fcedbe");
     private static readonly Guid IdWithCustodianUnavailable = new("beaa6de5-d411-4da8-850e-06047d3170be");
@@ -178,6 +180,74 @@ public class ClearinghouseBusinessLogicTests
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
         ex.Message.Should().Be("BusinessPartnerNumber is null");
+    }
+
+    [Theory]
+    [InlineData(UniqueIdentifierId.VAT_ID, "DE123456789")]
+    [InlineData(UniqueIdentifierId.VAT_ID, "123456789")]
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "HRB123456")]
+    public async Task HandleStartClearingHouse_WithoutContryCodeVatId_ThrowsConflictException(UniqueIdentifierId uniqueIdentifierId, string vatId)
+    {
+        // Arrange
+        var entry = new ApplicationChecklistEntry(Guid.NewGuid(), ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO, DateTimeOffset.UtcNow);
+
+        var checklist = ImmutableDictionary.CreateRange<ApplicationChecklistEntryTypeId, ApplicationChecklistEntryStatusId>([
+            new(ApplicationChecklistEntryTypeId.REGISTRATION_VERIFICATION, ApplicationChecklistEntryStatusId.DONE),
+            new(ApplicationChecklistEntryTypeId.BUSINESS_PARTNER_NUMBER, ApplicationChecklistEntryStatusId.DONE),
+            new(ApplicationChecklistEntryTypeId.IDENTITY_WALLET, ApplicationChecklistEntryStatusId.DONE),
+            new(ApplicationChecklistEntryTypeId.CLEARING_HOUSE, ApplicationChecklistEntryStatusId.TO_DO)
+        ]);
+        var addressData = _fixture.Build<ClearinghouseAddressData>()
+            .With(x => x.CountryAlpha2Code, "DE")
+            .Create();
+        var dataWithoutCountryCodeVatId = _fixture.Build<ClearinghouseData>()
+            .With(x => x.ApplicationStatusId, CompanyApplicationStatusId.SUBMITTED)
+            .With(x => x.Address, addressData)
+            .With(x => x.Bpn, ValidBpn)
+            .With(x => x.Identifiers, [new CompanyUniqueIdentifier(uniqueIdentifierId, vatId)])
+            .Create();
+
+        var context = new IApplicationChecklistService.WorkerChecklistProcessStepData(IdWithoutCountryCodeVatId, ProcessStepTypeId.START_CLEARING_HOUSE, checklist, Enumerable.Empty<ProcessStepTypeId>());
+        A.CallTo(() => _applicationRepository.GetClearinghouseDataForApplicationId(IdWithoutCountryCodeVatId))
+            .Returns(dataWithoutCountryCodeVatId);
+
+        var hearders = ImmutableDictionary.CreateRange<string, string>([new("Business-Partner-Number", ValidBpn)]);
+        var transferData = new ClearinghouseTransferData(
+            new LegalEntity(
+                dataWithoutCountryCodeVatId.Name,
+                new LegalAddress(
+                    dataWithoutCountryCodeVatId.Address!.CountryAlpha2Code,
+                    string.Format("{0}-{1}", dataWithoutCountryCodeVatId.Address.CountryAlpha2Code, dataWithoutCountryCodeVatId.Address.Region),
+                    dataWithoutCountryCodeVatId.Address.City,
+                    dataWithoutCountryCodeVatId.Address.Zipcode,
+                    string.IsNullOrEmpty(dataWithoutCountryCodeVatId.Address.Streetnumber)
+                        ? dataWithoutCountryCodeVatId.Address.Streetname
+                        : string.Format("{0} {1}", dataWithoutCountryCodeVatId.Address.Streetname, dataWithoutCountryCodeVatId.Address.Streetnumber)),
+                dataWithoutCountryCodeVatId.Identifiers.Select(ci =>
+                    new UniqueIdData(
+                        ci.UniqueIdentifierId.GetUniqueIdentifierId(),
+                        ci.Value.GetUniqueIdentifierValue(ci.UniqueIdentifierId, dataWithoutCountryCodeVatId.Address.CountryAlpha2Code))
+                    )),
+            ValidationModes.LEGAL_NAME,
+            new CallBack("https://www.test.de", hearders)
+        );
+        A.CallTo(() => _clearinghouseService.TriggerCompanyDataPost(transferData, A<CancellationToken>._));
+
+        // Act
+        var result = await _logic.HandleClearinghouse(context, CancellationToken.None);
+
+        // Assert
+        result.ModifyChecklistEntry.Should().NotBeNull();
+        if (uniqueIdentifierId == UniqueIdentifierId.VAT_ID)
+        {
+            transferData.LegalEntity.Identifiers.Should().ContainSingle().And.Satisfy(
+                p => p.Type == "schema:vatID" && p.Value == "DE123456789");
+        }
+        else if (uniqueIdentifierId == UniqueIdentifierId.COMMERCIAL_REG_NUMBER)
+        {
+            transferData.LegalEntity.Identifiers.Should().ContainSingle().And.Satisfy(
+                p => p.Type == "schema:taxID" && p.Value == "HRB123456");
+        }
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Concatenate only vatId identifier with countryCode and send it to clearing house

## Why

There are some (old) companies where they dont have countryCode concatenated with their vatId and vatId only contains the numbers (123456789) but clearing house has been validating the vatIds from a data source where countryCode concatenation is required (like DE123456789) so, we need to check and concatenate the countryCode with customer's vatId if vatId doesn't contains countryCode.

## Issue

Ref: #1308

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
