### PR TITLE
feat(technical user role): add connector management

### DIFF
--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_assigned_collections.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_assigned_collections.json
@@ -84,6 +84,10 @@
     "user_role_collection_id": "8cb12ea2-aed4-4d75-b041-ba297df3d2f2"
   },
   {
+    "user_role_id": "607818be-4978-41f4-bf63-fa8d2de51169",
+    "user_role_collection_id": "8cb12ea2-aed4-4d75-b041-ba297df3d2f2"
+  },
+  {
     "user_role_id": "607818be-4978-41f4-bf63-fa8d2de51180",
     "user_role_collection_id": "a5b8b1de-7759-4620-9c87-6b6d74fb4fbc"
   },

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_descriptions.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_role_descriptions.json
@@ -150,6 +150,16 @@
     "description": "Technical user to add offers; activate subscription requests and create managed connector registrations for 3rd parties."
   },
   {
+    "user_role_id": "607818be-4978-41f4-bf63-fa8d2de51169",
+    "language_short_name": "de",
+    "description": "Technischer User zur Verwaltung (Anzeigen, Erstellen, Modifizieren und Löschen) von Unternehmens-Connectors und des technischen Users über die API, für die vollständige Automatisierung der Connector-Registrierung."
+  },
+  {
+    "user_role_id": "607818be-4978-41f4-bf63-fa8d2de51169",
+    "language_short_name": "en",
+    "description": "Technical user to manage (view, create, modify, and delete) company connectors and the technical user via API for full automation of connector registration."
+  },
+  {
     "user_role_id": "34c42896-a003-4653-af8f-ba06ca595752",
     "language_short_name": "de",
     "description": "Technischer User zur Erstellung von Registrierungen von Drittanbietern durch Onboarding Service Provider."

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_roles.json
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/Data/user_roles.json
@@ -120,6 +120,12 @@
     "last_editor_id": null
   },
   {
+    "id": "607818be-4978-41f4-bf63-fa8d2de51169",
+    "user_role": "Connector Management",
+    "offer_id": "0ffcb416-1101-4ba6-8d4a-a9dfa31745a4",
+    "last_editor_id": null
+  },
+  {
     "id": "3940f9b0-4393-4463-b659-15463098557b",
     "user_role": "Semantic Model Management",
     "offer_id": "0ffcb416-1101-4ba6-8d4a-a9dfa31745a4",

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -691,7 +691,7 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Assert
         result.Should().NotBe(default);
         result.Bpn.Should().Be("BPNL00000003CRHK");
-        result.TechnicalUserRoleIds.Should().HaveCount(19).And.OnlyHaveUniqueItems();
+        result.TechnicalUserRoleIds.Should().HaveCount(20).And.OnlyHaveUniqueItems();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRoleCollectionRolesViewTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRoleCollectionRolesViewTests.cs
@@ -45,7 +45,7 @@ public class CompanyRoleCollectionRolesViewTests : IAssemblyFixture<TestDbFixtur
 
         // Act
         var result = await sut.CompanyRoleCollectionRolesView.ToListAsync();
-        result.Should().HaveCount(62);
+        result.Should().HaveCount(63);
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRolesRepositoryTests.cs
@@ -56,7 +56,7 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         var data = await sut.GetCoreOfferRolesAsync(_validCompanyId, "en", ClientId).ToListAsync();
 
         // Assert
-        data.Should().HaveCount(19);
+        data.Should().HaveCount(20);
     }
 
     #endregion
@@ -109,7 +109,7 @@ public class UserRolesRepositoryTests : IAssemblyFixture<TestDbFixture>
         var data = await sut.GetServiceAccountRolesAsync(_validCompanyId, ClientId, Constants.DefaultLanguage).ToListAsync();
 
         // Assert
-        data.Should().HaveCount(19);
+        data.Should().HaveCount(20);
         data.Should().OnlyHaveUniqueItems();
     }
 


### PR DESCRIPTION
## Description

Add new Connector Manager role to seeding data and update tests. For Active Participant.

## Why

Customer want to manage connector registration via API to automate registration flow.

## Issue

Refs: #1329
Depends on: eclipse-tractusx/portal-iam#271 / eclipse-tractusx/portal-iam#276 by @arnabcx

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
