### PR TITLE
fix: add connector type check for validate technical user

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -206,8 +206,11 @@ public class ConnectorsBusinessLogic(
 
     private async Task ValidateTechnicalUser(ConnectorTypeId type, string name, Guid? technicalUserId, Guid companyId)
     {
-        if (technicalUserId == null && type == ConnectorTypeId.COMPANY_CONNECTOR)
+        if (technicalUserId == null)
         {
+            if (type != ConnectorTypeId.COMPANY_CONNECTOR)
+                return;
+
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER, [new ErrorParameter("name", name)]);
         }
 

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -206,14 +206,11 @@ public class ConnectorsBusinessLogic(
 
     private async Task ValidateTechnicalUser(ConnectorTypeId type, string name, Guid? technicalUserId, Guid companyId)
     {
-
-        if (type != ConnectorTypeId.COMPANY_CONNECTOR && technicalUserId == null)
-        {
-            return;
-        }
-
         if (technicalUserId == null)
         {
+            if (type != ConnectorTypeId.COMPANY_CONNECTOR)
+                return;
+
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER, [new ErrorParameter("name", name)]);
         }
 

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -206,11 +206,14 @@ public class ConnectorsBusinessLogic(
 
     private async Task ValidateTechnicalUser(ConnectorTypeId type, string name, Guid? technicalUserId, Guid companyId)
     {
+
+        if (type != ConnectorTypeId.COMPANY_CONNECTOR && technicalUserId == null)
+        {
+            return;
+        }
+
         if (technicalUserId == null)
         {
-            if (type != ConnectorTypeId.COMPANY_CONNECTOR)
-                return;
-
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER, [new ErrorParameter("name", name)]);
         }
 

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -125,7 +125,7 @@ public class ConnectorsBusinessLogic(
             throw UnexpectedConditionException.Create(AdministrationConnectorErrors.CONNECTOR_UNEXPECTED_NO_BPN_ASSIGNED, new ErrorParameter[] { new(nameof(companyId), companyId.ToString()) });
         }
 
-        await ValidateTechnicalUser(name, technicalUserId, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
+        await ValidateTechnicalUser(ConnectorTypeId.COMPANY_CONNECTOR, name, technicalUserId, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
 
         var connectorRequestModel = new ConnectorRequestModel(name, connectorUrl, ConnectorTypeId.COMPANY_CONNECTOR, location, companyId, companyId, technicalUserId);
         return await CreateAndRegisterConnectorAsync(
@@ -174,7 +174,7 @@ public class ConnectorsBusinessLogic(
             throw ConflictException.Create(AdministrationConnectorErrors.CONNECTOR_CONFLICT_SET_BPN, new ErrorParameter[] { new("companyId", result.CompanyId.ToString()) });
         }
 
-        await ValidateTechnicalUser(name, technicalUserId, result.CompanyId).ConfigureAwait(ConfigureAwaitOptions.None);
+        await ValidateTechnicalUser(ConnectorTypeId.CONNECTOR_AS_A_SERVICE, name, technicalUserId, result.CompanyId).ConfigureAwait(ConfigureAwaitOptions.None);
 
         var connectorRequestModel = new ConnectorRequestModel(name, connectorUrl, ConnectorTypeId.CONNECTOR_AS_A_SERVICE, location, companyId, result.CompanyId, technicalUserId);
         return await CreateAndRegisterConnectorAsync(
@@ -204,15 +204,15 @@ public class ConnectorsBusinessLogic(
         }
     }
 
-    private async Task ValidateTechnicalUser(string name, Guid? technicalUserId, Guid companyId)
+    private async Task ValidateTechnicalUser(ConnectorTypeId type, string name, Guid? technicalUserId, Guid companyId)
     {
-        if (technicalUserId == null)
+        if (technicalUserId == null && type == ConnectorTypeId.COMPANY_CONNECTOR)
         {
             throw ControllerArgumentException.Create(AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER, [new ErrorParameter("name", name)]);
         }
 
         var (activeUserExists, linkedToConnectorOrOffer) = await portalRepositories.GetInstance<ITechnicalUserRepository>()
-                .CheckTechnicalUserDetailsAsync(technicalUserId.Value, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
+                .CheckTechnicalUserDetailsAsync(technicalUserId!.Value, companyId).ConfigureAwait(ConfigureAwaitOptions.None);
 
         if (!activeUserExists)
         {

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -541,13 +541,13 @@ public class ConnectorsBusinessLogicTests
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task CreateManagedConnectorAsync_WithTechnicalUser_ReturnsCreatedConnectorData(bool clearingHouseDisabled)
+    [InlineData(true, "ac1cf001-7fbc-1f2f-817f-bce058020002")] // Valid technical user
+    [InlineData(false, null)]
+    public async Task CreateManagedConnectorAsync_WithTechnicalUser_ReturnsCreatedConnectorData(bool clearingHouseDisabled, string? technicalUserIdString)
     {
         // Arrange
-        var sa01 = Guid.NewGuid();
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, _validOfferSubscriptionId, sa01);
+        Guid? technicalUserId = technicalUserIdString != null ? Guid.Parse(technicalUserIdString) : null;
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, _validOfferSubscriptionId, technicalUserId);
         var sut = new ConnectorsBusinessLogic(_portalRepositories, Options.Create(new ConnectorsSettings
         {
             MaxPageSize = 15,


### PR DESCRIPTION
## Description

Added connector type check in validate technical user method for connector creation. 

## Why

A 400 error was being thrown when creating a managed connector. This was caused by the introduction of error handling when creating a connector without a technical user #1411 . The method that validates the technical user is shared in both the owned and managed connector creation function, this is problematic as the managed connector is created without the technical user. 

## Issue

#1426 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
