### PR TITLE
fix: Connector catalogue url validation

### DIFF
--- a/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
+++ b/src/administration/Administration.Service/ErrorHandling/AdministrationConnectorErrorMessageContainer.cs
@@ -46,7 +46,8 @@ public class AdministrationConnectorErrorMessageContainer : IErrorMessageContain
         new((int)AdministrationConnectorErrors.CONNECTOR_CONFLICT_INACTIVE_STATE,"Connector {connectorId} is in state {connectorStatusId}"),
         new((int)AdministrationConnectorErrors.CONNECTOR_DUPLICATE,"Connector {name} does already exists for url {connectorUrl}"),
         new((int)AdministrationConnectorErrors.CONNECTOR_ARGUMENT_TECH_USER_IN_USE,"Technical User {technicalUserId} is already used by another connector or offer"),
-        new((int)AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER,"Connector {name} must have a technical user")
+        new((int)AdministrationConnectorErrors.CONNECTOR_MISSING_TECH_USER,"Connector {name} must have a technical user"),
+        new((int)AdministrationConnectorErrors.CONNECTOR_INCORRECT_CATALOG_URL_FORMAT,"Connector catalog URL {catalogUrl} is incorrect. The URL must end with /api/v{n}/dsp")
     ]);
 
     public Type Type { get => typeof(AdministrationConnectorErrors); }
@@ -76,5 +77,6 @@ public enum AdministrationConnectorErrors
     CONNECTOR_CONFLICT_INACTIVE_STATE,
     CONNECTOR_DUPLICATE,
     CONNECTOR_ARGUMENT_TECH_USER_IN_USE,
-    CONNECTOR_MISSING_TECH_USER
+    CONNECTOR_MISSING_TECH_USER,
+    CONNECTOR_INCORRECT_CATALOG_URL_FORMAT
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -246,7 +246,7 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateConnectorAsync_WithoutTechnicalUser_ThrowsException()
     {
         // Arrange
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, null);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, null);
 
         // Act
         async Task Act() => await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
@@ -289,7 +289,7 @@ public class ConnectorsBusinessLogicTests
             ]
         }), _sdFactoryBusinessLogic, _identityService, _serviceAccountManagement, _dateTimeProvider, A.Fake<ILogger<ConnectorsBusinessLogic>>());
 
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, ServiceAccountUserId);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, ServiceAccountUserId);
 
         // Act
         var result = await sut.CreateConnectorAsync(connectorInput, CancellationToken.None);
@@ -311,7 +311,7 @@ public class ConnectorsBusinessLogicTests
         // Arrange
         A.CallTo(() => _connectorsRepository.CheckConnectorExists(A<string>._, A<string>._))
             .Returns(true);
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, ServiceAccountUserId);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, ServiceAccountUserId);
         Task Act() => _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
 
         // Act
@@ -329,7 +329,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var saId = Guid.NewGuid();
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, saId);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, saId);
 
         // Act
         async Task Act() => await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
@@ -352,7 +352,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var saId = Guid.NewGuid();
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", "de", saId);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", "de", saId);
         A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(saId, ValidCompanyId))
                   .Returns((true, true));
         // Act
@@ -373,7 +373,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var sa01 = Guid.NewGuid();
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, sa01);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, sa01);
 
         A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
         // Act
@@ -414,7 +414,7 @@ public class ConnectorsBusinessLogicTests
             ]
         }), _sdFactoryBusinessLogic, _identityService, _serviceAccountManagement, _dateTimeProvider, A.Fake<ILogger<ConnectorsBusinessLogic>>());
 
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, sa01);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, sa01);
         A.CallTo(() => _identity.CompanyId).Returns(CompanyIdWithoutSdDocument);
         A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
 
@@ -431,7 +431,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var sa01 = Guid.NewGuid();
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, sa01);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, sa01);
         A.CallTo(() => _identity.CompanyId).Returns(CompanyIdWithoutSdDocument);
         A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
         // Act
@@ -446,7 +446,7 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateConnectorAsync_WithInvalidLocation_ThrowsControllerArgumentException()
     {
         // Arrange
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", "invalid", null);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", "invalid", null);
 
         // Act
         async Task Act() => await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
@@ -460,7 +460,7 @@ public class ConnectorsBusinessLogicTests
     public async Task CreateConnectorAsync_WithCompanyWithoutBpn_ThrowsUnexpectedConditionException()
     {
         // Arrange
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, null);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, null);
         A.CallTo(() => _identity.CompanyId).Returns(CompanyWithoutBpnId);
 
         // Act
@@ -476,7 +476,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var sa01 = Guid.NewGuid();
-        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, sa01);
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, sa01);
         A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
 
         // Act
@@ -486,6 +486,21 @@ public class ConnectorsBusinessLogicTests
         result.Should().NotBeEmpty();
         _connectors.Should().HaveCount(1);
         A.CallTo(() => _connectorsRepository.CreateConnectorAssignedSubscriptions(A<Guid>._, A<Guid>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task CreateConnectorAsync_WithIncorrectCatalogUrl_ThrowsException()
+    {
+        // Arrange
+        var sa01 = Guid.NewGuid();
+        var connectorInput = new ConnectorInputModel("connectorName", "https://test.de", CountryCode_de, sa01);
+
+        // Act
+        async Task Act() => await _logic.CreateConnectorAsync(connectorInput, CancellationToken.None);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_INCORRECT_CATALOG_URL_FORMAT.ToString());
     }
 
     #endregion
@@ -525,7 +540,7 @@ public class ConnectorsBusinessLogicTests
             ]
         }), _sdFactoryBusinessLogic, _identityService, _serviceAccountManagement, _dateTimeProvider, A.Fake<ILogger<ConnectorsBusinessLogic>>());
 
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, _validOfferSubscriptionId, ServiceAccountUserId);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, _validOfferSubscriptionId, ServiceAccountUserId);
         SetupCheckActiveServiceAccountExistsForCompanyAsyncForManaged();
         // Act
         var result = await sut.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);
@@ -547,7 +562,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         Guid? technicalUserId = technicalUserIdString != null ? Guid.Parse(technicalUserIdString) : null;
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, _validOfferSubscriptionId, technicalUserId);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, _validOfferSubscriptionId, technicalUserId);
         var sut = new ConnectorsBusinessLogic(_portalRepositories, Options.Create(new ConnectorsSettings
         {
             MaxPageSize = 15,
@@ -592,7 +607,7 @@ public class ConnectorsBusinessLogicTests
         // Arrange
         A.CallTo(() => _connectorsRepository.CheckConnectorExists(A<string>._, A<string>._))
             .Returns(true);
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, _validOfferSubscriptionId, ServiceAccountUserId);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, _validOfferSubscriptionId, ServiceAccountUserId);
         Task Act() => _logic.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);
 
         // Act
@@ -612,7 +627,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var sa01 = Guid.NewGuid();
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", "invalid", _validOfferSubscriptionId, sa01);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", "invalid", _validOfferSubscriptionId, sa01);
 
         // Act
         async Task Act() => await _logic.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);
@@ -634,7 +649,7 @@ public class ConnectorsBusinessLogicTests
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
             .Returns((false, default, default, default, default, default, default));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, subscriptionId, sa01);
 
         SetupTechnicalIdentity();
 
@@ -654,7 +669,7 @@ public class ConnectorsBusinessLogicTests
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
             .Returns((true, false, default, default, default, default, default));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, subscriptionId, sa01);
 
         SetupTechnicalIdentity();
 
@@ -674,7 +689,7 @@ public class ConnectorsBusinessLogicTests
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
             .Returns((true, true, true, default, default, default, default));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, subscriptionId, sa01);
 
         SetupTechnicalIdentity();
 
@@ -694,7 +709,7 @@ public class ConnectorsBusinessLogicTests
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
             .Returns((true, true, false, OfferSubscriptionStatusId.INACTIVE, default, default, default));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, subscriptionId, sa01);
 
         SetupTechnicalIdentity();
 
@@ -714,7 +729,7 @@ public class ConnectorsBusinessLogicTests
         var subscriptionId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, A<Guid>.That.Matches(x => x == ValidCompanyId)))
             .Returns((true, true, false, OfferSubscriptionStatusId.ACTIVE, null, ValidCompanyId, ValidCompanyBpn));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, sa01);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, subscriptionId, sa01);
         A.CallTo(() => _technicalUserRepository.CheckTechnicalUserDetailsAsync(A<Guid>._, A<Guid>._)).Returns((true, false));
 
         // Act
@@ -733,7 +748,7 @@ public class ConnectorsBusinessLogicTests
         var companyId = Guid.NewGuid();
         A.CallTo(() => _offerSubscriptionRepository.CheckOfferSubscriptionWithOfferProvider(subscriptionId, ValidCompanyId))
             .Returns((true, true, false, OfferSubscriptionStatusId.ACTIVE, Guid.NewGuid(), companyId, null));
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, subscriptionId, null);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, subscriptionId, null);
 
         SetupTechnicalIdentity();
 
@@ -750,7 +765,7 @@ public class ConnectorsBusinessLogicTests
     {
         // Arrange
         var saId = Guid.NewGuid();
-        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, _validOfferSubscriptionId, saId);
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de/api/v1/dsp", CountryCode_de, _validOfferSubscriptionId, saId);
 
         // Act
         async Task Act() => await _logic.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);
@@ -766,6 +781,21 @@ public class ConnectorsBusinessLogicTests
           &&
           y.Value == HostCompanyId.ToString()
           );
+    }
+
+    [Fact]
+    public async Task CreateManagedConnectorAsync_WithIncorrectCatalogUrl_ThrowsException()
+    {
+        // Arrange
+        var saId = Guid.NewGuid();
+        var connectorInput = new ManagedConnectorInputModel("connectorName", "https://test.de", CountryCode_de, _validOfferSubscriptionId, saId);
+
+        // Act
+        async Task Act() => await _logic.CreateManagedConnectorAsync(connectorInput, CancellationToken.None);
+
+        // Assert
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+        ex.Message.Should().Be(AdministrationConnectorErrors.CONNECTOR_INCORRECT_CATALOG_URL_FORMAT.ToString());
     }
 
     #endregion
@@ -1232,7 +1262,7 @@ public class ConnectorsBusinessLogicTests
             .Returns<ConnectorUpdateInformation?>(null);
 
         // Act
-        async Task Act() => await _logic.UpdateConnectorUrl(connectorId, new ConnectorUpdateRequest("https://test.de"), CancellationToken.None);
+        async Task Act() => await _logic.UpdateConnectorUrl(connectorId, new ConnectorUpdateRequest("https://test.de/api/v1/dsp"), CancellationToken.None);
 
         // Assert
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
@@ -1245,13 +1275,13 @@ public class ConnectorsBusinessLogicTests
         // Arrange
         var connectorId = Guid.NewGuid();
         var data = _fixture.Build<ConnectorUpdateInformation>()
-            .With(x => x.ConnectorUrl, "https://test.de")
+            .With(x => x.ConnectorUrl, "https://test.de/api/v1/dsp")
             .Create();
         A.CallTo(() => _connectorsRepository.GetConnectorUpdateInformation(connectorId, _identity.CompanyId))
             .Returns(data);
 
         // Act
-        await _logic.UpdateConnectorUrl(connectorId, new ConnectorUpdateRequest("https://test.de"), CancellationToken.None);
+        await _logic.UpdateConnectorUrl(connectorId, new ConnectorUpdateRequest("https://test.de/api/v1/dsp"), CancellationToken.None);
 
         // Assert
         A.CallTo(() => _portalRepositories.SaveAsync()).MustNotHaveHappened();


### PR DESCRIPTION
## Description

- Added validation for own & managed connector catalog urls
- Validation to ensure catalog urls finish with "/api/v1/dsp" where v1 ca be v1 to vn*.

## Why

Previously, the connector catalogue url attribute of the /connectors/daps & connectors/managed POST endpoints allowed urls that did not follow the correct end structure of "/api/v1/dsp".

## Issue

#1449 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
