### PR TITLE
fix(userstatus): add Service endpoint msg for pending user status of technical user.

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/TechnicalUserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/TechnicalUserBusinessLogic.cs
@@ -168,7 +168,7 @@ public class TechnicalUserBusinessLogic(
 
         if (result.DimServiceAccountData != null)
         {
-            authServiceUrl = result.DimServiceAccountData.AuthenticationServiceUrl;
+            authServiceUrl = (result.Status != UserStatusId.PENDING) ? result.DimServiceAccountData.AuthenticationServiceUrl : "Technical User Status is Still in pending state";
             iamClientAuthMethod = IamClientAuthMethod.SECRET;
             var cryptoHelper = _settings.EncryptionConfigs.GetCryptoHelper(_settings.EncryptionConfigIndex);
             secret = cryptoHelper.Decrypt(

--- a/src/administration/Administration.Service/BusinessLogic/TechnicalUserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/TechnicalUserBusinessLogic.cs
@@ -168,7 +168,10 @@ public class TechnicalUserBusinessLogic(
 
         if (result.DimServiceAccountData != null)
         {
-            authServiceUrl = (result.Status != UserStatusId.PENDING) ? result.DimServiceAccountData.AuthenticationServiceUrl : "Technical User Status is Still in pending state";
+            authServiceUrl = result.Status == UserStatusId.PENDING
+                ? "Technical User Status is Still in pending state"
+                : result.DimServiceAccountData.AuthenticationServiceUrl;
+
             iamClientAuthMethod = IamClientAuthMethod.SECRET;
             var cryptoHelper = _settings.EncryptionConfigs.GetCryptoHelper(_settings.EncryptionConfigIndex);
             secret = cryptoHelper.Decrypt(


### PR DESCRIPTION
## Description

When creating an external technical user and viewing it's details the service endpoint which is displayed is wrong value that value should be shown only when user status is active 

## Why

Proper msg need to show in place of Service Endpoint for existing techincal user with pending user status

## Issue

#1326 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
