### PR TITLE
chore: update swagger in dotnet tools

### DIFF
--- a/src/administration/Administration.Service/.config/dotnet-tools.json
+++ b/src/administration/Administration.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "9.0.1",
+      "version": "9.0.3",
       "commands": [
         "swagger"
       ],

--- a/src/marketplace/Apps.Service/.config/dotnet-tools.json
+++ b/src/marketplace/Apps.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "9.0.1",
+      "version": "9.0.3",
       "commands": [
         "swagger"
       ],

--- a/src/marketplace/Services.Service/.config/dotnet-tools.json
+++ b/src/marketplace/Services.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "9.0.1",
+      "version": "9.0.3",
       "commands": [
         "swagger"
       ],

--- a/src/notifications/Notifications.Service/.config/dotnet-tools.json
+++ b/src/notifications/Notifications.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "9.0.1",
+      "version": "9.0.3",
       "commands": [
         "swagger"
       ],

--- a/src/registration/Registration.Service/.config/dotnet-tools.json
+++ b/src/registration/Registration.Service/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "9.0.1",
+      "version": "9.0.3",
       "commands": [
         "swagger"
       ],


### PR DESCRIPTION
## Description

update swagger in the dotnet tools which are used to generate the open api doc

## Why

To use the latest version of swagger for the open api doc generation

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
