### PR TITLE
fix(managedConnector): pending offer subscription is available to register the connector

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -496,8 +496,7 @@ public class OfferSubscriptionsRepository(PortalDbContext dbContext) : IOfferSub
     public IAsyncEnumerable<OfferSubscriptionConnectorData> GetConnectorOfferSubscriptionData(bool? connectorIdSet, Guid companyId) =>
         dbContext.OfferSubscriptions
             .Where(os =>
-                os.Offer!.ProviderCompanyId == companyId &&
-                (os.OfferSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE || os.OfferSubscriptionStatusId == OfferSubscriptionStatusId.PENDING) &&
+                os.Offer!.ProviderCompanyId == companyId && os.OfferSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE &&
                 (connectorIdSet == null || (connectorIdSet.Value ? os.ConnectorAssignedOfferSubscriptions.Any() : !os.ConnectorAssignedOfferSubscriptions.Any())))
             .Select(os => new OfferSubscriptionConnectorData(
                 os.Id,

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -1008,10 +1008,8 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetConnectorOfferSubscriptionData(null, new Guid("41fd2ab8-7123-4546-9bef-a388d91b2999")).ToListAsync();
 
         // Assert
-        result.Should().HaveCount(3)
+        result.Should().HaveCount(1)
             .And.Satisfy(
-                x => x.SubscriptionId == new Guid("014afd09-e51a-4ecf-83ab-a5380d9af832"),
-                x => x.SubscriptionId == new Guid("92be9d79-4064-422c-bdc8-a12ca7d26e5d"),
                 x => x.SubscriptionId == new Guid("ed6065b1-0902-4d5e-9470-33a716022a1a"));
     }
 
@@ -1025,7 +1023,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetConnectorOfferSubscriptionData(true, new Guid("41fd2ab8-7123-4546-9bef-a388d91b2999")).ToListAsync();
 
         // Assert
-        result.Should().HaveCount(2).And.AllSatisfy(x => x.ConnectorIds.Should().NotBeNullOrEmpty());
+        result.Should().HaveCount(1).And.AllSatisfy(x => x.ConnectorIds.Should().NotBeNullOrEmpty());
     }
 
     [Fact]
@@ -1038,7 +1036,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetConnectorOfferSubscriptionData(false, new Guid("41fd2ab8-7123-4546-9bef-a388d91b2999")).ToListAsync();
 
         // Assert
-        result.Should().HaveCount(1).And.AllSatisfy(x => x.ConnectorIds.Should().BeEmpty());
+        result.Should().HaveCount(0);
     }
 
     #endregion


### PR DESCRIPTION
## Description

Pending offer subscription is available to register the connector

## Why

Pending/requested subscription starts appearing the offers for managed connectors registration.
API: /api/administration/Connectors/offerSubscriptions?connectorIdSet=false

## Issue

Ref: #1417 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
