### PR TITLE
fix(auto-setup): fixed the validation and request for callback url

### DIFF
--- a/src/externalsystems/OfferProvider.Library/BusinessLogic/OfferProviderBusinessLogic.cs
+++ b/src/externalsystems/OfferProvider.Library/BusinessLogic/OfferProviderBusinessLogic.cs
@@ -121,35 +121,38 @@ public class OfferProviderBusinessLogic : IOfferProviderBusinessLogic
             throw new ConflictException("Client should be set");
         }
 
-        if (data.ServiceAccounts.Count() > 1)
-        {
-            throw new ConflictException("There should be not more than one service account for the offer subscription");
-        }
+        List<CallbackTechnicalUserInfoData>? technicalUsersInfoData = null;
 
-        CallbackTechnicalUserInfoData? technicalUserInfoData = null;
-        if (data.ServiceAccounts.Count() == 1)
+        if (data.ServiceAccounts?.Any() == true)
         {
-            var serviceAccount = data.ServiceAccounts.First();
-            if (serviceAccount.TechnicalClientId == null)
-            {
-                throw new ConflictException($"ClientId of serviceAccount {serviceAccount.TechnicalUserId} should be set");
-            }
+            technicalUsersInfoData = [];
             async Task<string?> GetServiceAccountSecret(string technicalClientId)
             {
                 var internalClientId = await _provisioningManager.GetIdOfCentralClientAsync(technicalClientId).ConfigureAwait(ConfigureAwaitOptions.None);
                 var authData = await _provisioningManager.GetCentralClientAuthDataAsync(internalClientId).ConfigureAwait(ConfigureAwaitOptions.None);
                 return authData.Secret;
             }
-            technicalUserInfoData = new CallbackTechnicalUserInfoData(
-                serviceAccount.TechnicalUserId,
-                serviceAccount.TechnicalUserKindId == TechnicalUserKindId.INTERNAL
+
+            foreach (var serviceAccount in data.ServiceAccounts)
+            {
+                if (serviceAccount.TechnicalClientId == null)
+                {
+                    throw new ConflictException($"ClientId of serviceAccount {serviceAccount.TechnicalUserId} should be set");
+                }
+
+                var secret = serviceAccount.TechnicalUserKindId == TechnicalUserKindId.INTERNAL
                     ? await GetServiceAccountSecret(serviceAccount.TechnicalClientId).ConfigureAwait(ConfigureAwaitOptions.None)
-                    : null,
-                serviceAccount.TechnicalClientId);
+                    : null;
+
+                technicalUsersInfoData.Add(new CallbackTechnicalUserInfoData(
+                    serviceAccount.TechnicalUserId,
+                    secret,
+                    serviceAccount.TechnicalClientId));
+            }
         }
 
         var callbackData = new OfferProviderCallbackData(
-            technicalUserInfoData,
+            technicalUsersInfoData,
             new CallbackClientInfoData(data.ClientId)
         );
         await _offerProviderService

--- a/src/externalsystems/OfferProvider.Library/Models/OfferProviderCallbackData.cs
+++ b/src/externalsystems/OfferProvider.Library/Models/OfferProviderCallbackData.cs
@@ -25,10 +25,10 @@ namespace Org.Eclipse.TractusX.Portal.Backend.OfferProvider.Library.Models;
 /// <summary>
 /// Callback data for the offer provider after the auto setup succeeded
 /// </summary>
-/// <param name="TechnicalUserInfo">Object containing the information of the technical user</param>
+/// <param name="TechnicalUsersInfo">List containing the information of the technical users</param>
 /// <param name="ClientInfo">Information of the created client</param>
 public record OfferProviderCallbackData(
-    [property: JsonPropertyName("technicalUserInfo")] CallbackTechnicalUserInfoData? TechnicalUserInfo,
+    [property: JsonPropertyName("technicalUsersInfo")] IEnumerable<CallbackTechnicalUserInfoData>? TechnicalUsersInfo,
     [property: JsonPropertyName("clientInfo")] CallbackClientInfoData? ClientInfo
 );
 

--- a/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
+++ b/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
@@ -262,7 +262,7 @@ public class OfferProviderBusinessLogicTests
         };
 
         var serviceAccounts = technicalUsers
-            .Select(tu => (tu.Id, (string?)tu.ClientId, TechnicalUserKindId.INTERNAL))
+            .Select(tu => (tu.Id, tu.ClientId, TechnicalUserKindId.INTERNAL))
             .ToArray();
 
         A.CallTo(() => _offerSubscriptionRepository.GetTriggerProviderCallbackInformation(_subscriptionId))

--- a/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
+++ b/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
@@ -191,7 +191,6 @@ public class OfferProviderBusinessLogicTests
     {
         // Arrange
         var technicalUserId = Guid.NewGuid();
-        var technicalUserInternalClientId = Guid.NewGuid().ToString();
         var serviceAccounts = new (Guid, string?, TechnicalUserKindId)[]
         {
             new(technicalUserId, null, TechnicalUserKindId.INTERNAL)

--- a/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
+++ b/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
@@ -247,8 +247,8 @@ public class OfferProviderBusinessLogicTests
         result.nextStepTypeIds.Should().BeNull();
         result.stepStatusId.Should().Be(ProcessStepStatusId.DONE);
         result.modified.Should().BeTrue();
-        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUsersInfo!.FirstOrDefault()!.TechnicalUserSecret == "test123"), A<string>._, A<CancellationToken>._))
-            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUsersInfo != null && x.TechnicalUsersInfo.Count() > 0 && x.TechnicalUsersInfo.First().TechnicalUserSecret == "test123"), A<string>._, A<CancellationToken>._))
+    .MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -257,8 +257,8 @@ public class OfferProviderBusinessLogicTests
         // Arrange
         var technicalUsers = new[]
         {
-        new { Id = Guid.NewGuid(), ClientId = "sa1", InternalClientId = Guid.NewGuid().ToString(), Secret = "test123" },
-        new { Id = Guid.NewGuid(), ClientId = "sa2", InternalClientId = Guid.NewGuid().ToString(), Secret = "test456" }
+            new { Id = Guid.NewGuid(), ClientId = "sa1", InternalClientId = Guid.NewGuid().ToString(), Secret = "test123" },
+            new { Id = Guid.NewGuid(), ClientId = "sa2", InternalClientId = Guid.NewGuid().ToString(), Secret = "test456" }
         };
 
         var serviceAccounts = technicalUsers
@@ -322,7 +322,7 @@ public class OfferProviderBusinessLogicTests
             .MustNotHaveHappened();
         A.CallTo(() => _provisioningManager.GetCentralClientAuthDataAsync(A<string>._))
             .MustNotHaveHappened();
-        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUsersInfo!.FirstOrDefault()!.TechnicalUserSecret == null), A<string>._, A<CancellationToken>._))
+        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUsersInfo != null && x.TechnicalUsersInfo.Count() > 0 && x.TechnicalUsersInfo.First().TechnicalUserSecret == null), A<string>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
+++ b/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
@@ -217,30 +217,9 @@ public class OfferProviderBusinessLogicTests
         result.nextStepTypeIds.Should().BeNull();
         result.stepStatusId.Should().Be(ProcessStepStatusId.DONE);
         result.modified.Should().BeTrue();
-        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUserInfo == null), A<string>._, A<CancellationToken>._))
+        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUsersInfo == null), A<string>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
 
-    }
-
-    [Fact]
-    public async Task TriggerProviderCallback_WithMultipleServiceAccountSet_Throws()
-    {
-        // Arrange
-        var fakeId = Guid.NewGuid();
-        var serviceAccounts = new (Guid, string?, TechnicalUserKindId)[]
-        {
-            new(Guid.NewGuid(), "sa1", TechnicalUserKindId.INTERNAL),
-            new(Guid.NewGuid(), "sa2", TechnicalUserKindId.INTERNAL)
-        };
-        A.CallTo(() => _offerSubscriptionRepository.GetTriggerProviderCallbackInformation(fakeId))
-            .Returns((serviceAccounts, "cl1", "https://callback.com", OfferSubscriptionStatusId.ACTIVE));
-        async Task Act() => await _sut.TriggerProviderCallback(fakeId, CancellationToken.None);
-
-        // Act
-        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-
-        // Assert
-        ex.Message.Should().Be("There should be not more than one service account for the offer subscription");
     }
 
     [Fact]
@@ -268,8 +247,55 @@ public class OfferProviderBusinessLogicTests
         result.nextStepTypeIds.Should().BeNull();
         result.stepStatusId.Should().Be(ProcessStepStatusId.DONE);
         result.modified.Should().BeTrue();
-        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUserInfo!.TechnicalUserSecret == "test123"), A<string>._, A<CancellationToken>._))
+        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUsersInfo!.FirstOrDefault()!.TechnicalUserSecret == "test123"), A<string>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task TriggerProviderCallback_WithValidData_InternalSA_MultipleTechnicalUsers_ReturnsExpected()
+    {
+        // Arrange
+        var technicalUsers = new[]
+        {
+        new { Id = Guid.NewGuid(), ClientId = "sa1", InternalClientId = Guid.NewGuid().ToString(), Secret = "test123" },
+        new { Id = Guid.NewGuid(), ClientId = "sa2", InternalClientId = Guid.NewGuid().ToString(), Secret = "test456" }
+        };
+
+        var serviceAccounts = technicalUsers
+            .Select(tu => (tu.Id, (string?)tu.ClientId, TechnicalUserKindId.INTERNAL))
+            .ToArray();
+
+        A.CallTo(() => _offerSubscriptionRepository.GetTriggerProviderCallbackInformation(_subscriptionId))
+            .Returns((serviceAccounts, "cl1", "https://callback.com", OfferSubscriptionStatusId.ACTIVE));
+
+        foreach (var user in technicalUsers)
+        {
+            A.CallTo(() => _provisioningManager.GetIdOfCentralClientAsync(user.ClientId))
+                .Returns(user.InternalClientId);
+            A.CallTo(() => _provisioningManager.GetCentralClientAuthDataAsync(user.InternalClientId))
+                .Returns(new ClientAuthData(IamClientAuthMethod.SECRET) { Secret = user.Secret });
+        }
+
+        // Act
+        var result = await _sut.TriggerProviderCallback(_subscriptionId, CancellationToken.None);
+
+        // Assert
+        result.nextStepTypeIds.Should().BeNull();
+        result.stepStatusId.Should().Be(ProcessStepStatusId.DONE);
+        result.modified.Should().BeTrue();
+
+        var expectedTechnicalUsers = technicalUsers.Select(tu =>
+          new CallbackTechnicalUserInfoData(tu.Id, tu.Secret, tu.ClientId)).ToList();
+
+        // Verify the callback method was called with the expected data
+        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(
+            A<OfferProviderCallbackData>.That.Matches(x =>
+                x.TechnicalUsersInfo != null &&
+                x.TechnicalUsersInfo.SequenceEqual(expectedTechnicalUsers)
+            ),
+            A<string>._,
+            A<CancellationToken>._
+        )).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
@@ -296,7 +322,7 @@ public class OfferProviderBusinessLogicTests
             .MustNotHaveHappened();
         A.CallTo(() => _provisioningManager.GetCentralClientAuthDataAsync(A<string>._))
             .MustNotHaveHappened();
-        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUserInfo!.TechnicalUserSecret == null), A<string>._, A<CancellationToken>._))
+        A.CallTo(() => _offerProviderService.TriggerOfferProviderCallback(A<OfferProviderCallbackData>.That.Matches(x => x.TechnicalUsersInfo!.FirstOrDefault()!.TechnicalUserSecret == null), A<string>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
+++ b/tests/externalsystems/OfferProvider.Library.Tests/BusinessLogic/OfferProviderBusinessLogicTests.cs
@@ -187,6 +187,28 @@ public class OfferProviderBusinessLogicTests
     }
 
     [Fact]
+    public async Task TriggerProviderCallback_WithTechnicalClientIdNotSet_Throws()
+    {
+        // Arrange
+        var technicalUserId = Guid.NewGuid();
+        var technicalUserInternalClientId = Guid.NewGuid().ToString();
+        var serviceAccounts = new (Guid, string?, TechnicalUserKindId)[]
+        {
+            new(technicalUserId, null, TechnicalUserKindId.INTERNAL)
+        };
+        var fakeId = Guid.NewGuid();
+        A.CallTo(() => _offerSubscriptionRepository.GetTriggerProviderCallbackInformation(fakeId))
+            .Returns((serviceAccounts, "cl1", "callback", OfferSubscriptionStatusId.ACTIVE));
+        async Task Act() => await _sut.TriggerProviderCallback(fakeId, CancellationToken.None);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ConflictException>(Act);
+
+        // Assert
+        ex.Message.Should().Be($"ClientId of serviceAccount {technicalUserId} should be set");
+    }
+
+    [Fact]
     public async Task TriggerProviderCallback_WithCallbackUrlNotSet_Skips()
     {
         // Arrange


### PR DESCRIPTION
## Description

Removed the validation which was for single technical users only
Updated the request body sent in the callback URL 

## Why

Now the app can have multiple technical users, so this fix is to enable the code to send multiple technical users to the callback URL.

## Issue

#1307 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
