### PR TITLE
fix: swap app subscription auth and service urls

### DIFF
--- a/docs/api/apps-service.yaml
+++ b/docs/api/apps-service.yaml
@@ -3748,11 +3748,11 @@ components:
           nullable: true
         did_resolver:
           type: string
-        decentralIdentityManagementAuthUrl:
-          type: string
         decentralIdentityManagementServiceUrl:
           type: string
           nullable: true
+        decentralIdentityManagementAuthUrl:
+          type: string
       additionalProperties: false
     SubscriptionStatusSorting:
       enum:

--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -2865,11 +2865,11 @@ components:
           nullable: true
         did_resolver:
           type: string
-        decentralIdentityManagementAuthUrl:
-          type: string
         decentralIdentityManagementServiceUrl:
           type: string
           nullable: true
+        decentralIdentityManagementAuthUrl:
+          type: string
       additionalProperties: false
     SubscriptionStatusSorting:
       enum:

--- a/src/marketplace/Offers.Library/Models/OfferProviderSubscriptionDetailData.cs
+++ b/src/marketplace/Offers.Library/Models/OfferProviderSubscriptionDetailData.cs
@@ -54,6 +54,6 @@ public record SubscriptionExternalServiceData(
     [property: JsonPropertyName("participant_id")] string? ParticipantId,
     [property: JsonPropertyName("iatp_id")] string? IatpId,
     [property: JsonPropertyName("did_resolver")] string DidResolver,
-    [property: JsonPropertyName("decentralIdentityManagementAuthUrl")] string DecentralIdentityManagementAuthUrl,
-    [property: JsonPropertyName("decentralIdentityManagementServiceUrl")] string? DecentralIdentityManagementServiceUrl
+    [property: JsonPropertyName("decentralIdentityManagementServiceUrl")] string? DecentralIdentityManagementServiceUrl,
+    [property: JsonPropertyName("decentralIdentityManagementAuthUrl")] string DecentralIdentityManagementAuthUrl
 );

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -812,8 +812,8 @@ public class OfferService(
                 data.ExternalServiceData?.ParticipantId,
                 data.ExternalServiceData == null || data.ExternalServiceData.TrustedIssuer.EndsWith(":holder-iatp") ? data.ExternalServiceData?.TrustedIssuer : $"{data.ExternalServiceData.TrustedIssuer}:holder-iatp",
                 walletData.BpnDidResolverUrl,
-                walletData.DecentralIdentityManagementAuthUrl,
-                data.ExternalServiceData?.DecentralIdentityManagementServiceUrl));
+                data.ExternalServiceData?.DecentralIdentityManagementServiceUrl,
+                walletData.DecentralIdentityManagementAuthUrl));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Description

Switched auth and service urls in payload of the apps/{appId}/subscription/{subscriptionId}/provider API

## Why

The "decentralIdentityManagementAuthUrl" and "decentralIdentityManagementServiceUrl" attributes were returning incorrect values. It appears their values were mixed up, so they have now been switched back to the correct ones.

## Issue

#1401 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
