### PR TITLE
fix: external technical user creation for app and service subscriptions

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -185,4 +185,5 @@ public interface IOfferSubscriptionsRepository
     Task<(string? Bpn, string? OfferName, Guid? ProcessId)> GetDimTechnicalUserDataForSubscriptionId(Guid offerSubscriptionId);
 
     IAsyncEnumerable<(Process Process, ProcessStep<Process, ProcessTypeId, ProcessStepTypeId> ProcessStep)> GetOfferSubscriptionRetriggerProcessesForCompanyId(Guid companyId);
+    IAsyncEnumerable<(ProcessTypeId ProcessTypeId, VerifyProcessData<ProcessTypeId, ProcessStepTypeId> ProcessData, Guid? TechnicalUserId, Guid? TechnicalUserVersion)> GetProcessDataForTechnicalUserCallback(Guid processId, IEnumerable<ProcessStepTypeId> processStepTypeIds);
 }

--- a/src/provisioning/Provisioning.Library/Models/ServiceAccountCreationProcessData.cs
+++ b/src/provisioning/Provisioning.Library/Models/ServiceAccountCreationProcessData.cs
@@ -22,6 +22,6 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 namespace Org.Eclipse.TractusX.Portal.Backend.Provisioning.Library.Models;
 
 public record ServiceAccountCreationProcessData(
-    ProcessTypeId? ProcessTypeId,
+    ProcessTypeId ProcessTypeId,
     Guid? ProcessId
 );

--- a/src/provisioning/Provisioning.Library/Service/ITechnicalUserCreation.cs
+++ b/src/provisioning/Provisioning.Library/Service/ITechnicalUserCreation.cs
@@ -44,6 +44,6 @@ public interface ITechnicalUserCreation
             TechnicalUserTypeId technicalUserTypeId,
             bool enhanceTechnicalUserName,
             bool enabled,
-            ServiceAccountCreationProcessData? processData,
+            ServiceAccountCreationProcessData processData,
             Action<TechnicalUser>? setOptionalParameter = null);
 }

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
@@ -267,8 +267,8 @@ public class OfferSetupServiceTests
         A.CallTo(() => _technicalUserProfileService.GetTechnicalUserProfilesForOfferSubscription(A<Guid>._))
             .Returns(
             [
-                new("sa1", "test", IamClientAuthMethod.SECRET, Enumerable.Empty<Guid>()),
-                new("sa2", "test1", IamClientAuthMethod.SECRET, Enumerable.Empty<Guid>())
+                new("sa1", "test", IamClientAuthMethod.SECRET, []),
+                new("sa2", "test1", IamClientAuthMethod.SECRET, [])
             ]);
 
         A.CallTo(() => _appInstanceRepository.CreateAppInstance(A<Guid>._, A<Guid>._))
@@ -304,11 +304,11 @@ public class OfferSetupServiceTests
         var data = new OfferAutoSetupData(_pendingSubscriptionId, url);
 
         // Act
-        async Task Act() => await _sut.AutoSetupOfferAsync(data, Enumerable.Empty<UserRoleConfig>(), OfferTypeId.APP, "https://base-address.com", Enumerable.Empty<UserRoleConfig>());
+        async Task Act() => await _sut.AutoSetupOfferAsync(data, [], OfferTypeId.APP, "https://base-address.com", []);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFERURL_NOT_CONTAIN.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFERURL_NOT_CONTAIN));
     }
 
     [Fact]
@@ -360,7 +360,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.ONLY_ONE_APP_INSTANCE_FOR_SINGLE_INSTANCE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.ONLY_ONE_APP_INSTANCE_FOR_SINGLE_INSTANCE));
         A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
     }
 
@@ -374,11 +374,11 @@ public class OfferSetupServiceTests
             .Returns<OfferSubscriptionTransferData?>(null);
 
         // Act
-        async Task Action() => await _sut.AutoSetupOfferAsync(data, Enumerable.Empty<UserRoleConfig>(), OfferTypeId.SERVICE, "https://base-address.com", Enumerable.Empty<UserRoleConfig>());
+        async Task Action() => await _sut.AutoSetupOfferAsync(data, [], OfferTypeId.SERVICE, "https://base-address.com", []);
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Action);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFER_SUBCRIPTION_NOT_EXIST.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFER_SUBCRIPTION_NOT_EXIST));
         A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
     }
 
@@ -390,11 +390,11 @@ public class OfferSetupServiceTests
         var data = new OfferAutoSetupData(_validSubscriptionId, "https://new-url.com/");
 
         // Act
-        async Task Action() => await _sut.AutoSetupOfferAsync(data, Enumerable.Empty<UserRoleConfig>(), OfferTypeId.SERVICE, "https://base-address.com", Enumerable.Empty<UserRoleConfig>());
+        async Task Action() => await _sut.AutoSetupOfferAsync(data, [], OfferTypeId.SERVICE, "https://base-address.com", []);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Action);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFER_SUBSCRIPTION_PENDING.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFER_SUBSCRIPTION_PENDING));
         A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
     }
 
@@ -408,11 +408,11 @@ public class OfferSetupServiceTests
         A.CallTo(() => _identity.CompanyId).Returns(Guid.NewGuid());
 
         // Act
-        async Task Action() => await _sut.AutoSetupOfferAsync(data, Enumerable.Empty<UserRoleConfig>(), OfferTypeId.SERVICE, "https://base-address.com", Enumerable.Empty<UserRoleConfig>());
+        async Task Action() => await _sut.AutoSetupOfferAsync(data, [], OfferTypeId.SERVICE, "https://base-address.com", []);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Action);
-        ex.Message.Should().Be(OfferSetupServiceErrors.ONLY_PROVIDER_CAN_SETUP_SERVICE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.ONLY_PROVIDER_CAN_SETUP_SERVICE));
         A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();
     }
 
@@ -425,10 +425,10 @@ public class OfferSetupServiceTests
     {
         // Arrange
         var appInstanceId = Guid.NewGuid();
-        var appInstance = new AppInstance(appInstanceId, _validOfferId, default);
+        var appInstance = new AppInstance(appInstanceId, _validOfferId, Guid.Empty);
         SetupCreateSingleInstance(appInstance);
         A.CallTo(() => _technicalUserProfileService.GetTechnicalUserProfilesForOffer(_validOfferId, A<OfferTypeId>._))
-            .Returns(new TechnicalUserCreationInfo[] { new(Guid.NewGuid().ToString(), "test", IamClientAuthMethod.SECRET, Enumerable.Empty<Guid>()) }.AsFakeIEnumerable(out var enumerator));
+            .Returns(new TechnicalUserCreationInfo[] { new(Guid.NewGuid().ToString(), "test", IamClientAuthMethod.SECRET, []) }.AsFakeIEnumerable(out var enumerator));
 
         // Act
         var result = await _sut.ActivateSingleInstanceAppAsync(_validOfferId);
@@ -451,7 +451,7 @@ public class OfferSetupServiceTests
         async Task Act() => await _sut.ActivateSingleInstanceAppAsync(offerId);
 
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.APP_DOES_NOT_EXIST.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.APP_DOES_NOT_EXIST));
     }
 
     [Fact]
@@ -462,7 +462,7 @@ public class OfferSetupServiceTests
         async Task Act() => await _sut.ActivateSingleInstanceAppAsync(_offerIdWithWithNoInstanceSetupIds);
 
         var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.SINGLE_INSTANCE_OFFER_MUST_HAVE_ONE_INSTANCE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.SINGLE_INSTANCE_OFFER_MUST_HAVE_ONE_INSTANCE));
     }
 
     [Fact]
@@ -472,7 +472,7 @@ public class OfferSetupServiceTests
         async Task Act() => await _sut.ActivateSingleInstanceAppAsync(_offerIdWithoutClient);
 
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.CLIENTID_EMPTY_FOR_SINGLE_INSTANCE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.CLIENTID_EMPTY_FOR_SINGLE_INSTANCE));
     }
 
     [Fact]
@@ -482,7 +482,7 @@ public class OfferSetupServiceTests
         async Task Act() => await _sut.ActivateSingleInstanceAppAsync(_offerIdWithMultipleInstances);
 
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFER_NOT_SINGLE_INSTANCE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFER_NOT_SINGLE_INSTANCE));
     }
 
     #endregion
@@ -539,7 +539,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.APP_INSTANCE_ALREADY_EXISTS.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.APP_INSTANCE_ALREADY_EXISTS));
     }
 
     #endregion
@@ -550,13 +550,13 @@ public class OfferSetupServiceTests
     public async Task UpdateSingleInstance_CallsExpected()
     {
         // Arrange
-        const string url = "https://test.de";
+        const string Url = "https://test.de";
 
         // Act
-        await _sut.UpdateSingleInstance("test", url);
+        await _sut.UpdateSingleInstance("test", Url);
 
         // Assert
-        A.CallTo(() => _provisioningManager.UpdateClient("test", url, $"{url}/*"))
+        A.CallTo(() => _provisioningManager.UpdateClient("test", Url, $"{Url}/*"))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -635,7 +635,7 @@ public class OfferSetupServiceTests
         A.CallTo(() => _appInstanceRepository.RemoveAppInstanceAssignedServiceAccounts(A<Guid>._, A<IEnumerable<Guid>>._))
             .MustNotHaveHappened();
 
-        result.Message.Should().Be(OfferSetupServiceErrors.APP_INSTANCE_ASSOCIATED_WITH_SUBSCRIPTIONS.ToString());
+        result.Message.Should().Be(nameof(OfferSetupServiceErrors.APP_INSTANCE_ASSOCIATED_WITH_SUBSCRIPTIONS));
     }
 
     #endregion
@@ -659,7 +659,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFERURL_NOT_CONTAIN.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFERURL_NOT_CONTAIN));
     }
 
     [Theory]
@@ -678,7 +678,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFER_SUBCRIPTION_NOT_EXIST.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFER_SUBCRIPTION_NOT_EXIST));
     }
 
     [Theory]
@@ -700,7 +700,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFER_SUBSCRIPTION_PENDING.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFER_SUBSCRIPTION_PENDING));
     }
 
     [Theory]
@@ -723,7 +723,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ForbiddenException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.ONLY_PROVIDER_CAN_SETUP_SERVICE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.ONLY_PROVIDER_CAN_SETUP_SERVICE));
     }
 
     [Theory]
@@ -748,7 +748,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.ONLY_ONE_APP_INSTANCE_FOR_SINGLE_INSTANCE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.ONLY_ONE_APP_INSTANCE_FOR_SINGLE_INSTANCE));
     }
 
     [Theory]
@@ -784,7 +784,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.STEP_NOT_ELIGIBLE_FOR_SINGLE_INSTANCE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.STEP_NOT_ELIGIBLE_FOR_SINGLE_INSTANCE));
     }
 
     [Theory]
@@ -848,7 +848,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFERSUBSCRIPTION_NOT_EXIST.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFERSUBSCRIPTION_NOT_EXIST));
     }
 
     [Fact]
@@ -869,7 +869,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.ONLY_ONE_APP_INSTANCE_FOR_SINGLE_INSTANCE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.ONLY_ONE_APP_INSTANCE_FOR_SINGLE_INSTANCE));
     }
 
     [Fact]
@@ -890,7 +890,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.PROCESS_STEP_ONLY_FOR_SINGLE_INSTANCE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.PROCESS_STEP_ONLY_FOR_SINGLE_INSTANCE));
     }
 
     [Fact]
@@ -912,7 +912,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.SUBSCRIPTION_ONLY_ACTIVATED_BY_PROVIDER.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.SUBSCRIPTION_ONLY_ACTIVATED_BY_PROVIDER));
     }
 
     [Fact]
@@ -973,7 +973,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFERSUBSCRIPTION_NOT_EXIST.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFERSUBSCRIPTION_NOT_EXIST));
     }
 
     [Fact]
@@ -992,7 +992,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFERS_WITHOUT_TYPE_NOT_ELIGIBLE.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFERS_WITHOUT_TYPE_NOT_ELIGIBLE));
     }
 
     [Theory]
@@ -1001,20 +1001,20 @@ public class OfferSetupServiceTests
     public async Task CreateClient_WithValidData_ReturnsExpected(bool technicalUserNeeded)
     {
         // Arrange
-        const string clientId = "cl1";
-        const string url = "https://www.test.de";
+        const string ClientId = "cl1";
+        const string Url = "https://www.test.de";
         var offerSubscriptionId = Guid.NewGuid();
         var iamClientId = Guid.NewGuid();
-        var data = new OfferSubscriptionClientCreationData(_validOfferId, OfferTypeId.APP, url, technicalUserNeeded);
+        var data = new OfferSubscriptionClientCreationData(_validOfferId, OfferTypeId.APP, Url, technicalUserNeeded);
         var detail = new AppSubscriptionDetail(Guid.NewGuid(), offerSubscriptionId);
         A.CallTo(() => _offerSubscriptionsRepository.GetClientCreationData(offerSubscriptionId))
             .Returns(data);
         A.CallTo(() => _userRolesRepository.GetUserRolesForOfferIdAsync(_validOfferId))
             .Returns(Enumerable.Repeat("TestRole", 1).ToAsyncEnumerable());
-        A.CallTo(() => _provisioningManager.SetupClientAsync($"{url}/*", url, A<IEnumerable<string>>._, false))
-            .Returns(clientId);
-        A.CallTo(() => _clientRepository.CreateClient(clientId))
-            .Returns(new IamClient(iamClientId, clientId));
+        A.CallTo(() => _provisioningManager.SetupClientAsync($"{Url}/*", Url, A<IEnumerable<string>>._, false))
+            .Returns(ClientId);
+        A.CallTo(() => _clientRepository.CreateClient(ClientId))
+            .Returns(new IamClient(iamClientId, ClientId));
         A.CallTo(() => _appSubscriptionDetailRepository.CreateAppSubscriptionDetail(offerSubscriptionId, A<Action<AppSubscriptionDetail?>>._))
             .Invokes((Guid _, Action<AppSubscriptionDetail> setOptionalParameter) =>
             {
@@ -1055,7 +1055,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFERSUBSCRIPTION_NOT_EXIST.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFERSUBSCRIPTION_NOT_EXIST));
     }
 
     [Fact]
@@ -1073,7 +1073,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.TECHNICAL_USER_NOT_NEEDED.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.TECHNICAL_USER_NOT_NEEDED));
     }
 
     [Theory]
@@ -1104,7 +1104,7 @@ public class OfferSetupServiceTests
             .Returns(userRoleData.ToAsyncEnumerable());
         A.CallTo(() => _technicalUserProfileService.GetTechnicalUserProfilesForOfferSubscription(A<Guid>._))
             .Returns([new(Guid.NewGuid().ToString(), "test", IamClientAuthMethod.SECRET, roleIds)]);
-        A.CallTo(() => _technicalUserCreation.CreateTechnicalUsersAsync(A<TechnicalUserCreationInfo>._, A<Guid>._, A<IEnumerable<string>>.That.IsSameSequenceAs(new[] { Bpn }), TechnicalUserTypeId.MANAGED, A<bool>._, A<bool>._, A<ServiceAccountCreationProcessData>._, A<Action<TechnicalUser>>._))
+        A.CallTo(() => _technicalUserCreation.CreateTechnicalUsersAsync(A<TechnicalUserCreationInfo>._, A<Guid>._, A<IEnumerable<string>>.That.IsSameSequenceAs(new[] { Bpn }), TechnicalUserTypeId.MANAGED, A<bool>._, A<bool>._, A<ServiceAccountCreationProcessData>.That.Matches(x => x.ProcessId == processId), A<Action<TechnicalUser>>._))
             .Invokes((TechnicalUserCreationInfo _,
                 Guid _,
                 IEnumerable<string> _,
@@ -1165,7 +1165,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.BPN_MUST_BE_SET.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.BPN_MUST_BE_SET));
         A.CallTo(() => _offerSubscriptionsRepository.GetDimTechnicalUserDataForSubscriptionId(offerSubscriptionId))
             .MustHaveHappenedOnceExactly();
     }
@@ -1183,7 +1183,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFER_NAME_MUST_BE_SET.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFER_NAME_MUST_BE_SET));
         A.CallTo(() => _offerSubscriptionsRepository.GetDimTechnicalUserDataForSubscriptionId(offerSubscriptionId))
             .MustHaveHappenedOnceExactly();
     }
@@ -1201,7 +1201,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFERSUBSCRIPTION_MUST_BE_LINKED_TO_PROCESS.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFERSUBSCRIPTION_MUST_BE_LINKED_TO_PROCESS));
         A.CallTo(() => _offerSubscriptionsRepository.GetDimTechnicalUserDataForSubscriptionId(offerSubscriptionId))
             .MustHaveHappenedOnceExactly();
     }
@@ -1272,7 +1272,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.OFFERSUBSCRIPTION_NOT_EXIST.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.OFFERSUBSCRIPTION_NOT_EXIST));
     }
 
     [Theory]
@@ -1288,7 +1288,7 @@ public class OfferSetupServiceTests
         A.CallTo(() => _notificationService.CreateNotificationsWithExistenceCheck(A<IEnumerable<UserRoleConfig>>._, null, A<IEnumerable<(string?, NotificationTypeId)>>._, A<Guid>._, A<string>._, A<string>._, A<bool?>._))
             .Returns(new[] { Guid.NewGuid() }.AsFakeIAsyncEnumerable(out var createNotificationsEnumerator));
         A.CallTo(() => _offerSubscriptionsRepository.GetSubscriptionActivationDataByIdAsync(offerSubscription.Id))
-            .Returns(new SubscriptionActivationData(_validOfferId, OfferSubscriptionStatusId.PENDING, OfferTypeId.APP, "Test App", "Stark Industries", _companyId, requesterEmail, "Tony", "Stark", Guid.NewGuid(), new(true, null), [Guid.NewGuid()], offerSubscriptionProcessDataId, Guid.NewGuid(), _companyId, null, Enumerable.Empty<string>(), true));
+            .Returns(new SubscriptionActivationData(_validOfferId, OfferSubscriptionStatusId.PENDING, OfferTypeId.APP, "Test App", "Stark Industries", _companyId, requesterEmail, "Tony", "Stark", Guid.NewGuid(), new(true, null), [Guid.NewGuid()], offerSubscriptionProcessDataId, Guid.NewGuid(), _companyId, null, [], true));
         A.CallTo(() => _offerSubscriptionProcessService.VerifySubscriptionAndProcessSteps(offerSubscription.Id, ProcessStepTypeId.ACTIVATE_SUBSCRIPTION, null, true))
             .Returns(new ManualProcessStepData<ProcessTypeId, ProcessStepTypeId>(ProcessStepTypeId.ACTIVATE_SUBSCRIPTION, _fixture.Create<Process>(), [processStep], _portalRepositories));
 
@@ -1429,7 +1429,7 @@ public class OfferSetupServiceTests
 
         // Assert
         var ex = await Assert.ThrowsAsync<ConflictException>(Act);
-        ex.Message.Should().Be(OfferSetupServiceErrors.COMPANY_MUST_BE_PROVIDER.ToString());
+        ex.Message.Should().Be(nameof(OfferSetupServiceErrors.COMPANY_MUST_BE_PROVIDER));
     }
 
     [Fact]
@@ -1483,11 +1483,10 @@ public class OfferSetupServiceTests
                         $"cl{count}",
                         new ServiceAccountData(Guid.NewGuid().ToString(), $"cl{count}",
                             new ClientAuthData(IamClientAuthMethod.SECRET) { Secret = "katze!1234" }),
-                        new UserRoleData[]
-                        {
+                        [
                             new(Guid.NewGuid(), $"client{count}", "role1"),
-                            new(Guid.NewGuid(), $"client{count}", "role2"),
-                        })
+                            new(Guid.NewGuid(), $"client{count}", "role2")
+                        ])
                 ]);
                 count++;
                 return result;
@@ -1547,7 +1546,7 @@ public class OfferSetupServiceTests
             .Returns(new OfferSubscriptionTransferData(OfferSubscriptionStatusId.PENDING, true, "Company",
                 _companyId, _companyUserId, _existingServiceId, offerTypeId, "Test Service",
                 Bpn, "user@email.com", "Tony", "Gilbert", (isSingleInstance, null),
-                Enumerable.Empty<Guid>(),
+                [],
                 null));
         A.CallTo(() => _offerSubscriptionsRepository.GetOfferDetailsAndCheckProviderCompany(
                 A<Guid>.That.Not.Matches(x => x == _pendingSubscriptionId || x == _validSubscriptionId || x == _offerIdWithMultipleInstances),
@@ -1590,9 +1589,9 @@ public class OfferSetupServiceTests
         A.CallTo(() => _offerRepository.GetSingleInstanceOfferData(_offerIdWithoutClient, OfferTypeId.APP))
             .Returns(new SingleInstanceOfferData(CompanyUserCompanyId, "app1", Bpn, true, [(_validInstanceSetupId, string.Empty)]));
         A.CallTo(() => _offerRepository.GetSingleInstanceOfferData(_offerIdWithMultipleInstances, OfferTypeId.APP))
-            .Returns(new SingleInstanceOfferData(CompanyUserCompanyId, "app1", Bpn, false, Enumerable.Empty<(Guid, string)>()));
+            .Returns(new SingleInstanceOfferData(CompanyUserCompanyId, "app1", Bpn, false, []));
         A.CallTo(() => _offerRepository.GetSingleInstanceOfferData(_offerIdWithWithNoInstanceSetupIds, OfferTypeId.APP))
-            .Returns(new SingleInstanceOfferData(CompanyUserCompanyId, "app1", Bpn, true, Enumerable.Empty<(Guid, string)>()));
+            .Returns(new SingleInstanceOfferData(CompanyUserCompanyId, "app1", Bpn, true, []));
         A.CallTo(() => _offerRepository.GetSingleInstanceOfferData(A<Guid>.That.Not.Matches(x => x == _offerIdWithoutClient || x == _validOfferId || x == _offerIdWithMultipleInstances || x == _offerIdWithWithNoInstanceSetupIds), OfferTypeId.APP))
             .Returns<SingleInstanceOfferData?>(null);
     }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -1145,6 +1145,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
     }
 
     #endregion
+
     #region Create OfferSubscription
 
     [Fact]
@@ -1225,6 +1226,28 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
                 x.Process.ProcessTypeId == ProcessTypeId.OFFER_SUBSCRIPTION &&
                 x.ProcessStep.ProcessStepTypeId == ProcessStepTypeId.RETRIGGER_PROVIDER &&
                 x.ProcessStep.ProcessStepStatusId == ProcessStepStatusId.TODO);
+    }
+
+    #endregion
+
+    #region GetProcessDataForTechnicalUserCallback
+
+    [Fact]
+    public async Task GetProcessDataForTechnicalUserCallback_ReturnsExpected()
+    {
+        // Arrange
+        var processId = new Guid("d91ac968-ffe8-466f-b34a-ae2517b7c6ab");
+        var (sut, _) = await CreateSut();
+
+        var result = await sut.GetProcessDataForTechnicalUserCallback(processId, [ProcessStepTypeId.AWAIT_CREATE_DIM_TECHNICAL_USER_RESPONSE]).ToListAsync();
+
+        result.Should().ContainSingle()
+            .Which.Should()
+            .Match<(ProcessTypeId ProcessTypeId, VerifyProcessData<ProcessTypeId, ProcessStepTypeId> ProcessData, Guid?
+                TechnicalUserId, Guid? TechnicalUserVersion)>(x =>
+                x.ProcessTypeId == ProcessTypeId.OFFER_SUBSCRIPTION &&
+                x.ProcessData.ProcessSteps!.Count() == 1 &&
+                x.TechnicalUserId == new Guid("4ce1b774-3d00-4e07-9a53-ae1f64193392"));
     }
 
     #endregion

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offer_subscriptions.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/offer_subscriptions.unittest.json
@@ -29,7 +29,8 @@
     "last_editor_id": null,
     "display_name": null,
     "description": null,
-    "date_created": "2022-03-24 18:01:33.394000 +00:00"
+    "date_created": "2022-03-24 18:01:33.394000 +00:00",
+    "process_id":  "d91ac968-ffe8-466f-b34a-ae2517b7c6ab"
   },
   {
     "company_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/process_steps.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/process_steps.unittest.json
@@ -254,5 +254,21 @@
     "process_id": "44927361-3766-4f07-9f18-860158880d86",
     "date_created": "2023-10-11 08:15:20.479000 +00:00",
     "date_last_changed": null
+  },
+  {
+    "id": "8aaffd4f-9620-487f-b095-214518a4ced8",
+    "process_step_type_id": 500,
+    "process_step_status_id": 2,
+    "process_id": "d91ac968-ffe8-466f-b34a-ae2517b7c6ab",
+    "date_created": "2023-10-11 08:15:20.479000 +00:00",
+    "date_last_changed": null
+  },
+  {
+    "id": "86d5a161-b4cb-44e6-b85e-c1f24f60be11",
+    "process_step_type_id": 502,
+    "process_step_status_id": 1,
+    "process_id": "d91ac968-ffe8-466f-b34a-ae2517b7c6ab",
+    "date_created": "2023-10-11 08:15:20.479000 +00:00",
+    "date_last_changed": null
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/processes.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/processes.unittest.json
@@ -100,5 +100,11 @@
     "process_type_id" : 7,
     "lock_expiry_date" : "2023-03-01 00:00:00.000000 +00:00",
     "version" : "deadbeef-dead-beef-dead-beefdeadbeef"
+  },
+  {
+    "id":  "d91ac968-ffe8-466f-b34a-ae2517b7c6ab",
+    "process_type_id" : 3,
+    "lock_expiry_date" : "2023-03-01 00:00:00.000000 +00:00",
+    "version" : "deadbeef-dead-beef-dead-beefdeadbeef"
   }
 ]


### PR DESCRIPTION
## Description

adjust the technical user creation callback from dim middle layer

## Why

to activate the technical users when a app or service subscription is setup

## Issue

Refs: #1371

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
