### PR TITLE
fix(regex): region regex update

### DIFF
--- a/src/framework/Framework.Async/Directory.Build.props
+++ b/src/framework/Framework.Async/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Cors/Directory.Build.props
+++ b/src/framework/Framework.Cors/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DBAccess/Directory.Build.props
+++ b/src/framework/Framework.DBAccess/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DateTimeProvider/Directory.Build.props
+++ b/src/framework/Framework.DateTimeProvider/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.DependencyInjection/Directory.Build.props
+++ b/src/framework/Framework.DependencyInjection/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Controller/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.ErrorHandling/Directory.Build.props
+++ b/src/framework/Framework.ErrorHandling/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.HttpClientExtensions/Directory.Build.props
+++ b/src/framework/Framework.HttpClientExtensions/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.IO/Directory.Build.props
+++ b/src/framework/Framework.IO/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Identity/Directory.Build.props
+++ b/src/framework/Framework.Identity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Linq/Directory.Build.props
+++ b/src/framework/Framework.Linq/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Logging/Directory.Build.props
+++ b/src/framework/Framework.Logging/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/Directory.Build.props
+++ b/src/framework/Framework.Models/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -42,7 +42,7 @@ public static class ValidationExpressions
     /// <remarks>
     /// The pattern ensures ISO-1366-2 code value: NW
     /// </remarks>
-    public const string Region = "^[A-Z1-9]{1,3}$";
+    public const string Region = "^[A-Z0-9]{1,3}$";
 
     #region UniqueIdentifiers
     public const string Worldwide = "Worldwide";

--- a/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library.Concrete/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
+++ b/src/framework/Framework.Processes.ProcessIdentity/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
+++ b/src/framework/Framework.Processes.Worker.Library/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Seeding/Directory.Build.props
+++ b/src/framework/Framework.Seeding/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Swagger/Directory.Build.props
+++ b/src/framework/Framework.Swagger/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Token/Directory.Build.props
+++ b/src/framework/Framework.Token/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/framework/Framework.Web/Directory.Build.props
+++ b/src/framework/Framework.Web/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.15.0</VersionPrefix>
+    <VersionPrefix>3.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -896,10 +896,15 @@ public class RegistrationBusinessLogicTest
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("BPNL00000003CRHK")]
-    public async Task SetCompanyWithAddressAsync_ModifyCompany(string? bpn)
+    [InlineData(null, "X")]
+    [InlineData("", "XX")]
+    [InlineData("BPNL00000003CRHK", "XXX")]
+    [InlineData("BPNL00000003CRHK", "0")]
+    [InlineData("BPNL00000003CRHK", "02")]
+    [InlineData("BPNL00000003CRHK", "123")]
+    [InlineData("BPNL00000003CRHK", "023")]
+    [InlineData("BPNL00000003CRHK", "X23")]
+    public async Task SetCompanyWithAddressAsync_ModifyCompany(string? bpn, string region)
     {
         //Arrange
         var applicationId = Guid.NewGuid();
@@ -913,7 +918,7 @@ public class RegistrationBusinessLogicTest
             .With(x => x.BusinessPartnerNumber, bpn)
             .With(x => x.CompanyId, companyId)
             .With(x => x.CountryAlpha2Code, _alpha2code)
-            .With(x => x.Region, _region)
+            .With(x => x.Region, region)
             .With(x => x.UniqueIds, [new CompanyUniqueIdData(UniqueIdentifierId.VAT_ID, _vatId)])
             .Create();
 


### PR DESCRIPTION
## Description

Registration api responding 400 error code "REGION_INVALID"

## Why

Registration api is responding 400 error when entring "140" region value
Current regex: `^[A-Z1-9]{1,3}$`
Expected regex: `^[A-Z0-9]{1,3}$`

## Issue

Ref: #1404

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
