### PR TITLE
fix: decentralized identity management auth url missing suffix

### DIFF
--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -795,7 +795,8 @@ public class OfferService(
         var data = await GetOfferSubscriptionDetailsInternal(offerId, subscriptionId, offerTypeId, contactUserRoles, OfferCompanyRole.Provider, portalRepositories.GetInstance<IOfferSubscriptionsRepository>().GetOfferSubscriptionDetailsForProviderAsync)
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
-        var authUrl = data.ExternalServiceData?.DecentralIdentityManagementServiceUrl;
+        var url = data.ExternalServiceData?.DecentralIdentityManagementServiceUrl;
+        var authUrl = url!.Contains("/oauth/token") ? url : $"{url}/oauth/token";
         var serviceUrl = walletData.DecentralIdentityManagementAuthUrl;
 
         return new OfferProviderSubscriptionDetailData(

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -795,8 +795,7 @@ public class OfferService(
         var data = await GetOfferSubscriptionDetailsInternal(offerId, subscriptionId, offerTypeId, contactUserRoles, OfferCompanyRole.Provider, portalRepositories.GetInstance<IOfferSubscriptionsRepository>().GetOfferSubscriptionDetailsForProviderAsync)
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
-        var url = data.ExternalServiceData?.DecentralIdentityManagementServiceUrl;
-        var authUrl = url!.Contains("/oauth/token") ? url : $"{url}/oauth/token";
+        var authUrl = data.ExternalServiceData?.DecentralIdentityManagementServiceUrl;
         var serviceUrl = walletData.DecentralIdentityManagementAuthUrl;
 
         return new OfferProviderSubscriptionDetailData(
@@ -816,7 +815,7 @@ public class OfferService(
                 data.ExternalServiceData?.ParticipantId,
                 data.ExternalServiceData == null || data.ExternalServiceData.TrustedIssuer.EndsWith(":holder-iatp") ? data.ExternalServiceData?.TrustedIssuer : $"{data.ExternalServiceData.TrustedIssuer}:holder-iatp",
                 walletData.BpnDidResolverUrl,
-                authUrl,
+                authUrl!.Contains("/oauth/token") ? authUrl : $"{authUrl}/oauth/token",
                 serviceUrl));
     }
 

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -2292,7 +2292,7 @@ public class OfferServiceTests
         result.AppInstanceId.Should().Be(data.AppInstanceId);
         result.OfferSubscriptionStatus.Should().Be(data.OfferSubscriptionStatus);
         result.ExternalService.DecentralIdentityManagementServiceUrl.Should().Be(walletData.DecentralIdentityManagementAuthUrl);
-        result.ExternalService.DecentralIdentityManagementAuthUrl.Should().Be(data.ExternalServiceData!.DecentralIdentityManagementServiceUrl);
+        result.ExternalService.DecentralIdentityManagementAuthUrl.Should().Be(data.ExternalServiceData!.DecentralIdentityManagementServiceUrl + "/oauth/token");
         A.CallTo(() => _userRolesRepository.GetUserRoleIdsUntrackedAsync(A<IEnumerable<UserRoleConfig>>.That.IsSameSequenceAs(companyAdminRoles)))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => _offerSubscriptionsRepository.GetOfferSubscriptionDetailsForProviderAsync(appId, subscriptionId, _companyId, OfferTypeId.APP, A<IEnumerable<Guid>>.That.IsSameSequenceAs(new[] { _validUserRoleId })))


### PR DESCRIPTION
## Description

Added Decentralized Identity Management Auth Url check and addition of "oauth/token" incase it does not exist. 

## Why

For users to access the Decentralized service, the auth url must contain "oauth/token" suffix. Incase the wallet is missing the suffix in the auth URL, portal will ensure the suffix is added. 

## Issue

#1424 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
