### PR TITLE
fix(serviceSubscriptionDecline): resolved the api route issue

### DIFF
--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -1527,7 +1527,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           description: The User is unauthorized
-  '/subscription/{subscriptionId}/decline':
+  '/api/services/subscription/{subscriptionId}/decline':
     put:
       tags:
         - Services

--- a/src/marketplace/Services.Service/Controllers/ServicesController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServicesController.cs
@@ -364,7 +364,7 @@ public class ServicesController : ControllerBase
     /// <response code="400">If sub claim is empty/invalid or user does not exist, or any other parameters are invalid.</response>
     /// <response code="500">Internal Server Error.</response>
     [HttpPut]
-    [Route("/subscription/{subscriptionId}/decline")]
+    [Route("subscription/{subscriptionId}/decline")]
     [Authorize(Roles = "decline_subscription")]
     [Authorize(Policy = PolicyTypes.ValidIdentity)]
     [Authorize(Policy = PolicyTypes.ValidCompany)]


### PR DESCRIPTION
## Description

Service Subscription | Decline api is throwing 404 error

## Why

When a service with valid subscriptionId is tried to be declined then 404 error is displaying.
![image](https://github.com/user-attachments/assets/c5241e26-856e-489d-91ae-3608231fced3)


## Issue

Ref: https://github.com/eclipse-tractusx/portal-backend/issues/1377

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
