### PR TITLE
fix(auto-setup): fix the open id

### DIFF
--- a/src/externalsystems/OfferProvider.Library/OfferProviderService.cs
+++ b/src/externalsystems/OfferProvider.Library/OfferProviderService.cs
@@ -27,6 +27,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.OfferProvider.Library;
 public class OfferProviderService : IOfferProviderService
 {
     private const string GrantType = "client_credentials";
+    private const string Scope = "openid";
     private readonly ITokenService _tokenService;
 
     /// <summary>
@@ -47,7 +48,8 @@ public class OfferProviderService : IOfferProviderService
             TokenAddress = authUrl,
             ClientId = clientId,
             ClientSecret = clientSecret,
-            GrantType = GrantType
+            GrantType = GrantType,
+            Scope = Scope
         };
         using var httpClient = await _tokenService.GetAuthorizedClient<OfferProviderService>(settings, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);
@@ -66,7 +68,8 @@ public class OfferProviderService : IOfferProviderService
             TokenAddress = authUrl,
             ClientId = clientId,
             ClientSecret = clientSecret,
-            GrantType = GrantType
+            GrantType = GrantType,
+            Scope = Scope
         };
         using var httpClient = await _tokenService.GetAuthorizedClient<OfferProviderService>(settings, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);

--- a/src/externalsystems/OnboardingServiceProvider.Library/OnboardingServiceProviderService.cs
+++ b/src/externalsystems/OnboardingServiceProvider.Library/OnboardingServiceProviderService.cs
@@ -27,6 +27,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.OnboardingServiceProvider.Library;
 public class OnboardingServiceProviderService : IOnboardingServiceProviderService
 {
     private const string GrantType = "client_credentials";
+    private const string Scope = "openid";
     private readonly ITokenService _tokenService;
 
     /// <summary>
@@ -45,7 +46,8 @@ public class OnboardingServiceProviderService : IOnboardingServiceProviderServic
             TokenAddress = ospDetails.AuthUrl,
             ClientId = ospDetails.ClientId,
             ClientSecret = ospDetails.ClientSecret,
-            GrantType = GrantType
+            GrantType = GrantType,
+            Scope = Scope
         };
         using var httpClient = await _tokenService.GetAuthorizedClient<OnboardingServiceProviderService>(settings, cancellationToken)
             .ConfigureAwait(ConfigureAwaitOptions.None);


### PR DESCRIPTION
## Description

Added scope in token generation in auto setup.

## Why

Token generation was failing as most of the IDP requires scope

## Issue

#1375 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
