### PR TITLE
fix(businessApps): Unsubscribed Apps are visible

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -174,6 +174,7 @@ public class OfferSubscriptionsRepository(PortalDbContext dbContext) : IOfferSub
             .SelectMany(user => user.Identity!.Company!.OfferSubscriptions.Where(subscription =>
                 subscription.Offer!.OfferTypeId == OfferTypeId.APP &&
                 subscription.Offer.UserRoles.Any(ur => ur.IdentityAssignedRoles.Any(iar => iar.IdentityId == userId)) &&
+                subscription.OfferSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE &&
                 subscription.AppSubscriptionDetail!.AppInstance != null &&
                 subscription.AppSubscriptionDetail.AppSubscriptionUrl != null))
             .Select(offerSubscription => new ValueTuple<Guid, Guid, string?, string, Guid, string>(


### PR DESCRIPTION
## Description

Unsubscribed Apps visible on the home page, under Business Applications section.

## Why

Unsubscribed Apps are visible.

## Issue

Ref: #1035

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that existing tests pass locally with my changes