### PR TITLE
feat: add createdAt to subscription status response

### DIFF
--- a/docs/api/apps-service.yaml
+++ b/docs/api/apps-service.yaml
@@ -3041,6 +3041,9 @@ components:
           nullable: true
         technicalUser:
           type: boolean
+        dateCreated:
+          type: string
+          format: date-time
         processStepTypeId:
           $ref: '#/components/schemas/ProcessStepTypeId'
       additionalProperties: false

--- a/docs/api/services-service.yaml
+++ b/docs/api/services-service.yaml
@@ -1686,6 +1686,9 @@ components:
           nullable: true
         technicalUser:
           type: boolean
+        dateCreated:
+          type: string
+          format: date-time
         processStepTypeId:
           $ref: '#/components/schemas/ProcessStepTypeId'
       additionalProperties: false

--- a/src/marketplace/Offers.Library/Extensions/CompanySubscriptionStatusExtensions.cs
+++ b/src/marketplace/Offers.Library/Extensions/CompanySubscriptionStatusExtensions.cs
@@ -33,5 +33,7 @@ public static class CompanySubscriptionStatusExtensions
             data.BpnNumber,
             data.Email,
             data.TechnicalUser,
+            data.DateCreated,
             data.ProcessSteps.GetProcessStepTypeId(offerId));
+            
 }

--- a/src/marketplace/Offers.Library/Extensions/CompanySubscriptionStatusExtensions.cs
+++ b/src/marketplace/Offers.Library/Extensions/CompanySubscriptionStatusExtensions.cs
@@ -35,5 +35,4 @@ public static class CompanySubscriptionStatusExtensions
             data.TechnicalUser,
             data.DateCreated,
             data.ProcessSteps.GetProcessStepTypeId(offerId));
-            
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanySubscriptionStatusData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanySubscriptionStatusData.cs
@@ -35,5 +35,6 @@ public record CompanySubscriptionStatusData(
     string? BpnNumber,
     string? Email,
     bool TechnicalUser,
+    DateTimeOffset DateCreated,
     IEnumerable<(ProcessStepTypeId ProcessStepTypeId, ProcessStepStatusId ProcessStepStatusId)> ProcessSteps
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferCompanySubscriptionStatusData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferCompanySubscriptionStatusData.cs
@@ -44,5 +44,6 @@ public record CompanySubscriptionStatus(
     string? BpnNumber,
     string? Email,
     bool TechnicalUser,
+    DateTimeOffset DateCreated,
     ProcessStepTypeId? ProcessStepTypeId
 );

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -79,6 +79,7 @@ public class OfferSubscriptionsRepository(PortalDbContext dbContext) : IOfferSub
                                 s.Company.BusinessPartnerNumber,
                                 s.Requester!.Email,
                                 s.Offer!.TechnicalUserProfiles.Any(tup => tup.TechnicalUserProfileAssignedUserRoles.Any()),
+                                s.DateCreated,
                                 s.Process!.ProcessSteps
                                     .Where(ps => ps.ProcessStepStatusId == ProcessStepStatusId.TODO)
                                     .Select(ps => new ValueTuple<ProcessStepTypeId, ProcessStepStatusId>(

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
@@ -210,23 +210,23 @@ public class AppsControllerTests
                 var companySubscriptionStatuses = new List<CompanySubscriptionStatus>
                 {
                     new CompanySubscriptionStatus(
-                        Guid.NewGuid(),               // CompanyId
-                        $"Company {i}",               // CompanyName
-                        Guid.NewGuid(),               // SubscriptionId
-                        OfferSubscriptionStatusId.ACTIVE,
-                        "DE",                         // Country
-                        $"BPN00000000{i}",                    // BpnNumber
-                        $"email{i}@example.com",      // Email
-                        false,                        // TechnicalUser
-                        createdAt,                    // CreatedAt
+                        Guid.NewGuid(),
+                        $"Company {i}",
+                        Guid.NewGuid(),
+                        OfferSubscriptionStatusId.PENDING,
+                        "DE",
+                        $"BPN00000000000{i}",
+                        $"email{i}@example.com",
+                        false,
+                        createdAt,
                         ProcessStepTypeId.MANUAL_TRIGGER_ACTIVATE_SUBSCRIPTION)
                 };
 
                 return new OfferCompanySubscriptionStatusResponse(
-                    Guid.NewGuid(),                   // OfferId
-                    $"Test Offer {i}",                // OfferName
-                    companySubscriptionStatuses,      // CompanySubscriptionStatuses
-                    Guid.NewGuid());                  // Image
+                    Guid.NewGuid(),
+                    $"Test Offer {i}",
+                    companySubscriptionStatuses,
+                    Guid.NewGuid());
             })
             .ToImmutableArray();
 


### PR DESCRIPTION
## Description

Added DateCreated attribute to subscription status response 

## Why

To optimise filtering functionality in the frontend, a creation date of the subscription is needed in the response

## Issue

[1590](https://github.com/eclipse-tractusx/portal-frontend/issues/1590)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
