### PR TITLE
feat: update registration administration apis to return company short name

### DIFF
--- a/docs/api/administration-service.yaml
+++ b/docs/api/administration-service.yaml
@@ -6935,6 +6935,8 @@ components:
         hostCompanyName:
           type: string
           nullable: true
+        hostCompanyShortName:
+          type: string
         selfDescriptionDocumentId:
           type: string
           format: uuid

--- a/docs/api/administration-service.yaml
+++ b/docs/api/administration-service.yaml
@@ -6979,11 +6979,13 @@ components:
           $ref: '#/components/schemas/ConnectorTypeId'
         name:
           type: string
+        hostCompanyName:
+          type: string
+        hostCompanyShortName:
+          type: string
         companyId:
           type: string
           format: uuid
-        hostCompanyName:
-          type: string
         skippedDate:
           type: string
           format: date-time

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
@@ -20,6 +20,7 @@
 
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
@@ -60,6 +61,7 @@ public record ManagedConnectorData(
     ConnectorTypeId Type,
     ConnectorStatusId Status,
     string? ProviderCompanyName,
+    [property: JsonPropertyName("providerShortName")] string Shortname,
     Guid? SelfDescriptionDocumentId,
     TechnicalUserData? TechnicalUser,
     string ConnectorUrl);

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
@@ -61,7 +61,7 @@ public record ManagedConnectorData(
     ConnectorTypeId Type,
     ConnectorStatusId Status,
     string? ProviderCompanyName,
-    [property: JsonPropertyName("providerShortName")] string Shortname,
+    [property: JsonPropertyName("hostCompanyShortName")] string Shortname,
     Guid? SelfDescriptionDocumentId,
     TechnicalUserData? TechnicalUser,
     string ConnectorUrl);

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
@@ -36,6 +36,8 @@ public record ConnectorData(
     ConnectorStatusId Status,
     Guid? HostId,
     string? HostCompanyName,
+    [property: JsonPropertyName("hostCompanyShortName")] string Shortname,
+
     Guid? SelfDescriptionDocumentId,
     TechnicalUserData? TechnicalUser,
     string ConnectorUrl

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
@@ -18,9 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
@@ -29,15 +29,13 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 /// </summary>
 public record ConnectorData(
     string Name,
-    [StringLength(2, MinimumLength = 2)]
-    string Location,
+    [StringLength(2, MinimumLength = 2)] string Location,
     Guid Id,
     ConnectorTypeId Type,
     ConnectorStatusId Status,
     Guid? HostId,
     string? HostCompanyName,
     [property: JsonPropertyName("hostCompanyShortName")] string Shortname,
-
     Guid? SelfDescriptionDocumentId,
     TechnicalUserData? TechnicalUser,
     string ConnectorUrl
@@ -46,19 +44,14 @@ public record ConnectorData(
 /// <summary>
 /// Connector information for the daps call.
 /// </summary>
-public record ConnectorInformationData(
-    string Name,
-    string Bpn,
-    Guid Id,
-    string Url);
+public record ConnectorInformationData(string Name, string Bpn, Guid Id, string Url);
 
 /// <summary>
 /// View model for connectors.
 /// </summary>
 public record ManagedConnectorData(
     string Name,
-    [StringLength(2, MinimumLength = 2)]
-    string Location,
+    [StringLength(2, MinimumLength = 2)] string Location,
     Guid Id,
     ConnectorTypeId Type,
     ConnectorStatusId Status,
@@ -66,7 +59,8 @@ public record ManagedConnectorData(
     [property: JsonPropertyName("hostCompanyShortName")] string Shortname,
     Guid? SelfDescriptionDocumentId,
     TechnicalUserData? TechnicalUser,
-    string ConnectorUrl);
+    string ConnectorUrl
+);
 
 /// <summary>
 /// connector information to delete
@@ -82,8 +76,20 @@ public record DeleteConnectorData(
     DeleteServiceAccountData DeleteServiceAccountData,
     string Location
 );
-public record ConnectorOfferSubscription(Guid AssignedOfferSubscriptionIds, OfferSubscriptionStatusId OfferSubscriptionStatus);
+
+public record ConnectorOfferSubscription(
+    Guid AssignedOfferSubscriptionIds,
+    OfferSubscriptionStatusId OfferSubscriptionStatus
+);
 
 public record TechnicalUserData(Guid Id, string Name, string? ClientId, string Description);
 
-public record ConnectorMissingSdDocumentData(Guid ConnectorId, ConnectorTypeId Type, string Name, Guid CompanyId, string HostCompanyName, DateTimeOffset? SkippedDate);
+public record ConnectorMissingSdDocumentData(
+    Guid ConnectorId,
+    ConnectorTypeId Type,
+    string Name,
+    string HostCompanyName,
+    [property: JsonPropertyName("hostCompanyShortName")] string Shortname,
+    Guid CompanyId,
+    DateTimeOffset? SkippedDate
+);

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionConnectorData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionConnectorData.cs
@@ -19,10 +19,12 @@
  ********************************************************************************/
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+using System.Text.Json.Serialization;
 
 public record OfferSubscriptionConnectorData(
     Guid SubscriptionId,
     string CustomerName,
+    [property: JsonPropertyName("customerShortName")] string Shortname,
     string? OfferName,
     IEnumerable<Guid> ConnectorIds
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -57,6 +57,7 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
                 con.StatusId,
                 con.HostId,
                 con.Host!.Name,
+                con.Host!.Shortname,
                 con.SelfDescriptionDocumentId,
                 con.TechnicalUserId == null ? null : new TechnicalUserData(
                     con.TechnicalUser!.Id,
@@ -107,6 +108,7 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
                     connector.StatusId,
                     connector.HostId,
                     connector.Host!.Name,
+                    connector.Host!.Shortname,
                     connector.SelfDescriptionDocumentId,
                     connector.TechnicalUserId == default ? null : new TechnicalUserData(
                         connector.TechnicalUser!.Id,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -233,8 +233,9 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
                 con.Id,
                 con.TypeId,
                 con.Name,
-                con.HostId ?? con.ProviderId,
                 con.HostId != null ? con.Host!.Name : con.Provider!.Name,
+                con.Host!.Shortname,
+                con.HostId ?? con.ProviderId,
                 con.SdSkippedDate)
         ).SingleOrDefaultAsync();
 

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -84,6 +84,7 @@ public class ConnectorsRepository(PortalDbContext dbContext) : IConnectorsReposi
                     c.TypeId,
                     c.StatusId,
                     c.Provider!.Name,
+                    c.Provider!.Shortname,
                     c.SelfDescriptionDocumentId,
                     c.TechnicalUserId == default ? null : new TechnicalUserData(
                         c.TechnicalUser!.Id,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -501,6 +501,7 @@ public class OfferSubscriptionsRepository(PortalDbContext dbContext) : IOfferSub
             .Select(os => new OfferSubscriptionConnectorData(
                 os.Id,
                 os.Company!.Name,
+                os.Company!.Shortname,
                 os.Offer!.Name,
                 os.ConnectorAssignedOfferSubscriptions.Select(c => c.ConnectorId)
             ))


### PR DESCRIPTION
## Description

Added host/provider/company short name attributes to service API.

## Why

Some companies can have very long names, to improve usability/readability in the UI, it would be best to allow for company short name to be displayed.

## Issue

#1259 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes