### PR TITLE
feat(error): spelling_error_constraintset_delete

### DIFF
--- a/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
+++ b/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
@@ -38,7 +38,7 @@ public class GeneralHttpErrorHandler
     private static readonly IReadOnlyDictionary<HttpStatusCode, MetaData> Metadata = ImmutableDictionary.CreateRange(new[]
     {
         KeyValuePair.Create(HttpStatusCode.BadRequest, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.1", "One or more validation errors occurred.")),
-        KeyValuePair.Create(HttpStatusCode.Conflict, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.8", "The resorce is in conflict with the current request.")),
+        KeyValuePair.Create(HttpStatusCode.Conflict, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.8", "The resource is in conflict with the current request.")),
         KeyValuePair.Create(HttpStatusCode.NotFound, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4", "Cannot find representation of target resource.")),
         KeyValuePair.Create(HttpStatusCode.Forbidden, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3", "Access to requested resource is not permitted.")),
         KeyValuePair.Create(HttpStatusCode.UnsupportedMediaType, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13", "The server cannot process this type of content")),


### PR DESCRIPTION
## Description

Steps to reproduce:

Execute the endpoint /api/constraintSet/{constraintSetId} with forceConstraintDelete = False

Observed behavior:

error message: "The resorce is in conflict with the current request."


## Why
Required behavior:

The resource is in conflict with the current request.

## Issue

[DSCP-477](https://atc.bmwgroup.net/jira/browse/DSCP-477)

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [X] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [X] I have created and linked IP issues or requested their creation by a committer
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes
- [X] I have commented my code, particularly in hard-to-understand areas
