### PR TITLE
fix: retrieve processes for service account callback as no tracking

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -567,6 +567,7 @@ public class OfferSubscriptionsRepository(PortalDbContext dbContext) : IOfferSub
 
     public IAsyncEnumerable<(ProcessTypeId ProcessTypeId, VerifyProcessData<ProcessTypeId, ProcessStepTypeId> ProcessData, Guid? TechnicalUserId, Guid? TechnicalUserVersion)> GetProcessDataForTechnicalUserCallback(Guid processId, IEnumerable<ProcessStepTypeId> processStepTypeIds) =>
         dbContext.TechnicalUsers
+            .AsNoTracking()
             .Where(t => t.OfferSubscription!.ProcessId == processId && t.TechnicalUserKindId == TechnicalUserKindId.EXTERNAL)
             .Select(x => new ValueTuple<ProcessTypeId, VerifyProcessData<ProcessTypeId, ProcessStepTypeId>, Guid?, Guid?>(
                     x.OfferSubscription!.Process!.ProcessTypeId,


### PR DESCRIPTION
## Description

adjust the retrieving of the processes

## Why

Currently the process can't be updated because its already added in the changeTracking of ef

## Issue

Refs: #1371

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
