### PR TITLE
fix: add exception handling for connector with out tech user

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -125,7 +125,7 @@ public class ConnectorsBusinessLogic(
             throw UnexpectedConditionException.Create(AdministrationConnectorErrors.CONNECTOR_UNEXPECTED_NO_BPN_ASSIGNED, new ErrorParameter[] { new(nameof(companyId), companyId.ToString()) });
         }
 
-        await ValidateTechnicalUser(technicalUserId, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
+        await ValidateTechnicalUser(name, technicalUserId, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
 
         var connectorRequestModel = new ConnectorRequestModel(name, connectorUrl, ConnectorTypeId.COMPANY_CONNECTOR, location, companyId, companyId, technicalUserId);
         return await CreateAndRegisterConnectorAsync(
@@ -174,7 +174,7 @@ public class ConnectorsBusinessLogic(
             throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN, new ErrorParameter[] { new("companyId", result.CompanyId.ToString()) });
         }
 
-        await ValidateTechnicalUser(technicalUserId, result.CompanyId).ConfigureAwait(ConfigureAwaitOptions.None);
+        await ValidateTechnicalUser(name, technicalUserId, result.CompanyId).ConfigureAwait(ConfigureAwaitOptions.None);
 
         var connectorRequestModel = new ConnectorRequestModel(name, connectorUrl, ConnectorTypeId.CONNECTOR_AS_A_SERVICE, location, companyId, result.CompanyId, technicalUserId);
         return await CreateAndRegisterConnectorAsync(
@@ -204,11 +204,11 @@ public class ConnectorsBusinessLogic(
         }
     }
 
-    private async Task ValidateTechnicalUser(Guid? technicalUserId, Guid companyId)
+    private async Task ValidateTechnicalUser(string name, Guid? technicalUserId, Guid companyId)
     {
         if (technicalUserId == null)
         {
-            return;
+            throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER, [new ErrorParameter("name", name)]);
         }
 
         var (activeUserExists, linkedToConnectorOrOffer) = await portalRepositories.GetInstance<ITechnicalUserRepository>()

--- a/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
+++ b/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
@@ -46,7 +46,7 @@ public class AdministrationConnectorErrorMessageContainer : IErrorMessageContain
         new((int)AdministrationConnectorErrors.CONNECTOR_CONFLICT_INACTIVE_STATE,"Connector {connectorId} is in state {connectorStatusId}"),
         new((int)AdministrationConnectorErrors.CONNECTOR_DUPLICATE,"Connector {name} does already exists for url {connectorUrl}"),
         new((int)AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_IN_USE,"Technical User {technicalUserId} is already used by another connector or offer"),
-        new((int)AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER,"Connector {name} must have a technical user set")
+        new((int)AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER,"Connector {name} must have a technical user")
     ]);
 
     public Type Type { get => typeof(AdministrationConnectorErrors); }

--- a/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
+++ b/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
@@ -45,7 +45,8 @@ public class AdministrationConnectorErrorMessageContainer : IErrorMessageContain
         new((int)AdministrationConnectorErrors.CONNECTOR_NOT_HOST_COMPANY,"Company {companyId} is not the connectors host company"),
         new((int)AdministrationConnectorErrors.CONNECTOR_CONFLICT_INACTIVE_STATE,"Connector {connectorId} is in state {connectorStatusId}"),
         new((int)AdministrationConnectorErrors.CONNECTOR_DUPLICATE,"Connector {name} does already exists for url {connectorUrl}"),
-        new((int)AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_IN_USE,"Technical User {technicalUserId} is already used by another connector or offer")
+        new((int)AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_IN_USE,"Technical User {technicalUserId} is already used by another connector or offer"),
+        new((int)AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER,"Connector {name} must have a technical user set")
     ]);
 
     public Type Type { get => typeof(AdministrationConnectorErrors); }
@@ -74,5 +75,6 @@ public enum AdministrationConnectorErrors
     CONNECTOR_NOT_HOST_COMPANY,
     CONNECTOR_CONFLICT_INACTIVE_STATE,
     CONNECTOR_DUPLICATE,
-    CONNECTOR_ARGUMENT_TECH_USER_IN_USE
+    CONNECTOR_ARGUMENT_TECH_USER_IN_USE,
+    CONNECTOR_MISSING_TECH_USER
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -358,8 +358,10 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateConnectorAsync_WithClientIdNull_DoesntSaveData()
     {
         // Arrange
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, null);
+        var sa01 = Guid.NewGuid();
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, sa01);
 
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
         // Act
         var result = await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
 
@@ -372,6 +374,7 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateConnectorAsync_WithoutSelfDescriptionDocumentAndSdConnectionDisabled_CallsExpected()
     {
         // Arrange
+        var sa01 = Guid.NewGuid();
         var sut = new ConnectorsBusinessLogic(_portalRepositories, Options.Create(new ConnectorsSettings
         {
             MaxPageSize = 15,
@@ -397,8 +400,9 @@ public class ConnectorsBusinessLogicTests
             ]
         }), _sdFactoryBusinessLogic, _identityService, _serviceAccountManagement, _dateTimeProvider, A.Fake<ILogger<ConnectorsBusinessLogic>>());
 
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, null);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, sa01);
         A.CallTo(() => _identity.CompanyId).Returns(CompanyIdWithoutSdDocument);
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
 
         // Act
         await sut.CreateConnectorAsync(connectorInput, CancellationToken.None);
@@ -412,9 +416,10 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateConnectorAsync_WithoutSelfDescriptionDocument_ThrowsUnexpectedException()
     {
         // Arrange
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, null);
+        var sa01 = Guid.NewGuid();
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, sa01);
         A.CallTo(() => _identity.CompanyId).Returns(CompanyIdWithoutSdDocument);
-
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
         // Act
         async Task Act() => await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
 
@@ -456,7 +461,9 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateConnectorAsync_WithFailingDapsService_ReturnsCreatedConnectorData()
     {
         // Arrange
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, null);
+        var sa01 = Guid.NewGuid();
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, sa01);
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
 
         // Act
         var result = await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
@@ -525,7 +532,8 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateManagedConnectorAsync_WithTechnicalUser_ReturnsCreatedConnectorData(bool clearingHouseDisabled)
     {
         // Arrange
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, _validOfferSubscriptionId, null);
+        var sa01 = Guid.NewGuid();
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, _validOfferSubscriptionId, sa01);
         var sut = new ConnectorsBusinessLogic(_portalRepositories, Options.Create(new ConnectorsSettings
         {
             MaxPageSize = 15,
@@ -554,6 +562,7 @@ public class ConnectorsBusinessLogicTests
         SetupTechnicalIdentity();
 
         // Act
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
         var result = await sut.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);
 
         // Assert
@@ -588,7 +597,8 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateManagedConnectorAsync_WithInvalidLocation_ThrowsControllerArgumentException()
     {
         // Arrange
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", "invalid", _validOfferSubscriptionId, null);
+        var sa01 = Guid.NewGuid();
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", "invalid", _validOfferSubscriptionId, sa01);
 
         // Act
         async Task Act() => await _logic.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);
@@ -606,10 +616,11 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateManagedConnectorAsync_WithNotExistingSubscription_ThrowsNotFoundException()
     {
         // Arrange
+        var sa01 = Guid.NewGuid();
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
             .Returns((false, default, default, default, default, default, default));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
 
         SetupTechnicalIdentity();
 
@@ -625,10 +636,11 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateManagedConnectorAsync_WithCallerNotOfferProvider_ThrowsForbiddenException()
     {
         // Arrange
+        var sa01 = Guid.NewGuid();
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
             .Returns((true, false, default, default, default, default, default));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
 
         SetupTechnicalIdentity();
 
@@ -644,10 +656,11 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateManagedConnectorAsync_WithOfferAlreadyLinked_ThrowsUnexpectedConditionException()
     {
         // Arrange
+        var sa01 = Guid.NewGuid();
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
             .Returns((true, true, true, default, default, default, default));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
 
         SetupTechnicalIdentity();
 
@@ -663,10 +676,11 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateManagedConnectorAsync_WithInactiveSubscription_ThrowsUnexpectedConditionException()
     {
         // Arrange
+        var sa01 = Guid.NewGuid();
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
             .Returns((true, true, false, OfferSubscriptionStatusId.INACTIVE, default, default, default));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
 
         SetupTechnicalIdentity();
 
@@ -682,10 +696,12 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateManagedConnectorAsync_WithoutExistingSelfDescriptionDocument_ThrowsUnexpectedException()
     {
         // Arrange
+        var sa01 = Guid.NewGuid();
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, A<Guid>.That.Matches(x => x == ValidCompanyId)))
             .Returns((true, true, false, OfferSubscriptionStatusId.ACTIVE, null, ValidCompanyId, ValidCompanyBpn));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
 
         // Act
         async Task Act() => await _logic.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -240,7 +240,21 @@ public class ConnectorsBusinessLogicTests
     }
     #endregion
 
-    #region Create Connector
+    #region Create Connector 
+
+    [Fact]
+    public async Task CreateConnectorAsync_WithoutTechnicalUser_ThrowsException()
+    {
+        // Arrange
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, null);
+
+        // Act
+        async Task Act() => await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER.ToString());
+    }
 
     [Theory]
     [InlineData(true)]

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -574,9 +574,9 @@ public class ConnectorsBusinessLogicTests
         }), _sdFactoryBusinessLogic, _identityService, _serviceAccountManagement, _dateTimeProvider, A.Fake<ILogger<ConnectorsBusinessLogic>>());
 
         SetupTechnicalIdentity();
+        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
 
         // Act
-        A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
         var result = await sut.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);
 
         // Assert


### PR DESCRIPTION
## Description

Added exception handling for connector creation without specifiying a technical user.

## Why

A connector needs to have an active technical user assigned during creation. Therefore, if none is specified during the creation process, the API should throw and error and prevent its creation. 

## Issue

#1409 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
