### PR TITLE
feat(connector): add validation for technical user in connector registration

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -211,14 +211,15 @@ public class ConnectorsBusinessLogic(
             return;
         }
 
-        if (!await portalRepositories.GetInstance<ITechnicalUserRepository>()
-                .CheckActiveServiceAccountExistsForCompanyAsync(technicalUserId.Value, companyId).ConfigureAwait(ConfigureAwaitOptions.None))
+        var (activeUserExists, linkedToConnectorOrOffer) = await portalRepositories.GetInstance<ITechnicalUserRepository>()
+                .CheckTechnicalUserDetailsAsync(technicalUserId.Value, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
+
+        if (!activeUserExists)
         {
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_NOT_ACTIVE, [new ErrorParameter("technicalUserId", technicalUserId.Value.ToString()), new ErrorParameter("companyId", companyId.ToString())]);
         }
 
-        if (await portalRepositories.GetInstance<ITechnicalUserRepository>()
-        .CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(technicalUserId.Value, companyId).ConfigureAwait(ConfigureAwaitOptions.None))
+        if (linkedToConnectorOrOffer)
         {
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_IN_USE, [new ErrorParameter("technicalUserId", technicalUserId.Value.ToString())]);
         }

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -216,6 +216,12 @@ public class ConnectorsBusinessLogic(
         {
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_NOT_ACTIVE, [new ErrorParameter("technicalUserId", technicalUserId.Value.ToString()), new ErrorParameter("companyId", companyId.ToString())]);
         }
+
+        if (await portalRepositories.GetInstance<ITechnicalUserRepository>()
+        .CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(technicalUserId.Value, companyId).ConfigureAwait(ConfigureAwaitOptions.None))
+        {
+            throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_IN_USE, [new ErrorParameter("technicalUserId", technicalUserId.Value.ToString())]);
+        }
     }
 
     private async Task<Guid> CreateAndRegisterConnectorAsync(

--- a/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
+++ b/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
@@ -44,7 +44,8 @@ public class AdministrationConnectorErrorMessageContainer : IErrorMessageContain
         new((int)AdministrationConnectorErrors.CONNECTOR_CONFLICT_ALREADY_ASSIGNED,"Connector {externalId} already has a document assigned"),
         new((int)AdministrationConnectorErrors.CONNECTOR_NOT_HOST_COMPANY,"Company {companyId} is not the connectors host company"),
         new((int)AdministrationConnectorErrors.CONNECTOR_CONFLICT_INACTIVE_STATE,"Connector {connectorId} is in state {connectorStatusId}"),
-        new((int)AdministrationConnectorErrors.CONNECTOR_DUPLICATE,"Connector {name} does already exists for url {connectorUrl}")
+        new((int)AdministrationConnectorErrors.CONNECTOR_DUPLICATE,"Connector {name} does already exists for url {connectorUrl}"),
+        new((int)AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_IN_USE,"Technical User {technicalUserId} is already used by another connector or offer")
     ]);
 
     public Type Type { get => typeof(AdministrationConnectorErrors); }
@@ -72,5 +73,6 @@ public enum AdministrationConnectorErrors
     CONNECTOR_CONFLICT_ALREADY_ASSIGNED,
     CONNECTOR_NOT_HOST_COMPANY,
     CONNECTOR_CONFLICT_INACTIVE_STATE,
-    CONNECTOR_DUPLICATE
+    CONNECTOR_DUPLICATE,
+    CONNECTOR_ARGUMENT_TECH_USER_IN_USE
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserRepository.cs
@@ -41,6 +41,7 @@ public interface ITechnicalUserRepository
     Task<TechnicalUserDetailedData?> GetOwnTechnicalUserDataUntrackedAsync(Guid technicalUserId, Guid companyId);
     Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnTechnicalUsers(Guid userCompanyId, string? clientId, bool? isOwner, IEnumerable<UserStatusId> userStatusIds);
     Task<bool> CheckActiveServiceAccountExistsForCompanyAsync(Guid technicalUserId, Guid companyId);
+    Task<bool> CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(Guid technicalUserId, Guid companyId);
     Task<(Guid IdentityId, Guid CompanyId)> GetTechnicalUserDataByClientId(string clientId);
     void CreateExternalTechnicalUser(Guid technicalUserId, string authenticationServiceUrl, byte[] secret, byte[] initializationVector, int encryptionMode);
     void CreateExternalTechnicalUserCreationData(Guid technicalUserId, Guid processId);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ITechnicalUserRepository.cs
@@ -40,8 +40,7 @@ public interface ITechnicalUserRepository
     Task<OwnTechnicalUserData?> GetOwnTechnicalUserWithIamUserRolesAsync(Guid technicalUserId, Guid companyId, IEnumerable<ProcessStepTypeId> processStepsToFilter);
     Task<TechnicalUserDetailedData?> GetOwnTechnicalUserDataUntrackedAsync(Guid technicalUserId, Guid companyId);
     Func<int, int, Task<Pagination.Source<CompanyServiceAccountData>?>> GetOwnTechnicalUsers(Guid userCompanyId, string? clientId, bool? isOwner, IEnumerable<UserStatusId> userStatusIds);
-    Task<bool> CheckActiveServiceAccountExistsForCompanyAsync(Guid technicalUserId, Guid companyId);
-    Task<bool> CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(Guid technicalUserId, Guid companyId);
+    Task<(bool ActiveUserExists, bool LinkedToConnectorOrOffer)> CheckTechnicalUserDetailsAsync(Guid technicalUserId, Guid companyId);
     Task<(Guid IdentityId, Guid CompanyId)> GetTechnicalUserDataByClientId(string clientId);
     void CreateExternalTechnicalUser(Guid technicalUserId, string authenticationServiceUrl, byte[] secret, byte[] initializationVector, int encryptionMode);
     void CreateExternalTechnicalUserCreationData(Guid technicalUserId, Guid processId);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserRepository.cs
@@ -231,6 +231,15 @@ public class TechnicalUserRepository(PortalDbContext portalDbContext) : ITechnic
                 tu.Identity.CompanyId == companyId)
             .AnyAsync();
 
+    public Task<bool> CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(Guid technicalUserId, Guid companyId) =>
+        portalDbContext.TechnicalUsers
+            .Where(tu =>
+                tu.Id == technicalUserId &&
+               (tu.Connector != null ||
+                tu.OfferSubscription != null) &&
+                tu.Identity!.CompanyId == companyId)
+            .AnyAsync();
+
     public Task<(Guid IdentityId, Guid CompanyId)> GetTechnicalUserDataByClientId(string clientId) =>
         portalDbContext.TechnicalUsers
             .Where(tu => tu.ClientClientId == clientId)

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/TechnicalUserRepository.cs
@@ -223,23 +223,16 @@ public class TechnicalUserRepository(PortalDbContext portalDbContext) : ITechnic
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public async Task<(bool ActiveUserExists, bool LinkedToConnectorOrOffer)> CheckTechnicalUserDetailsAsync(Guid technicalUserId, Guid companyId)
-    {
-        var result = await portalDbContext.TechnicalUsers
-            .Where(tu =>
-                tu.Id == technicalUserId &&
-                tu.Identity!.CompanyId == companyId)
-            .Select(tu => new
-            {
-                IsActiveOrPending = tu.Identity!.UserStatusId == UserStatusId.ACTIVE || tu.Identity.UserStatusId == UserStatusId.PENDING,
-                IsLinkedToConnectorOrOffer = tu.Connector != null || tu.OfferSubscription != null
-            })
-            .SingleOrDefaultAsync();
-
-        return result != null
-            ? (result.IsActiveOrPending, result.IsLinkedToConnectorOrOffer)
-            : (false, false);
-    }
+    public async Task<(bool ActiveUserExists, bool LinkedToConnectorOrOffer)> CheckTechnicalUserDetailsAsync(Guid technicalUserId, Guid companyId) =>
+    await portalDbContext.TechnicalUsers
+         .Where(tu =>
+             tu.Id == technicalUserId &&
+             tu.Identity!.CompanyId == companyId)
+         .Select(tu => new ValueTuple<bool, bool>(
+             tu.Identity!.UserStatusId == UserStatusId.ACTIVE || tu.Identity.UserStatusId == UserStatusId.PENDING,
+             tu.Connector != null || tu.OfferSubscription != null
+         ))
+         .SingleOrDefaultAsync();
 
     public Task<(Guid IdentityId, Guid CompanyId)> GetTechnicalUserDataByClientId(string clientId) =>
         portalDbContext.TechnicalUsers

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -339,10 +339,8 @@ public class ConnectorsBusinessLogicTests
         // Arrange
         var saId = Guid.NewGuid();
         var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", "de", saId);
-        A.CallTo(() => _technicalUserRepository.CheckActiveServiceAccountExistsForCompanyAsync(saId, ValidCompanyId))
-                  .Returns(true);
-        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(saId, ValidCompanyId))
-                   .Returns(true);
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(saId, ValidCompanyId))
+                  .Returns((true, true));
         // Act
         async Task Act() => await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
 
@@ -1725,8 +1723,8 @@ public class ConnectorsBusinessLogicTests
         A.CallTo(() => _connectorsRepository.GetConnectorInformationByIdForIamUser(ExistingConnectorId, A<Guid>.That.Not.Matches(x => x == _identity.CompanyId)))
             .Returns((_fixture.Create<ConnectorInformationData>(), false));
 
-        A.CallTo(() => _technicalUserRepository.CheckActiveServiceAccountExistsForCompanyAsync(ServiceAccountUserId, ValidCompanyId))
-            .Returns(true);
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(ServiceAccountUserId, ValidCompanyId))
+                 .Returns((true, false));
 
         A.CallTo(() => _sdFactoryBusinessLogic.RegisterConnectorAsync(A<Guid>._, A<string>._, A<string>._, A<CancellationToken>._))
             .Returns(Task.CompletedTask);
@@ -1744,8 +1742,8 @@ public class ConnectorsBusinessLogicTests
 
     private void SetupCheckActiveServiceAccountExistsForCompanyAsyncForManaged()
     {
-        A.CallTo(() => _technicalUserRepository.CheckActiveServiceAccountExistsForCompanyAsync(ServiceAccountUserId, HostCompanyId))
-            .Returns(true);
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(ServiceAccountUserId, HostCompanyId))
+                 .Returns((true, false));
     }
 
     private void SetupIdentity()

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserRepositoryTests.cs
@@ -455,88 +455,84 @@ public class TechnicalUserRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
-    #region CheckActiveServiceAccountExistsForCompanyAsync
+    #region CheckTechnicalUserDetailsAsync
 
     [Fact]
-    public async Task CheckActiveServiceAccountExistsForCompanyAsync_ReturnsExpectedResult()
+    public async Task CheckTechnicalUserDetailsAsyncForActiveStatus_ReturnsExpectedResult()
     {
         // Arrange
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.CheckActiveServiceAccountExistsForCompanyAsync(_validServiceAccountId, new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+        var (active, _) = await sut.CheckTechnicalUserDetailsAsync(_validServiceAccountId, new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
 
         // Assert
-        result.Should().BeTrue();
+        active.Should().BeTrue();
     }
 
     [Fact]
-    public async Task CheckActiveServiceAccountExistsForCompanyAsyncForPendingStatus_ReturnsExpectedResult()
+    public async Task CheckTechnicalUserDetailsAsyncForPendingStatus_ReturnsExpectedResult()
     {
         // Arrange
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.CheckActiveServiceAccountExistsForCompanyAsync(new Guid("4ce1b774-3d00-4e07-9a53-ae1f64193394"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+        var (active, _) = await sut.CheckTechnicalUserDetailsAsync(new Guid("4ce1b774-3d00-4e07-9a53-ae1f64193394"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
 
         // Assert
-        result.Should().BeTrue();
+        active.Should().BeTrue();
     }
 
     [Fact]
-    public async Task CheckActiveServiceAccountExistsForCompanyAsyncForInactiveStatus_ReturnsExpectedResult()
+    public async Task CheckTechnicalUserDetailsAsyncForInactiveStatus_ReturnsExpectedResult()
     {
         // Arrange
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.CheckActiveServiceAccountExistsForCompanyAsync(new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94d"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+        var (active, _) = await sut.CheckTechnicalUserDetailsAsync(new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94d"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
 
         // Assert
-        result.Should().BeFalse();
-    }
-
-    #endregion
-
-    #region CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync
-
-    [Fact]
-    public async Task CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync_OfferLinked_ReturnsExpectedResult()
-    {
-        // Arrange
-        var (sut, _) = await CreateSut();
-
-        // Act
-        var result = await sut.CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(new Guid("a946f314-f53e-4c72-9124-40b72bcc59aa"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
-
-        // Assert
-        result.Should().BeTrue();
+        active.Should().BeFalse();
     }
 
     [Fact]
-    public async Task CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync_ConnectorLinked_ReturnsExpectedResult()
+    public async Task CheckTechnicalUserDetailsAsyncForOfferLinked_ReturnsExpectedResult()
     {
         // Arrange
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(new Guid("cd436931-8399-4c1d-bd81-7dffb298c7ca"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+        var (_, linked) = await sut.CheckTechnicalUserDetailsAsync(new Guid("a946f314-f53e-4c72-9124-40b72bcc59aa"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
 
         // Assert
-        result.Should().BeTrue();
+        linked.Should().BeTrue();
     }
 
     [Fact]
-    public async Task CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync_NotLinked_ReturnsExpectedResult()
+    public async Task CheckTechnicalUserDetailsAsyncForConnectorLinked_ReturnsExpectedResult()
     {
         // Arrange
         var (sut, _) = await CreateSut();
 
         // Act
-        var result = await sut.CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94e"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+        var (_, linked) = await sut.CheckTechnicalUserDetailsAsync(new Guid("cd436931-8399-4c1d-bd81-7dffb298c7ca"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
 
         // Assert
-        result.Should().BeFalse();
+        linked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckTechnicalUserDetailsAsyncForNotLinked_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var (_, linked) = await sut.CheckTechnicalUserDetailsAsync(new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94e"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+
+        // Assert
+        linked.Should().BeFalse();
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/TechnicalUserRepositoryTests.cs
@@ -498,6 +498,49 @@ public class TechnicalUserRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
+    #region CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync
+
+    [Fact]
+    public async Task CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync_OfferLinked_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(new Guid("a946f314-f53e-4c72-9124-40b72bcc59aa"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync_ConnectorLinked_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(new Guid("cd436931-8399-4c1d-bd81-7dffb298c7ca"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync_NotLinked_ReturnsExpectedResult()
+    {
+        // Arrange
+        var (sut, _) = await CreateSut();
+
+        // Act
+        var result = await sut.CheckTechnicalUserLinkedToConnectorOrOfferCompanyAsync(new Guid("38c92162-6328-40ce-80f3-22e3f3e9b94e"), new Guid("2dc4249f-b5ca-4d42-bef1-7a7a950a4f87"));
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
     #region CreateDimCompanyServiceAccount
 
     [Fact]


### PR DESCRIPTION
## Description

Added a validation for technical user in connector registration so that only available technical user can be used.

## Why

In last release database constraints has been removed and hence this api starts accepting same technical user to multiple connectors. 

## Issue

#1139 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
