### PR TITLE
feat(uniqueIdentifier): update country wise regex

### DIFF
--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Identity/Directory.Build.props
+++ b/src/framework/Framework.Identity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -36,11 +36,6 @@ public static class ValidationExpressions
     /// </remarks>
     public const string Company = @"^(?!.*\s$)([\p{L}\u0E00-\u0E7F\d\p{Sc}@%*+_\-/\\,.:;=<>!?&^#'\x22()[\]]\s?){1,160}$";
     public const string ExternalCertificateNumber = @"^[a-zA-Z0-9]{0,36}$";
-    public const string COMMERCIAL_REG_NUMBER = "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-)?){4,21}$";
-    public const string VAT_ID = "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-|\\/)?){5,18}$";
-    public const string LEI_CODE = "^[A-Za-z0-9]{20}$";
-    public const string VIES = "^[A-Z]{2}[0-9A-Za-z+*.]{2,12}$";
-    public const string EORI = "^[A-Z]{2}[A-Za-z0-9]{1,15}$";
     /// <summary>
     /// To validate Region field of Address.
     /// </summary>
@@ -48,4 +43,32 @@ public static class ValidationExpressions
     /// The pattern ensures ISO-1366-2 code value: NW
     /// </remarks>
     public const string Region = "^[A-Z1-9]{1,3}$";
+
+    #region UniqueIdentifiers
+    public static class Worldwide
+    {
+        public const string COMMERCIAL_REG_NUMBER = "^(?!.*\\s$)([A-Za-zÀ-ÿ0-9.()](\\.|\\s|-|_)?){4,50}$";
+        public const string VAT_ID = "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-|\\/)?){5,18}$";
+        public const string LEI_CODE = "^[A-Za-z0-9]{20}$";
+        public const string VIES = "^[A-Z]{2}[0-9A-Za-z+*.]{2,12}$";
+        public const string EORI = "^[A-Z]{2}[A-Za-z0-9]{1,15}$";
+    }
+    public static class DE
+    {
+        public const string COMMERCIAL_REG_NUMBER = "^(?!.*\\s$)([A-Za-zÀ-ÿ])([A-Za-zÀ-ÿ0-9.()](\\s|-|_)?){4,50}$";
+        public const string VAT_ID = "^DE\\d{9}$";
+    }
+    public static class FR
+    {
+        public const string COMMERCIAL_REG_NUMBER = "^(?!.*\\s$)([A-Za-z0-9]\\s?){14,17}$";
+    }
+    public static class MX
+    {
+        public const string VAT_ID = "^[a-zA-Z\\d-&]{12,13}$";
+    }
+    public static class IN
+    {
+        public const string VAT_ID = "^[a-zA-Z\\d-]{5,15}$";
+    }
+    #endregion
 }

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -47,30 +47,31 @@ public static class ValidationExpressions
     public const string Region = "^[A-Z1-9]{1,3}$";
 
     #region UniqueIdentifiers
+    private const string Worldwide = "Worldwide";
     public static readonly IReadOnlyDictionary<string, string> COMMERCIAL_REG_NUMBER = new Dictionary<string, string>
         {
-            { "Worldwide", "^(?!.*\\s$)([A-Za-zÀ-ÿ0-9.()](\\.|\\s|-|_)?){4,50}$" },
+            { Worldwide, "^(?!.*\\s$)([A-Za-zÀ-ÿ0-9.()](\\.|\\s|-|_)?){4,50}$" },
             { "DE", "^(?!.*\\s$)([A-Za-zÀ-ÿ])([A-Za-zÀ-ÿ0-9.()](\\s|-|_)?){4,50}$" },
-            { "FR", "^(?!.*\\s$)([A-Za-z0-9]\\s?){14,17}$" },
+            { "FR", "^\\d{9}$" },
         }.ToImmutableDictionary();
     public static readonly IReadOnlyDictionary<string, string> VAT_ID = new Dictionary<string, string>
         {
-            { "Worldwide", "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-|\\/)?){5,18}$" },
+            { Worldwide, "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-|\\/)?){5,18}$" },
             { "DE", "^DE\\d{9}$" },
             { "IN", "^[a-zA-Z\\d-]{5,15}$" },
             { "MX", "^[a-zA-Z\\d-&]{12,13}$" },
         }.ToImmutableDictionary();
     public static readonly IReadOnlyDictionary<string, string> VIES = new Dictionary<string, string>
         {
-            { "Worldwide", "^[A-Z]{2}[0-9A-Za-z+*.]{2,12}$" }
+            { Worldwide, "^[A-Z]{2}[0-9A-Za-z+*.]{2,12}$" }
         }.ToImmutableDictionary();
     public static readonly IReadOnlyDictionary<string, string> EORI = new Dictionary<string, string>
         {
-            { "Worldwide", "^[A-Z]{2}[A-Za-z0-9]{1,15}$" }
+            { Worldwide, "^[A-Z]{2}[A-Za-z0-9]{1,15}$" }
         }.ToImmutableDictionary();
     public static readonly IReadOnlyDictionary<string, string> LEI_CODE = new Dictionary<string, string>
         {
-            { "Worldwide", "^[A-Za-z0-9]{20}$" }
+            { Worldwide, "^[A-Za-z0-9]{20}$" }
         }.ToImmutableDictionary();
     #endregion
 }

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -17,8 +17,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using System.Collections.Immutable;
-
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 
 public static class ValidationExpressions

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -17,6 +17,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using System.Collections.Immutable;
+
 namespace Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 
 public static class ValidationExpressions
@@ -45,30 +47,30 @@ public static class ValidationExpressions
     public const string Region = "^[A-Z1-9]{1,3}$";
 
     #region UniqueIdentifiers
-    public static class Worldwide
-    {
-        public const string COMMERCIAL_REG_NUMBER = "^(?!.*\\s$)([A-Za-zÀ-ÿ0-9.()](\\.|\\s|-|_)?){4,50}$";
-        public const string VAT_ID = "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-|\\/)?){5,18}$";
-        public const string LEI_CODE = "^[A-Za-z0-9]{20}$";
-        public const string VIES = "^[A-Z]{2}[0-9A-Za-z+*.]{2,12}$";
-        public const string EORI = "^[A-Z]{2}[A-Za-z0-9]{1,15}$";
-    }
-    public static class DE
-    {
-        public const string COMMERCIAL_REG_NUMBER = "^(?!.*\\s$)([A-Za-zÀ-ÿ])([A-Za-zÀ-ÿ0-9.()](\\s|-|_)?){4,50}$";
-        public const string VAT_ID = "^DE\\d{9}$";
-    }
-    public static class FR
-    {
-        public const string COMMERCIAL_REG_NUMBER = "^(?!.*\\s$)([A-Za-z0-9]\\s?){14,17}$";
-    }
-    public static class MX
-    {
-        public const string VAT_ID = "^[a-zA-Z\\d-&]{12,13}$";
-    }
-    public static class IN
-    {
-        public const string VAT_ID = "^[a-zA-Z\\d-]{5,15}$";
-    }
+    public static readonly IReadOnlyDictionary<string, string> COMMERCIAL_REG_NUMBER = new Dictionary<string, string>
+        {
+            { "Worldwide", "^(?!.*\\s$)([A-Za-zÀ-ÿ0-9.()](\\.|\\s|-|_)?){4,50}$" },
+            { "DE", "^(?!.*\\s$)([A-Za-zÀ-ÿ])([A-Za-zÀ-ÿ0-9.()](\\s|-|_)?){4,50}$" },
+            { "FR", "^(?!.*\\s$)([A-Za-z0-9]\\s?){14,17}$" },
+        }.ToImmutableDictionary();
+    public static readonly IReadOnlyDictionary<string, string> VAT_ID = new Dictionary<string, string>
+        {
+            { "Worldwide", "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-|\\/)?){5,18}$" },
+            { "DE", "^DE\\d{9}$" },
+            { "IN", "^[a-zA-Z\\d-]{5,15}$" },
+            { "MX", "^[a-zA-Z\\d-&]{12,13}$" },
+        }.ToImmutableDictionary();
+    public static readonly IReadOnlyDictionary<string, string> VIES = new Dictionary<string, string>
+        {
+            { "Worldwide", "^[A-Z]{2}[0-9A-Za-z+*.]{2,12}$" }
+        }.ToImmutableDictionary();
+    public static readonly IReadOnlyDictionary<string, string> EORI = new Dictionary<string, string>
+        {
+            { "Worldwide", "^[A-Z]{2}[A-Za-z0-9]{1,15}$" }
+        }.ToImmutableDictionary();
+    public static readonly IReadOnlyDictionary<string, string> LEI_CODE = new Dictionary<string, string>
+        {
+            { "Worldwide", "^[A-Za-z0-9]{20}$" }
+        }.ToImmutableDictionary();
     #endregion
 }

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -48,30 +48,30 @@ public static class ValidationExpressions
 
     #region UniqueIdentifiers
     private const string Worldwide = "Worldwide";
-    public static readonly IReadOnlyDictionary<string, string> COMMERCIAL_REG_NUMBER = new Dictionary<string, string>
-        {
-            { Worldwide, "^(?!.*\\s$)([A-Za-zÀ-ÿ0-9.()](\\.|\\s|-|_)?){4,50}$" },
-            { "DE", "^(?!.*\\s$)([A-Za-zÀ-ÿ])([A-Za-zÀ-ÿ0-9.()](\\s|-|_)?){4,50}$" },
-            { "FR", "^\\d{9}$" },
-        }.ToImmutableDictionary();
-    public static readonly IReadOnlyDictionary<string, string> VAT_ID = new Dictionary<string, string>
-        {
-            { Worldwide, "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-|\\/)?){5,18}$" },
-            { "DE", "^DE\\d{9}$" },
-            { "IN", "^[a-zA-Z\\d-]{5,15}$" },
-            { "MX", "^[a-zA-Z\\d-&]{12,13}$" },
-        }.ToImmutableDictionary();
-    public static readonly IReadOnlyDictionary<string, string> VIES = new Dictionary<string, string>
-        {
-            { Worldwide, "^[A-Z]{2}[0-9A-Za-z+*.]{2,12}$" }
-        }.ToImmutableDictionary();
-    public static readonly IReadOnlyDictionary<string, string> EORI = new Dictionary<string, string>
-        {
-            { Worldwide, "^[A-Z]{2}[A-Za-z0-9]{1,15}$" }
-        }.ToImmutableDictionary();
-    public static readonly IReadOnlyDictionary<string, string> LEI_CODE = new Dictionary<string, string>
-        {
-            { Worldwide, "^[A-Za-z0-9]{20}$" }
-        }.ToImmutableDictionary();
+    public static readonly IEnumerable<(string, string)> COMMERCIAL_REG_NUMBER =
+        [
+            ( Worldwide, "^(?!.*\\s$)([A-Za-zÀ-ÿ0-9.()](\\.|\\s|-|_)?){4,50}$" ),
+            ( "DE", "^(?!.*\\s$)([A-Za-zÀ-ÿ])([A-Za-zÀ-ÿ0-9.()](\\s|-|_)?){4,50}$" ),
+            ( "FR", "^\\d{9}$" ),
+        ];
+    public static readonly IEnumerable<(string, string)> VAT_ID =
+        [
+            ( Worldwide, "^(?!.*\\s$)([A-Za-z0-9](\\.|\\s|-|\\/)?){5,18}$" ),
+            ( "DE", "^DE\\d{9}$" ),
+            ( "IN", "^[a-zA-Z\\d-]{5,15}$" ),
+            ( "MX", "^[a-zA-Z\\d-&]{12,13}$" ),
+        ];
+    public static readonly IEnumerable<(string, string)> VIES =
+        [
+            ( Worldwide, "^[A-Z]{2}[0-9A-Za-z+*.]{2,12}$" )
+        ];
+    public static readonly IEnumerable<(string, string)> EORI =
+        [
+            ( Worldwide, "^[A-Z]{2}[A-Za-z0-9]{1,15}$" )
+        ];
+    public static readonly IEnumerable<(string, string)> LEI_CODE =
+        [
+            ( Worldwide, "^[A-Za-z0-9]{20}$" )
+        ];
     #endregion
 }

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -45,7 +45,7 @@ public static class ValidationExpressions
     public const string Region = "^[A-Z1-9]{1,3}$";
 
     #region UniqueIdentifiers
-    private const string Worldwide = "Worldwide";
+    public const string Worldwide = "Worldwide";
     public static readonly IEnumerable<(string, string)> COMMERCIAL_REG_NUMBER =
         [
             ( Worldwide, "^(?!.*\\s$)([A-Za-zÀ-ÿ0-9.()](\\.|\\s|-|_)?){4,50}$" ),

--- a/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
+++ b/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.10.0</VersionPrefix>
+    <VersionPrefix>3.11.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/registration/Registration.Common/RegistrationValidation.cs
+++ b/src/registration/Registration.Common/RegistrationValidation.cs
@@ -31,6 +31,15 @@ public static class RegistrationValidation
 {
     private static readonly Regex BpnRegex = new(ValidationExpressions.Bpn, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private static readonly Regex RegionRegex = new(ValidationExpressions.Region, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static readonly IReadOnlyDictionary<(UniqueIdentifierId, string), Regex> UniqueIdentifierExpressions = ImmutableDictionary.CreateRange(
+        new (UniqueIdentifierId Identifier, IEnumerable<(string Country, string Expression)> Expressions)[]
+        {
+            (UniqueIdentifierId.COMMERCIAL_REG_NUMBER, ValidationExpressions.COMMERCIAL_REG_NUMBER),
+            (UniqueIdentifierId.VAT_ID, ValidationExpressions.VAT_ID),
+            (UniqueIdentifierId.VIES, ValidationExpressions.VIES),
+            (UniqueIdentifierId.EORI, ValidationExpressions.EORI),
+            (UniqueIdentifierId.LEI_CODE, ValidationExpressions.LEI_CODE)
+        }.SelectMany(x => x.Expressions.Select(y => KeyValuePair.Create((x.Identifier, y.Country), new Regex(y.Expression, RegexOptions.Compiled, TimeSpan.FromSeconds(1))))));
 
     public static void ValidateData(this RegistrationData data)
     {
@@ -141,13 +150,4 @@ public static class RegistrationValidation
         }
         return regex.IsMatch(value);
     }
-    private static readonly IReadOnlyDictionary<(UniqueIdentifierId, string), Regex> UniqueIdentifierExpressions = ImmutableDictionary.CreateRange(
-        new (UniqueIdentifierId Identifier, IEnumerable<(string Country, string Expression)> Expressions)[]
-        {
-            (UniqueIdentifierId.COMMERCIAL_REG_NUMBER, ValidationExpressions.COMMERCIAL_REG_NUMBER),
-            (UniqueIdentifierId.VAT_ID, ValidationExpressions.VAT_ID),
-            (UniqueIdentifierId.VIES, ValidationExpressions.VIES),
-            (UniqueIdentifierId.EORI, ValidationExpressions.EORI),
-            (UniqueIdentifierId.LEI_CODE, ValidationExpressions.LEI_CODE)
-        }.SelectMany(x => x.Expressions.Select(y => KeyValuePair.Create((x.Identifier, y.Country), new Regex(y.Expression, RegexOptions.Compiled, TimeSpan.FromSeconds(1))))));
 }

--- a/src/registration/Registration.Common/RegistrationValidation.cs
+++ b/src/registration/Registration.Common/RegistrationValidation.cs
@@ -80,7 +80,7 @@ public static class RegistrationValidation
                 Enumerable.Repeat(new ErrorParameter("duplicateValues", string.Join(", ", duplicateIds.Select(uniqueId => uniqueId.UniqueIdentifierId))), 1));
         }
 
-        data.UniqueIds.Where(uniqueId => IsInvalidValueByUniqueIdentifier(uniqueId.Value, uniqueId.UniqueIdentifierId, data.CountryAlpha2Code))
+        data.UniqueIds.Where(uniqueId => !IsInvalidValueByUniqueIdentifier(uniqueId.Value, uniqueId.UniqueIdentifierId, data.CountryAlpha2Code))
             .IfAny(invalidUniqueIdentifiersValues =>
                 {
                     throw new ControllerArgumentException(
@@ -135,11 +135,11 @@ public static class RegistrationValidation
     private static bool IsInvalidValueByUniqueIdentifier(string value, UniqueIdentifierId uniqueIdentifierId, string countryCode) =>
         uniqueIdentifierId switch
         {
-            UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !IsRegexMatched(ValidationExpressions.COMMERCIAL_REG_NUMBER, countryCode).IsMatch(value),
-            UniqueIdentifierId.VAT_ID => !IsRegexMatched(ValidationExpressions.VAT_ID, countryCode).IsMatch(value),
-            UniqueIdentifierId.LEI_CODE => !IsRegexMatched(ValidationExpressions.LEI_CODE, countryCode).IsMatch(value),
-            UniqueIdentifierId.VIES => !IsRegexMatched(ValidationExpressions.VIES, countryCode).IsMatch(value),
-            UniqueIdentifierId.EORI => !IsRegexMatched(ValidationExpressions.EORI, countryCode).IsMatch(value),
+            UniqueIdentifierId.COMMERCIAL_REG_NUMBER => IsRegexMatched(ValidationExpressions.COMMERCIAL_REG_NUMBER, countryCode).IsMatch(value),
+            UniqueIdentifierId.VAT_ID => IsRegexMatched(ValidationExpressions.VAT_ID, countryCode).IsMatch(value),
+            UniqueIdentifierId.LEI_CODE => IsRegexMatched(ValidationExpressions.LEI_CODE, countryCode).IsMatch(value),
+            UniqueIdentifierId.VIES => IsRegexMatched(ValidationExpressions.VIES, countryCode).IsMatch(value),
+            UniqueIdentifierId.EORI => IsRegexMatched(ValidationExpressions.EORI, countryCode).IsMatch(value),
             _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
         };
 

--- a/src/registration/Registration.Common/RegistrationValidation.cs
+++ b/src/registration/Registration.Common/RegistrationValidation.cs
@@ -146,7 +146,7 @@ public static class RegistrationValidation
     {
         if (!UniqueIdentifierExpressions.TryGetValue((uniqueIdentifierId, countryCode), out var regex))
         {
-            regex = UniqueIdentifierExpressions.GetValueOrDefault((uniqueIdentifierId, "Worldwide")) ?? throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId));
+            regex = UniqueIdentifierExpressions.GetValueOrDefault((uniqueIdentifierId, ValidationExpressions.Worldwide)) ?? throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId));
         }
         return regex.IsMatch(value);
     }

--- a/src/registration/Registration.Common/RegistrationValidation.cs
+++ b/src/registration/Registration.Common/RegistrationValidation.cs
@@ -29,11 +29,6 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Registration.Common;
 public static class RegistrationValidation
 {
     private static readonly Regex BpnRegex = new(ValidationExpressions.Bpn, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-    private static readonly Regex CommercialRegNumRegex = new(ValidationExpressions.COMMERCIAL_REG_NUMBER, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-    private static readonly Regex VatIdRegex = new(ValidationExpressions.VAT_ID, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-    private static readonly Regex LeiCodeRegex = new(ValidationExpressions.LEI_CODE, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-    private static readonly Regex ViesRegex = new(ValidationExpressions.VIES, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-    private static readonly Regex EoriRegex = new(ValidationExpressions.EORI, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
     private static readonly Regex RegionRegex = new(ValidationExpressions.Region, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
     public static void ValidateData(this RegistrationData data)
@@ -85,7 +80,7 @@ public static class RegistrationValidation
                 Enumerable.Repeat(new ErrorParameter("duplicateValues", string.Join(", ", duplicateIds.Select(uniqueId => uniqueId.UniqueIdentifierId))), 1));
         }
 
-        data.UniqueIds.Where(uniqueId => IsInvalidValueByUniqueIdentifier(uniqueId.Value, uniqueId.UniqueIdentifierId))
+        data.UniqueIds.Where(uniqueId => IsInvalidValueByUniqueIdentifier(uniqueId.Value, uniqueId.UniqueIdentifierId, data.CountryAlpha2Code))
             .IfAny(invalidUniqueIdentifiersValues =>
                 {
                     throw new ControllerArgumentException(
@@ -137,14 +132,55 @@ public static class RegistrationValidation
         }
     }
 
-    private static bool IsInvalidValueByUniqueIdentifier(string value, UniqueIdentifierId uniqueIdentifierId) =>
-        uniqueIdentifierId switch
+    private static bool IsInvalidValueByUniqueIdentifier(string value, UniqueIdentifierId uniqueIdentifierId, string countryCode) =>
+        countryCode switch
         {
-            UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !CommercialRegNumRegex.IsMatch(value),
-            UniqueIdentifierId.VAT_ID => !VatIdRegex.IsMatch(value),
-            UniqueIdentifierId.LEI_CODE => !LeiCodeRegex.IsMatch(value),
-            UniqueIdentifierId.VIES => !ViesRegex.IsMatch(value),
-            UniqueIdentifierId.EORI => !EoriRegex.IsMatch(value),
-            _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId))
+            "DE" => uniqueIdentifierId switch
+            {
+                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.DE.COMMERCIAL_REG_NUMBER).IsMatch(value),
+                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.DE.VAT_ID).IsMatch(value),
+                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
+                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
+                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
+                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
+            },
+            "FR" => uniqueIdentifierId switch
+            {
+                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.FR.COMMERCIAL_REG_NUMBER).IsMatch(value),
+                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.Worldwide.VAT_ID).IsMatch(value),
+                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
+                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
+                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
+                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
+            },
+            "MX" => uniqueIdentifierId switch
+            {
+                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.Worldwide.COMMERCIAL_REG_NUMBER).IsMatch(value),
+                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.MX.VAT_ID).IsMatch(value),
+                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
+                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
+                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
+                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
+            },
+            "IN" => uniqueIdentifierId switch
+            {
+                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.Worldwide.COMMERCIAL_REG_NUMBER).IsMatch(value),
+                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.IN.VAT_ID).IsMatch(value),
+                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
+                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
+                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
+                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
+            },
+            _ => uniqueIdentifierId switch
+            {
+                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.Worldwide.COMMERCIAL_REG_NUMBER).IsMatch(value),
+                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.Worldwide.VAT_ID).IsMatch(value),
+                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
+                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
+                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
+                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
+            }
         };
+
+    private static Regex Regex(string regex) => new(regex, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 }

--- a/src/registration/Registration.Common/RegistrationValidation.cs
+++ b/src/registration/Registration.Common/RegistrationValidation.cs
@@ -133,54 +133,21 @@ public static class RegistrationValidation
     }
 
     private static bool IsInvalidValueByUniqueIdentifier(string value, UniqueIdentifierId uniqueIdentifierId, string countryCode) =>
-        countryCode switch
+        uniqueIdentifierId switch
         {
-            "DE" => uniqueIdentifierId switch
-            {
-                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.DE.COMMERCIAL_REG_NUMBER).IsMatch(value),
-                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.DE.VAT_ID).IsMatch(value),
-                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
-                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
-                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
-                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
-            },
-            "FR" => uniqueIdentifierId switch
-            {
-                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.FR.COMMERCIAL_REG_NUMBER).IsMatch(value),
-                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.Worldwide.VAT_ID).IsMatch(value),
-                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
-                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
-                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
-                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
-            },
-            "MX" => uniqueIdentifierId switch
-            {
-                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.Worldwide.COMMERCIAL_REG_NUMBER).IsMatch(value),
-                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.MX.VAT_ID).IsMatch(value),
-                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
-                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
-                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
-                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
-            },
-            "IN" => uniqueIdentifierId switch
-            {
-                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.Worldwide.COMMERCIAL_REG_NUMBER).IsMatch(value),
-                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.IN.VAT_ID).IsMatch(value),
-                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
-                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
-                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
-                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
-            },
-            _ => uniqueIdentifierId switch
-            {
-                UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !Regex(ValidationExpressions.Worldwide.COMMERCIAL_REG_NUMBER).IsMatch(value),
-                UniqueIdentifierId.VAT_ID => !Regex(ValidationExpressions.Worldwide.VAT_ID).IsMatch(value),
-                UniqueIdentifierId.LEI_CODE => !Regex(ValidationExpressions.Worldwide.LEI_CODE).IsMatch(value),
-                UniqueIdentifierId.VIES => !Regex(ValidationExpressions.Worldwide.VIES).IsMatch(value),
-                UniqueIdentifierId.EORI => !Regex(ValidationExpressions.Worldwide.EORI).IsMatch(value),
-                _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
-            }
+            UniqueIdentifierId.COMMERCIAL_REG_NUMBER => !IsRegexMatched(ValidationExpressions.COMMERCIAL_REG_NUMBER, countryCode).IsMatch(value),
+            UniqueIdentifierId.VAT_ID => !IsRegexMatched(ValidationExpressions.VAT_ID, countryCode).IsMatch(value),
+            UniqueIdentifierId.LEI_CODE => !IsRegexMatched(ValidationExpressions.LEI_CODE, countryCode).IsMatch(value),
+            UniqueIdentifierId.VIES => !IsRegexMatched(ValidationExpressions.VIES, countryCode).IsMatch(value),
+            UniqueIdentifierId.EORI => !IsRegexMatched(ValidationExpressions.EORI, countryCode).IsMatch(value),
+            _ => throw new ControllerArgumentException($"Unique identifier: {uniqueIdentifierId} is not available in the system", nameof(uniqueIdentifierId)),
         };
 
-    private static Regex Regex(string regex) => new(regex, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static Regex IsRegexMatched(IReadOnlyDictionary<string, string> identifier, string countryCode)
+    {
+        if (!identifier.TryGetValue(countryCode, out var regex))
+            regex = identifier.GetValueOrDefault("Worldwide")!;
+
+        return new(regex, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    }
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/NetworkBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/NetworkBusinessLogicTests.cs
@@ -501,8 +501,7 @@ public class NetworkBusinessLogicTests
     [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "F1103R_HRB98814", "DE")]
 
     // FR
-    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "Paris HRB 175450", "FR")]
-    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "F1103R HRB98814", "FR")]
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "849281571", "FR")]
 
     // MX
     [InlineData(UniqueIdentifierId.VAT_ID, "MX-1234567890", "MX")]

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -754,8 +754,7 @@ public class RegistrationBusinessLogicTest
     [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "F1103R_HRB98814", "DE")]
 
     // FR
-    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "Paris HRB 175450", "FR")]
-    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "F1103R HRB98814", "FR")]
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "849281571", "FR")]
 
     // MX
     [InlineData(UniqueIdentifierId.VAT_ID, "MX-1234567890", "MX")]

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -739,8 +739,33 @@ public class RegistrationBusinessLogicTest
             c.BusinessPartnerNumber == companyData.BusinessPartnerNumber);
     }
 
-    [Fact]
-    public async Task SetCompanyWithAddressAsync__WithCompanyNameChange_ModifiesCompany()
+    [Theory]
+    // Worldwide
+    [InlineData(UniqueIdentifierId.VAT_ID, "WW129273398", "WW")]
+    [InlineData(UniqueIdentifierId.VIES, "WW129273398", "WW")]
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "München HRB 175450", "WW")]
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "F1103R_HRB98814", "WW")]
+    [InlineData(UniqueIdentifierId.EORI, "WW12345678912345", "WW")]
+    [InlineData(UniqueIdentifierId.LEI_CODE, "529900T8BM49AURSDO55", "WW")]
+
+    // DE
+    [InlineData(UniqueIdentifierId.VAT_ID, "DE129273398", "DE")]
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "München HRB 175450", "DE")]
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "F1103R_HRB98814", "DE")]
+
+    // FR
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "Paris HRB 175450", "FR")]
+    [InlineData(UniqueIdentifierId.COMMERCIAL_REG_NUMBER, "F1103R HRB98814", "FR")]
+
+    // MX
+    [InlineData(UniqueIdentifierId.VAT_ID, "MX-1234567890", "MX")]
+    [InlineData(UniqueIdentifierId.VAT_ID, "MX1234567890", "MX")]
+    [InlineData(UniqueIdentifierId.VAT_ID, "MX1234567890&", "MX")]
+
+    // IN
+    [InlineData(UniqueIdentifierId.VAT_ID, "IN123456789", "IN")]
+    [InlineData(UniqueIdentifierId.VAT_ID, "IN-123456789", "IN")]
+    public async Task SetCompanyWithAddressAsync__WithCompanyNameChange_ModifiesCompany(UniqueIdentifierId uniqueIdentifierId, string identifierValue, string countryCode)
     {
         //Arrange
         var applicationId = Guid.NewGuid();
@@ -755,9 +780,9 @@ public class RegistrationBusinessLogicTest
             .With(x => x.Name, "Test Company Updated Name")
             .With(x => x.BusinessPartnerNumber, "BPNL00000001TEST")
             .With(x => x.CompanyId, companyId)
-            .With(x => x.CountryAlpha2Code, _alpha2code)
+            .With(x => x.CountryAlpha2Code, countryCode)
             .With(x => x.Region, _region)
-            .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, _vatId)])
+            .With(x => x.UniqueIds, [new CompanyUniqueIdData(uniqueIdentifierId, identifierValue)])
             .Create();
 
         var sut = new RegistrationBusinessLogic(


### PR DESCRIPTION
## Description

UniqueIdentifier's regex updates country wise, as per frontend: https://github.com/eclipse-tractusx/portal-frontend-registration/blob/main/src/types/Patterns.ts

## Why

- Currently, umlauts are not being validated when used as CRN: München HRB 42243 and return 400 error.
- As per new Tagus release changes, Commercial registration number needs to be validated with this format: F1103R_HRB98814

## Issue

Ref: #1314

## Corresponding Frontend PR

https://github.com/eclipse-tractusx/portal-frontend-registration/pull/364

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas