### PR TITLE
fix(connector): sd-toggle check while updating connector url

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -125,6 +125,11 @@ public class ConnectorsBusinessLogic(
             throw UnexpectedConditionException.Create(AdministrationConnectorErrors.CONNECTOR_UNEXPECTED_NO_BPN_ASSIGNED, new ErrorParameter[] { new(nameof(companyId), companyId.ToString()) });
         }
 
+        if (string.IsNullOrWhiteSpace(result.CountryAlpha2Code))
+        {
+            throw UnexpectedConditionException.Create(AdministrationConnectorErrors.CONNECTOR_COUNTRYCODE_NOT_FOUND, [new(nameof(companyId), companyId.ToString())]);
+        }
+
         await ValidateTechnicalUser(technicalUserId, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
 
         var connectorRequestModel = new ConnectorRequestModel(name, connectorUrl, ConnectorTypeId.COMPANY_CONNECTOR, location, companyId, companyId, technicalUserId);
@@ -134,6 +139,7 @@ public class ConnectorsBusinessLogic(
             result.SelfDescriptionDocumentId,
             null,
             companyId,
+            result.CountryAlpha2Code,
             cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
     }
 
@@ -148,7 +154,7 @@ public class ConnectorsBusinessLogic(
             .CheckOfferSubscriptionWithOfferProvider(subscriptionId, companyId)
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
-        if (!result.Exists)
+        if (result == null || !result.Exists)
         {
             throw NotFoundException.Create(AdministrationConnectorErrors.CONNECTOR_NOT_OFFERSUBSCRIPTION_EXIST, new ErrorParameter[] { new(nameof(subscriptionId), subscriptionId.ToString()) });
         }
@@ -171,7 +177,12 @@ public class ConnectorsBusinessLogic(
 
         if (string.IsNullOrWhiteSpace(result.ProviderBpn))
         {
-            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN, new ErrorParameter[] { new("companyId", result.CompanyId.ToString()) });
+            throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN, [new(nameof(companyId), companyId.ToString())]);
+        }
+
+        if (string.IsNullOrWhiteSpace(result.CountryAlpha2Code))
+        {
+            throw UnexpectedConditionException.Create(AdministrationConnectorErrors.CONNECTOR_COUNTRYCODE_NOT_FOUND, [new(nameof(companyId), companyId.ToString())]);
         }
 
         await ValidateTechnicalUser(technicalUserId, result.CompanyId).ConfigureAwait(ConfigureAwaitOptions.None);
@@ -183,6 +194,7 @@ public class ConnectorsBusinessLogic(
             result.SelfDescriptionDocumentId,
             subscriptionId,
             result.CompanyId,
+            result.CountryAlpha2Code,
             cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
     }
 
@@ -224,9 +236,10 @@ public class ConnectorsBusinessLogic(
         Guid? selfDescriptionDocumentId,
         Guid? subscriptionId,
         Guid companyId,
+        string countryAlpha2Code,
         CancellationToken cancellationToken)
     {
-        var countrySpecificSettings = _clearinghouseSettings.GetCountrySpecificSettings(connectorInputModel.Location);
+        var countrySpecificSettings = _clearinghouseSettings.GetCountrySpecificSettings(countryAlpha2Code);
         if (selfDescriptionDocumentId is null && !countrySpecificSettings.ClearinghouseConnectDisabled)
         {
             throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_NO_DESCRIPTION, [new(nameof(companyId), companyId.ToString())]);
@@ -417,12 +430,13 @@ public class ConnectorsBusinessLogic(
 
     private async Task UpdateConnectorUrlInternal(Guid connectorId, ConnectorUpdateRequest data, CancellationToken cancellationToken)
     {
+        var companyId = _identityData.CompanyId;
         var connectorsRepository = portalRepositories
             .GetInstance<IConnectorsRepository>();
         var documentRepository = portalRepositories
            .GetInstance<IDocumentRepository>();
         var connector = await connectorsRepository
-            .GetConnectorUpdateInformation(connectorId, _identityData.CompanyId)
+            .GetConnectorUpdateInformation(connectorId, companyId)
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
         if (connector == null)
@@ -433,6 +447,11 @@ public class ConnectorsBusinessLogic(
         if (connector.ConnectorUrl == data.ConnectorUrl)
         {
             return;
+        }
+
+        if (string.IsNullOrWhiteSpace(connector.CountryAlpha2Code))
+        {
+            throw UnexpectedConditionException.Create(AdministrationConnectorErrors.CONNECTOR_COUNTRYCODE_NOT_FOUND, [new(nameof(companyId), companyId.ToString())]);
         }
 
         if (!connector.IsProviderCompany)
@@ -473,10 +492,14 @@ public class ConnectorsBusinessLogic(
             throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_NO_DESCRIPTION, [new(nameof(connectorId), connectorId.ToString())]);
         }
 
-        var selfDescriptionDocumentUrl = $"{_connectorSettings.SelfDescriptionDocumentUrl}/{connector.SelfDescriptionCompanyDocumentId}";
-        await sdFactoryBusinessLogic
-            .RegisterConnectorAsync(connectorId, selfDescriptionDocumentUrl, bpn, cancellationToken)
-            .ConfigureAwait(ConfigureAwaitOptions.None);
+        var countrySpecificSettings = _clearinghouseSettings.GetCountrySpecificSettings(connector.CountryAlpha2Code);
+        if (!countrySpecificSettings.ClearinghouseConnectDisabled)
+        {
+            var selfDescriptionDocumentUrl = $"{_connectorSettings.SelfDescriptionDocumentUrl}/{connector.SelfDescriptionCompanyDocumentId}";
+            await sdFactoryBusinessLogic
+                .RegisterConnectorAsync(connectorId, selfDescriptionDocumentUrl, bpn, cancellationToken)
+                .ConfigureAwait(ConfigureAwaitOptions.None);
+        }
 
         await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
     }

--- a/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
+++ b/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
@@ -44,7 +44,8 @@ public class AdministrationConnectorErrorMessageContainer : IErrorMessageContain
         new((int)AdministrationConnectorErrors.CONNECTOR_CONFLICT_ALREADY_ASSIGNED,"Connector {externalId} already has a document assigned"),
         new((int)AdministrationConnectorErrors.CONNECTOR_NOT_HOST_COMPANY,"Company {companyId} is not the connectors host company"),
         new((int)AdministrationConnectorErrors.CONNECTOR_CONFLICT_INACTIVE_STATE,"Connector {connectorId} is in state {connectorStatusId}"),
-        new((int)AdministrationConnectorErrors.CONNECTOR_DUPLICATE,"Connector {name} does already exists for url {connectorUrl}")
+        new((int)AdministrationConnectorErrors.CONNECTOR_DUPLICATE,"Connector {name} does already exists for url {connectorUrl}"),
+        new((int)AdministrationConnectorErrors.CONNECTOR_COUNTRYCODE_NOT_FOUND,"The country code of company {companyId} must be set")
     ]);
 
     public Type Type { get => typeof(AdministrationConnectorErrors); }
@@ -72,5 +73,6 @@ public enum AdministrationConnectorErrors
     CONNECTOR_CONFLICT_ALREADY_ASSIGNED,
     CONNECTOR_NOT_HOST_COMPANY,
     CONNECTOR_CONFLICT_INACTIVE_STATE,
-    CONNECTOR_DUPLICATE
+    CONNECTOR_DUPLICATE,
+    CONNECTOR_COUNTRYCODE_NOT_FOUND
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionWithProvider.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionWithProvider.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW Group AG
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,14 +23,23 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
 /// <summary>
-/// View model for connectors.
+/// Get offer subscription with offer provider
 /// </summary>
-public record ConnectorUpdateInformation(
-    ConnectorStatusId Status,
-    ConnectorTypeId Type,
-    bool IsProviderCompany,
-    string ConnectorUrl,
-    string? Bpn,
-    string? CountryAlpha2Code,
+/// <param name="Exists">Existence of offer subscription</param>
+/// <param name="IsOfferProvider">true if Company Id is the same as ProviderCompanyId</param>
+/// <param name="OfferSubscriptionAlreadyLinked">true if OfferSubscription is already linked to a connector</param>
+/// <param name="OfferSubscriptionStatus">Offer subscription status</param>
+/// <param name="SelfDescriptionDocumentId">Provider company sd document id</param>
+/// <param name="CompanyId">Host/Customer company id</param>
+/// <param name="ProviderBpn">Provider's Bpn</param>
+/// <param name="CountryAlpha2Code">Provider's country code</param>
+public record OfferSubscriptionWithProvider(
+    bool Exists,
+    bool IsOfferProvider,
+    bool OfferSubscriptionAlreadyLinked,
+    OfferSubscriptionStatusId OfferSubscriptionStatus,
     Guid? SelfDescriptionDocumentId,
-    Guid? SelfDescriptionCompanyDocumentId);
+    Guid CompanyId,
+    string? ProviderBpn,
+    string? CountryAlpha2Code
+);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -183,10 +183,10 @@ public class CompanyRepository(PortalDbContext context) : ICompanyRepository
     }
 
     /// <inheritdoc />
-    public Task<(string? Bpn, Guid? SelfDescriptionDocumentId)> GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(Guid companyId) =>
+    public Task<(string? Bpn, Guid? SelfDescriptionDocumentId, string? CountryAlpha2Code)> GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(Guid companyId) =>
         context.Companies.AsNoTracking()
             .Where(x => x.Id == companyId)
-            .Select(x => new ValueTuple<string?, Guid?>(x.BusinessPartnerNumber, x.SelfDescriptionDocumentId))
+            .Select(x => new ValueTuple<string?, Guid?, string?>(x.BusinessPartnerNumber, x.SelfDescriptionDocumentId, x.Address!.CountryAlpha2Code))
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -190,7 +190,7 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
                             ps.ProcessStepStatusId == ProcessStepStatusId.TODO &&
                             processStepsToFilter.Contains(ps.ProcessStepTypeId)),
                     connector.TechnicalUser.ExternalTechnicalUserCreationData == null ? null : connector.TechnicalUser.ExternalTechnicalUserCreationData!.ProcessId),
-                connector.Host!.Address!.CountryAlpha2Code
+                connector.Provider!.Address!.CountryAlpha2Code
             )).SingleOrDefaultAsync();
 
     /// <inheritdoc />
@@ -203,8 +203,9 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
                 c.ProviderId == companyId,
                 c.ConnectorUrl,
                 c.Provider!.BusinessPartnerNumber,
+                c.Provider!.Address!.CountryAlpha2Code,
                 c.SelfDescriptionDocumentId,
-                c.Host!.SelfDescriptionDocumentId))
+                c.Provider!.SelfDescriptionDocumentId))
             .SingleOrDefaultAsync();
 
     public void DeleteConnector(Guid connectorId) =>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -95,11 +95,11 @@ public interface ICompanyRepository
     void AttachAndModifyProviderCompanyDetails(Guid providerCompanyDetailId, Action<ProviderCompanyDetail> initialize, Action<ProviderCompanyDetail> modify);
 
     /// <summary>
-    /// Gets the business partner number for the given id
+    /// Gets the business partner number, sd document and company's country code for the given id
     /// </summary>
     /// <param name="companyId">Id of the company</param>
-    /// <returns>Returns the business partner number</returns>
-    Task<(string? Bpn, Guid? SelfDescriptionDocumentId)> GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(Guid companyId);
+    /// <returns>Returns the business partner number, sd document and company's country code</returns>
+    Task<(string? Bpn, Guid? SelfDescriptionDocumentId, string? CountryAlpha2Code)> GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(Guid companyId);
 
     /// <summary>
     /// Gets the the companyAssigendUeseCase Details

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -154,7 +154,7 @@ public interface IOfferSubscriptionsRepository
     OfferSubscriptionProcessData CreateOfferSubscriptionProcessData(Guid offerSubscriptionId, string offerUrl);
     void RemoveOfferSubscriptionProcessData(Guid offerSubscriptionProcessDataId);
     IAsyncEnumerable<ProcessStepData> GetProcessStepsForSubscription(Guid offerSubscriptionId);
-    Task<(bool Exists, bool IsOfferProvider, bool OfferSubscriptionAlreadyLinked, OfferSubscriptionStatusId OfferSubscriptionStatus, Guid? SelfDescriptionDocumentId, Guid CompanyId, string? ProviderBpn)> CheckOfferSubscriptionWithOfferProvider(Guid subscriptionId, Guid offerProvidingCompanyId);
+    Task<OfferSubscriptionWithProvider?> CheckOfferSubscriptionWithOfferProvider(Guid subscriptionId, Guid offerProvidingCompanyId);
     IAsyncEnumerable<OfferSubscriptionConnectorData> GetConnectorOfferSubscriptionData(bool? connectorIdSet, Guid companyId);
 
     /// <summary>

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -477,19 +477,19 @@ public class OfferSubscriptionsRepository(PortalDbContext dbContext) : IOfferSub
             .ToAsyncEnumerable();
 
     /// <inheritdoc />
-    public Task<(bool Exists, bool IsOfferProvider, bool OfferSubscriptionAlreadyLinked, OfferSubscriptionStatusId OfferSubscriptionStatus, Guid? SelfDescriptionDocumentId, Guid CompanyId, string? ProviderBpn)> CheckOfferSubscriptionWithOfferProvider(Guid subscriptionId, Guid offerProvidingCompanyId) =>
+    public Task<OfferSubscriptionWithProvider?> CheckOfferSubscriptionWithOfferProvider(Guid subscriptionId, Guid offerProvidingCompanyId) =>
         dbContext.OfferSubscriptions
             .Where(x => x.Id == subscriptionId)
-            .Select(os => new ValueTuple<bool, bool, bool, OfferSubscriptionStatusId, Guid?, Guid, string?>(
+            .Select(os => new OfferSubscriptionWithProvider(
                 true,
                 os.Offer!.ProviderCompanyId == offerProvidingCompanyId,
                 os.ConnectorAssignedOfferSubscriptions.Any(),
                 os.OfferSubscriptionStatusId,
-                os.Company!.SelfDescriptionDocumentId,
+                os.Offer.ProviderCompany!.SelfDescriptionDocumentId,
                 os.CompanyId,
-                os.Company.BusinessPartnerNumber
-            ))
-            .SingleOrDefaultAsync();
+                os.Offer.ProviderCompany.BusinessPartnerNumber,
+                os.Offer.ProviderCompany.Address!.CountryAlpha2Code
+            )).SingleOrDefaultAsync();
 
     /// <inheritdoc />
     public IAsyncEnumerable<OfferSubscriptionConnectorData> GetConnectorOfferSubscriptionData(bool? connectorIdSet, Guid companyId) =>

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -55,6 +55,7 @@ public class ConnectorsBusinessLogicTests
     private static readonly Guid CompanyIdWithoutSdDocument = Guid.NewGuid();
     private static readonly Guid ExistingConnectorId = Guid.NewGuid();
     private static readonly Guid CompanyWithoutBpnId = Guid.NewGuid();
+    private static readonly Guid CompanyWithoutCountryCode = Guid.NewGuid();
     private readonly Guid _validOfferSubscriptionId = Guid.NewGuid();
     private readonly IIdentityData _identity;
     private readonly IFixture _fixture;
@@ -432,6 +433,21 @@ public class ConnectorsBusinessLogicTests
     }
 
     [Fact]
+    public async Task CreateConnectorAsync_WithoutCountryCode_ThrowsUnexpectedConditionException()
+    {
+        // Arrange
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, null);
+        A.CallTo(() => _identity.CompanyId).Returns(CompanyWithoutCountryCode);
+
+        // Act
+        async Task Act() => await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
+        exception.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_COUNTRYCODE_NOT_FOUND.ToString());
+    }
+
+    [Fact]
     public async Task CreateConnectorAsync_WithFailingDapsService_ReturnsCreatedConnectorData()
     {
         // Arrange
@@ -586,8 +602,9 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var subscriptionId = Guid.NewGuid();
+        var data = new OfferSubscriptionWithProvider(false, default, default, default, default, default, default, default);
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
-            .Returns((false, default, default, default, default, default, default));
+            .Returns(data);
         var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
 
         SetupTechnicalIdentity();
@@ -605,8 +622,9 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var subscriptionId = Guid.NewGuid();
+        var data = new OfferSubscriptionWithProvider(true, false, default, default, default, default, default, default);
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
-            .Returns((true, false, default, default, default, default, default));
+            .Returns(data);
         var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
 
         SetupTechnicalIdentity();
@@ -624,8 +642,9 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var subscriptionId = Guid.NewGuid();
+        var data = new OfferSubscriptionWithProvider(true, true, true, default, default, default, default, default);
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
-            .Returns((true, true, true, default, default, default, default));
+            .Returns(data);
         var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
 
         SetupTechnicalIdentity();
@@ -643,8 +662,9 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var subscriptionId = Guid.NewGuid();
+        var data = new OfferSubscriptionWithProvider(true, true, false, OfferSubscriptionStatusId.INACTIVE, default, default, default, default);
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
-            .Returns((true, true, false, OfferSubscriptionStatusId.INACTIVE, default, default, default));
+            .Returns(data);
         var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
 
         SetupTechnicalIdentity();
@@ -662,8 +682,9 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var subscriptionId = Guid.NewGuid();
+        var data = new OfferSubscriptionWithProvider(true, true, false, OfferSubscriptionStatusId.ACTIVE, null, ValidCompanyId, ValidCompanyBpn, CountryCode_de);
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, A<Guid>.That.Matches(x => x == ValidCompanyId)))
-            .Returns((true, true, false, OfferSubscriptionStatusId.ACTIVE, null, ValidCompanyId, ValidCompanyBpn));
+            .Returns(data);
         var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
 
         // Act
@@ -680,8 +701,9 @@ public class ConnectorsBusinessLogicTests
         // Arrange
         var subscriptionId = Guid.NewGuid();
         var companyId = Guid.NewGuid();
+        var data = new OfferSubscriptionWithProvider(true, true, false, OfferSubscriptionStatusId.ACTIVE, Guid.NewGuid(), companyId, null, CountryCode_de);
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
-            .Returns((true, true, false, OfferSubscriptionStatusId.ACTIVE, Guid.NewGuid(), companyId, null));
+            .Returns(data);
         var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
 
         SetupTechnicalIdentity();
@@ -692,6 +714,27 @@ public class ConnectorsBusinessLogicTests
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
         ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN.ToString());
+    }
+
+    [Fact]
+    public async Task CreateManagedConnectorAsync_WithSubscribingCompanyWithoutCountryCode_ThrowsUnexpectedConditionException()
+    {
+        // Arrange
+        var subscriptionId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        var data = new OfferSubscriptionWithProvider(true, true, false, OfferSubscriptionStatusId.ACTIVE, Guid.NewGuid(), companyId, ValidCompanyBpn, null);
+        A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
+            .Returns(data);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
+
+        SetupTechnicalIdentity();
+
+        // Act
+        async Task Act() => await _logic.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
+        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_COUNTRYCODE_NOT_FOUND.ToString());
     }
 
     [Fact]
@@ -1207,6 +1250,25 @@ public class ConnectorsBusinessLogicTests
     }
 
     [Fact]
+    public async Task UpdateConnectorUrl_WithoutCountryCode_ThrowsUnexpectedConditionException()
+    {
+        // Arrange
+        var connectorId = Guid.NewGuid();
+        var data = _fixture.Build<ConnectorUpdateInformation>()
+            .With(x => x.CountryAlpha2Code, string.Empty)
+            .Create();
+        A.CallTo(() => _connectorsRepository.GetConnectorUpdateInformation(connectorId, _identity.CompanyId))
+            .Returns(data);
+
+        // Act
+        async Task Act() => await _logic.UpdateConnectorUrl(connectorId, new ConnectorUpdateRequest("https://new.de"), CancellationToken.None);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
+        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_COUNTRYCODE_NOT_FOUND.ToString());
+    }
+
+    [Fact]
     public async Task UpdateConnectorUrl_WithUserNotOfProviderCompany_ThrowsForbiddenException()
     {
         // Arrange
@@ -1295,10 +1357,36 @@ public class ConnectorsBusinessLogicTests
         ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN.ToString());
     }
 
-    [Fact]
-    public async Task UpdateConnectorUrl_WithValidData_CallsExpected()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task UpdateConnectorUrl_WithValidData_CallsExpected(bool clearingHouseDisabled)
     {
         // Arrange
+        var sut = new ConnectorsBusinessLogic(_portalRepositories, Options.Create(new ConnectorsSettings
+        {
+            MaxPageSize = 15,
+            ValidCertificationContentTypes = new[]
+            {
+                "application/x-pem-file",
+                "application/x-x509-ca-cert",
+                "application/pkix-cert"
+            }
+        }),
+        Options.Create(new ClearinghouseSettings
+        {
+            DefaultClearinghouseCredentials = new ClearinghouseCredentialsSettings
+            {
+                CountryAlpha2Code = "DefaultOrWhatever",
+                ClearinghouseConnectDisabled = clearingHouseDisabled
+            },
+            RegionalClearinghouseCredentials = [
+                new ClearinghouseCredentialsSettings {
+                    CountryAlpha2Code = CountryCode_de,
+                    ClearinghouseConnectDisabled = clearingHouseDisabled
+                }
+            ]
+        }), _sdFactoryBusinessLogic, _identityService, _serviceAccountManagement, _dateTimeProvider, A.Fake<ILogger<ConnectorsBusinessLogic>>());
         var documentId = Guid.NewGuid();
         var connectorId = Guid.NewGuid();
         var document = new Document(documentId, null!, null!, null!, default, default, DocumentStatusId.PENDING, default, default);
@@ -1311,6 +1399,7 @@ public class ConnectorsBusinessLogicTests
             .With(x => x.Status, ConnectorStatusId.ACTIVE)
             .With(x => x.Type, ConnectorTypeId.CONNECTOR_AS_A_SERVICE)
             .With(x => x.Bpn, "BPNL123456789")
+            .With(x => x.CountryAlpha2Code, CountryCode_de)
             .With(x => x.SelfDescriptionDocumentId, documentId)
             .With(x => x.SelfDescriptionCompanyDocumentId, Guid.NewGuid())
             .Create();
@@ -1332,13 +1421,13 @@ public class ConnectorsBusinessLogicTests
            });
 
         // Act
-        await _logic.UpdateConnectorUrl(connectorId, new ConnectorUpdateRequest("https://new.de"), CancellationToken.None);
+        await sut.UpdateConnectorUrl(connectorId, new ConnectorUpdateRequest("https://new.de"), CancellationToken.None);
 
         // Assert
         A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         A.CallTo(() => _connectorsRepository.AttachAndModifyConnector(connectorId, null, A<Action<Connector>>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _documentRepository.AttachAndModifyDocument((Guid)data.SelfDescriptionDocumentId!, null, A<Action<Document>>._)).MustHaveHappenedOnceExactly();
-        A.CallTo(() => _sdFactoryBusinessLogic.RegisterConnectorAsync(A<Guid>._, A<string>._, A<string>._, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _sdFactoryBusinessLogic.RegisterConnectorAsync(A<Guid>._, A<string>._, A<string>._, A<CancellationToken>._)).MustHaveHappened(clearingHouseDisabled ? 0 : 1, Times.Exactly);
         connector.ConnectorUrl.Should().Be("https://new.de");
         document.DocumentStatusId.Should().Be(DocumentStatusId.INACTIVE);
     }
@@ -1678,13 +1767,15 @@ public class ConnectorsBusinessLogicTests
             .Returns(false);
 
         A.CallTo(() => _companyRepository.GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(ValidCompanyId))
-            .Returns((ValidCompanyBpn, Guid.NewGuid()));
+            .Returns((ValidCompanyBpn, Guid.NewGuid(), CountryCode_de));
         A.CallTo(() => _companyRepository.GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(CompanyIdWithoutSdDocument))
-            .Returns((ValidCompanyBpn, null));
-        A.CallTo(() => _companyRepository.GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(A<Guid>.That.Not.Matches(x => x == ValidCompanyId || x == CompanyIdWithoutSdDocument)))
-            .Returns((null, null));
+            .Returns((ValidCompanyBpn, null, CountryCode_de));
+        A.CallTo(() => _companyRepository.GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(CompanyWithoutCountryCode))
+            .Returns((ValidCompanyBpn, Guid.NewGuid(), null));
+        A.CallTo(() => _companyRepository.GetCompanyBpnAndSelfDescriptionDocumentByIdAsync(A<Guid>.That.Not.Matches(x => x == ValidCompanyId || x == CompanyIdWithoutSdDocument || x == CompanyWithoutCountryCode)))
+            .Returns((null, null, null));
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(_validOfferSubscriptionId, ValidCompanyId))
-            .Returns((true, true, false, OfferSubscriptionStatusId.ACTIVE, Guid.NewGuid(), HostCompanyId, ValidCompanyBpn));
+            .Returns(new OfferSubscriptionWithProvider(true, true, false, OfferSubscriptionStatusId.ACTIVE, Guid.NewGuid(), HostCompanyId, ValidCompanyBpn, CountryCode_de));
 
         A.CallTo(() => _connectorsRepository.CreateConnector(A<string>._, A<string>._, A<string>._, A<Action<Connector>?>._))
             .Invokes((string name, string location, string connectorUrl, Action<Connector>? setupOptionalFields) =>

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -241,6 +241,7 @@ public class CompanyRepositoryTests : IAssemblyFixture<TestDbFixture>
         results.Should().NotBe(default);
         results.Bpn.Should().NotBeNullOrEmpty();
         results.Bpn.Should().Be("BPNL00000003CRHK");
+        results.CountryAlpha2Code.Should().Be("DE");
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -407,6 +407,7 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
         result.Should().NotBeNull();
         result!.Status.Should().Be(ConnectorStatusId.PENDING);
         result.Type.Should().Be(ConnectorTypeId.COMPANY_CONNECTOR);
+        result.CountryAlpha2Code.Should().Be("DE");
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -959,10 +959,12 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var result = await sut.CheckOfferSubscriptionWithOfferProvider(new Guid("0b2ca541-206d-48ad-bc02-fb61fbcb5552"), new Guid("0dcd8209-85e2-4073-b130-ac094fb47106"));
 
         // Assert
+        result.Should().NotBeNull();
         result.Exists.Should().BeTrue();
         result.OfferSubscriptionStatus.Should().Be(OfferSubscriptionStatusId.ACTIVE);
-        result.ProviderBpn.Should().Be("BPNL00000003AYRE");
+        result.ProviderBpn.Should().Be("BPNL00000003LLHA");
         result.IsOfferProvider.Should().BeTrue();
+        result.CountryAlpha2Code.Should().Be("DE");
     }
 
     [Fact]
@@ -975,10 +977,12 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var result = await sut.CheckOfferSubscriptionWithOfferProvider(new Guid("0b2ca541-206d-48ad-bc02-fb61fbcb5552"), Guid.NewGuid());
 
         // Assert
+        result.Should().NotBeNull();
         result.Exists.Should().BeTrue();
         result.OfferSubscriptionStatus.Should().Be(OfferSubscriptionStatusId.ACTIVE);
-        result.ProviderBpn.Should().Be("BPNL00000003AYRE");
+        result.ProviderBpn.Should().Be("BPNL00000003LLHA");
         result.IsOfferProvider.Should().BeFalse();
+        result.CountryAlpha2Code.Should().Be("DE");
     }
 
     [Fact]
@@ -991,7 +995,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var result = await sut.CheckOfferSubscriptionWithOfferProvider(Guid.NewGuid(), new Guid("0dcd8209-85e2-4073-b130-ac094fb47106"));
 
         // Assert
-        result.Exists.Should().BeFalse();
+        result.Should().BeNull();
     }
 
     #endregion


### PR DESCRIPTION
## Description

Updating connector URL throws error

## Why
Updating connector URL throws error when SD toggle is disabled and same connector was created without sd-document.
- Consistency of create, update and delete connector while getting provider company's country code.
- Get provider company's country code to get country-specific settings.
- Get country-specific settings to get correct sd-toggle to call sd-factory API.

## Issue

Ref: #1346

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
