### PR TITLE
fix(defaultPaginationValues): Set default page and pageSize values paginated get APIs

### DIFF
--- a/docs/api/administration-service.yaml
+++ b/docs/api/administration-service.yaml
@@ -3184,12 +3184,14 @@ paths:
           schema:
             type: integer
             format: int32
+            default: 0
         - name: size
           in: query
           description: size to get number of records
           schema:
             type: integer
             format: int32
+            default: 15
         - name: companyApplicationStatusFilter
           in: query
           description: Search by company applicationstatus
@@ -3327,12 +3329,14 @@ paths:
           schema:
             type: integer
             format: int32
+            default: 0
         - name: size
           in: query
           description: size to get number of records
           schema:
             type: integer
             format: int32
+            default: 15
         - name: companyApplicationStatusFilter
           in: query
           description: Search by company applicationstatus
@@ -4478,12 +4482,14 @@ paths:
           schema:
             type: integer
             format: int32
+            default: 0
         - name: size
           in: query
           description: number of service account data
           schema:
             type: integer
             format: int32
+            default: 15
         - name: isOwner
           in: query
           description: isOwner either true or false
@@ -5267,12 +5273,14 @@ paths:
           schema:
             type: integer
             format: int32
+            default: 0
         - name: size
           in: query
           description: size to get number of records
           schema:
             type: integer
             format: int32
+            default: 15
         - name: companyUserId
           in: query
           description: Company User Id

--- a/src/administration/Administration.Service/Controllers/NetworkController.cs
+++ b/src/administration/Administration.Service/Controllers/NetworkController.cs
@@ -178,6 +178,6 @@ public class NetworkController(INetworkBusinessLogic logic)
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("companies")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyDetailsOspOnboarding>), StatusCodes.Status200OK)]
-    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync([FromQuery] int page, [FromQuery] int size, [FromQuery] CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, [FromQuery] string? companyName = null, [FromQuery] string? externalId = null, [FromQuery] DateCreatedOrderFilter? dateCreatedOrderFilter = null) =>
+    public Task<Pagination.Response<CompanyDetailsOspOnboarding>> GetOspCompanyDetailsAsync([FromQuery] int page = 0, [FromQuery] int size = 15, [FromQuery] CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, [FromQuery] string? companyName = null, [FromQuery] string? externalId = null, [FromQuery] DateCreatedOrderFilter? dateCreatedOrderFilter = null) =>
         logic.GetOspCompanyDetailsAsync(page, size, companyApplicationStatusFilter, companyName, externalId, dateCreatedOrderFilter);
 }

--- a/src/administration/Administration.Service/Controllers/RegistrationController.cs
+++ b/src/administration/Administration.Service/Controllers/RegistrationController.cs
@@ -77,7 +77,7 @@ public class RegistrationController(IRegistrationBusinessLogic logic)
     [Authorize(Roles = "view_submitted_applications")]
     [Route("applications")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyApplicationDetails>), StatusCodes.Status200OK)]
-    public Task<Pagination.Response<CompanyApplicationDetails>> GetApplicationDetailsAsync([FromQuery] int page, [FromQuery] int size, [FromQuery] CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, [FromQuery] string? companyName = null) =>
+    public Task<Pagination.Response<CompanyApplicationDetails>> GetApplicationDetailsAsync([FromQuery] int page = 0, [FromQuery] int size = 15, [FromQuery] CompanyApplicationStatusFilter? companyApplicationStatusFilter = null, [FromQuery] string? companyName = null) =>
         logic.GetCompanyApplicationDetailsAsync(page, size, companyApplicationStatusFilter, companyName);
 
     /// <summary>

--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -164,7 +164,7 @@ public class ServiceAccountController(ITechnicalUserBusinessLogic logic) : Contr
     [Authorize(Policy = PolicyTypes.ValidCompany)]
     [Route("owncompany/serviceaccounts")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyServiceAccountData>), StatusCodes.Status200OK)]
-    public Task<Pagination.Response<CompanyServiceAccountData>> GetServiceAccountsData([FromQuery] int page, [FromQuery] int size, [FromQuery] bool? isOwner, [FromQuery] string? clientId, [FromQuery] bool filterForInactive = false, [FromQuery] IEnumerable<UserStatusId>? userStatus = null) =>
+    public Task<Pagination.Response<CompanyServiceAccountData>> GetServiceAccountsData([FromQuery] int page = 0, [FromQuery] int size = 15, [FromQuery] bool? isOwner = null, [FromQuery] string? clientId = null, [FromQuery] bool filterForInactive = false, [FromQuery] IEnumerable<UserStatusId>? userStatus = null) =>
         logic.GetOwnCompanyServiceAccountsDataAsync(page, size, clientId, isOwner, filterForInactive, userStatus);
 
     /// <summary>

--- a/src/administration/Administration.Service/Controllers/UserController.cs
+++ b/src/administration/Administration.Service/Controllers/UserController.cs
@@ -176,8 +176,8 @@ public class UserController : ControllerBase
     [Route("owncompany/users")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyUserData>), StatusCodes.Status200OK)]
     public Task<Pagination.Response<CompanyUserData>> GetOwnCompanyUserDatasAsync(
-        [FromQuery] int page,
-        [FromQuery] int size,
+        [FromQuery] int page = 0,
+        [FromQuery] int size = 15,
         [FromQuery] Guid? companyUserId = null,
         [FromQuery] string? firstName = null,
         [FromQuery] string? lastName = null,


### PR DESCRIPTION
## Description

Setting default page and pageSize values to paginated get APIs

## Why

We have default page = 0 and size = 15 values in our APIs from where we respond paginated data but there are a few APIs where this default value is not set:

api/administration/registration/network/companies
api/administration/serviceaccount/owncompany/serviceaccounts
api/administration/registration/applications
api/administration/user/owncompany/users

## Issue

Ref: #1366

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
