### PR TITLE
feat: CONTRIBUTION - Implementation of an endpoint to allow the d…

### DIFF
--- a/docs/api/administration-service.yaml
+++ b/docs/api/administration-service.yaml
@@ -3583,6 +3583,44 @@ paths:
           description: Internal Server Error
         '401':
           description: The User is unauthorized
+    patch:
+      tags:
+        - Registration
+      summary: 'Updates the Did Document for the wallet (Authorization required - Roles: store_didDocument)'
+      parameters:
+        - name: bpn
+          in: path
+          description: BusinessPartnerNumber for dim
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Did Document for updating
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DidDocumentData'
+      responses:
+        '204':
+          description: Empty response on success.
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: No application found for the bpn.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Either the CompanyApplication is not in status Confirmed or the Company is not ACTIVE or Wallet does not exist.
+        '500':
+          description: Internal Server Error
+        '401':
+          description: The User is unauthorized
   '/api/administration/registration/applications/{applicationId}/checklistDetails':
     get:
       tags:
@@ -7070,6 +7108,11 @@ components:
         - ASC
         - DESC
       type: string
+    DidDocumentData:
+      type: object
+      properties:
+        didDocument: { }
+      additionalProperties: false
     DimUrlsResponse:
       type: object
       properties:

--- a/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -66,6 +66,14 @@ public interface IRegistrationBusinessLogic
     Task ProcessDimResponseAsync(string bpn, DimWalletData data, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Updates Did Document for the wallet
+    /// </summary>
+    /// <param name="bpn">the companies business partner number</param>
+    /// <param name="data">Did Document Data</param>
+    /// <param name="cancellationToken"></param>
+    Task UpdateDidDocumentAsync(string bpn, DidDocumentData data, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Gets the checklist details for the given application
     /// </summary>
     /// <param name="applicationId">Id of the application</param>

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -611,6 +611,14 @@ public sealed class RegistrationBusinessLogic(
         return result.Single();
     }
 
+    public async Task UpdateDidDocumentAsync(string bpn, DidDocumentData data, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Update the did document data {Data}", data.DidDocument.RootElement.GetRawText().Replace(Environment.NewLine, string.Empty));
+
+        await dimBusinessLogic.UpdateDidDocument(bpn, data, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        await portalRepositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+    }
+
     public Task RetriggerDeleteIdpSharedRealm(Guid processId) => ProcessStepTypeId.RETRIGGER_DELETE_IDP_SHARED_REALM.TriggerProcessStep(processId, portalRepositories, ProcessTypeExtensions.GetProcessStepForRetrigger);
     public Task RetriggerDeleteIdpSharedServiceAccount(Guid processId) => ProcessStepTypeId.RETRIGGER_DELETE_IDP_SHARED_SERVICEACCOUNT.TriggerProcessStep(processId, portalRepositories, ProcessTypeExtensions.GetProcessStepForRetrigger);
     public Task RetriggerDeleteCentralIdentityProvider(Guid processId) => ProcessStepTypeId.RETRIGGER_DELETE_CENTRAL_IDENTITY_PROVIDER.TriggerProcessStep(processId, portalRepositories, ProcessTypeExtensions.GetProcessStepForRetrigger);

--- a/src/administration/Administration.Service/Controllers/RegistrationController.cs
+++ b/src/administration/Administration.Service/Controllers/RegistrationController.cs
@@ -212,6 +212,29 @@ public class RegistrationController(IRegistrationBusinessLogic logic)
     }
 
     /// <summary>
+    /// Updates the Did Document for the wallet
+    /// </summary>
+    /// <param name="bpn">BusinessPartnerNumber for dim</param>
+    /// <param name="didDocumentData">Did Document for updating</param>
+    /// <param name="cancellationToken">Cancellation Token</param>
+    /// <returns>NoContent</returns>
+    /// Example: PATCH: api/administration/registration/dim/{bpn}
+    /// <response code="204">Empty response on success.</response>
+    /// <response code="404">No application found for the bpn.</response>
+    /// <response code="409">Either the CompanyApplication is not in status Confirmed or the Company is not ACTIVE or Wallet does not exist.</response>
+    [HttpPatch]
+    [Authorize(Roles = "store_didDocument")]
+    [Route("dim/{bpn}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    public async Task<NoContentResult> UpdateDidDocument([FromRoute] string bpn, [FromBody] DidDocumentData didDocumentData, CancellationToken cancellationToken)
+    {
+        await logic.UpdateDidDocumentAsync(bpn, didDocumentData, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        return NoContent();
+    }
+
+    /// <summary>
     /// Gets the information of an applications checklist
     /// </summary>
     /// <param name="applicationId">Id of the application the checklist should be provided for</param>

--- a/src/externalsystems/Dim.Library/BusinessLogic/IDimBusinessLogic.cs
+++ b/src/externalsystems/Dim.Library/BusinessLogic/IDimBusinessLogic.cs
@@ -33,5 +33,8 @@ public interface IDimBusinessLogic
     Task<IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult> CreateDimWalletAsync(IApplicationChecklistService.WorkerChecklistProcessStepData context, CancellationToken cancellationToken);
 
     Task ProcessDimResponse(string bpn, DimWalletData data, CancellationToken cancellationToken);
+
+    Task UpdateDidDocument(string bpn, DidDocumentData data, CancellationToken cancellationToken);
+
     Task<IApplicationChecklistService.WorkerChecklistProcessStepExecutionResult> ValidateDidDocument(IApplicationChecklistService.WorkerChecklistProcessStepData context, CancellationToken cancellationToken);
 }

--- a/src/externalsystems/Dim.Library/Models/WalletData.cs
+++ b/src/externalsystems/Dim.Library/Models/WalletData.cs
@@ -33,3 +33,7 @@ public record AuthenticationDetail(
     [property: JsonPropertyName("clientID")] string ClientId,
     [property: JsonPropertyName("clientSecret")] string ClientSecret
 );
+
+public record DidDocumentData(
+    [property: JsonPropertyName("didDocument")] JsonDocument DidDocument
+);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -175,8 +175,10 @@ public interface ICompanyRepository
     OnboardingServiceProviderDetail CreateOnboardingServiceProviderDetails(Guid companyId, string callbackUrl, string authUrl, string clientId, byte[] clientSecret, byte[]? initializationVector, int encryptionMode);
     Task<bool> CheckBpnExists(string bpn);
     void CreateWalletData(Guid companyId, string did, JsonDocument didDocument, string clientId, byte[] clientSecret, byte[]? initializationVector, int encryptionMode, string authenticationServiceUrl);
+    void AttachAndModifyWalletData(Guid walletId, Action<CompanyWalletData>? initialize, Action<CompanyWalletData> modify);
     Task<(bool Exists, JsonDocument DidDocument)> GetDidDocumentById(string bpn);
     IAsyncEnumerable<(Guid CompanyId, IEnumerable<Guid> SubmittedApplicationIds)> GetCompanySubmittedApplicationIdsByBpn(string bpn);
+    Task<Guid> GetCopmanyActiveWalletId(string bpn);
     Task<(string? Bpn, string? Did, string? WalletUrl)> GetDimServiceUrls(Guid companyId);
     Task<(string? Holder, string? BusinessPartnerNumber, WalletInformation? WalletInformation)> GetWalletData(Guid identityId);
     void RemoveProviderCompanyDetails(Guid providerCompanyDetailId);

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyWalletData.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyWalletData.cs
@@ -41,7 +41,7 @@ public class CompanyWalletData : IBaseEntity
 
     public Guid CompanyId { get; private set; }
 
-    public string Did { get; private set; }
+    public string Did { get; set; }
 
     public string ClientId { get; private set; }
 
@@ -49,10 +49,10 @@ public class CompanyWalletData : IBaseEntity
     public byte[]? InitializationVector { get; set; }
     public int EncryptionMode { get; set; }
 
-    public string AuthenticationServiceUrl { get; private set; }
+    public string AuthenticationServiceUrl { get; set; }
 
-    public virtual JsonDocument DidDocument { get; private set; }
+    public virtual JsonDocument DidDocument { get; set; }
 
     // Navigation properties
-    public virtual Company? Company { get; private set; }
+    public virtual Company? Company { get; set; }
 }

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -1369,4 +1369,24 @@ public class RegistrationBusinessLogicTest
     }
 
     #endregion
+
+    #region UpdateDidDocument
+
+    [Fact]
+    public async Task UpdateDidDocumentAsync_WithValidData_CallsExpected()
+    {
+        // Arrange
+        var data = new DidDocumentData(_fixture.Create<JsonDocument>());
+
+        // Act
+        await _logic.UpdateDidDocumentAsync(BusinessPartnerNumber, data, CancellationToken.None);
+
+        // Assert
+        A.CallTo(() => _dimBusinessLogic.UpdateDidDocument(BusinessPartnerNumber, data, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _portalRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
+    }
+
+    #endregion
+
 }

--- a/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
@@ -409,4 +409,17 @@ public class RegistrationControllerTest
         A.CallTo(() => _logic.TriggerChecklistAsync(applicationId, ApplicationChecklistEntryTypeId.APPLICATION_ACTIVATION, ProcessStepTypeId.RETRIGGER_SET_CX_MEMBERSHIP_IN_BPDM)).MustHaveHappenedOnceExactly();
         result.Should().BeOfType<NoContentResult>();
     }
+
+    [Fact]
+    public async Task UpdateDidDocument_WithValidData_ReturnsOk()
+    {
+        //Arrange
+        var data = _fixture.Create<DidDocumentData>();
+
+        //Act
+        await _controller.UpdateDidDocument("bpn", data, CancellationToken.None);
+
+        //Assert
+        A.CallTo(() => _logic.UpdateDidDocumentAsync("bpn", data, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
 }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/companies.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/companies.unittest.json
@@ -89,5 +89,17 @@
     "company_status_id": 1,
     "address_id": "27418031-d6b5-442b-8802-3f653c6679f7",
     "self_description_document_id": null
+  },
+  {
+    "id": "3dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "date_created": "2022-03-24 18:01:33.438000 +00:00",
+    "business_partner_number": "BPNL0000000DIDUP",
+    "name": "DCP Company",
+    "shortname": "DCP Company",
+    "company_status_id": 2,
+    "address_id": "27418031-d6b5-442b-8802-3f653c6679f7",
+    "self_description_document_id": null
   }
+
+  
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_applications.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_applications.unittest.json
@@ -48,5 +48,15 @@
     "checklist_process_id": "0187aba6-a66e-4fe5-9519-c4254a4a63d8",
     "company_application_type_id": 1,
     "last_editor_id": null
+  },
+  {
+    "id": "368980ef-1365-45b5-b588-148be852c674",
+    "date_created": "2023-11-06 10:01:33.439000 +00:00",
+    "date_last_changed": "2023-11-06 10:01:33.439000 +00:00",
+    "application_status_id": 8,
+    "company_id": "3dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "checklist_process_id": "98309fbf-6350-467a-a3ae-c92ed357c3fb",
+    "company_application_type_id": 1,
+    "last_editor_id": null
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_assigned_roles.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_assigned_roles.unittest.json
@@ -46,5 +46,13 @@
   {
     "company_id": "729e0af2-6723-4a7f-85a1-833d84b39bdf",
     "company_role_id": 3
+  },
+  {
+    "company_id": "3dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "company_role_id": 2
+  },
+  {
+    "company_id": "3dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "company_role_id": 3
   }
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_wallet_data.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/company_wallet_data.unittest.json
@@ -9,5 +9,17 @@
     "initialization_vector": null,
     "encryption_mode": 0,
     "authentication_service_url": "https://example.org/auth"
-  }
+  },
+  {
+      "id": "ac17d2a4-3bf8-4d78-906f-b96aeddddfd1",
+      "company_id": "3dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+      "did": "did:web:test",
+      "did_document": {},
+      "client_id": "cl1",
+      "client_secret": "",
+      "initialization_vector": null,
+      "encryption_mode": 0,
+      "authentication_service_url": "https://example.org/auth"
+    }
+  
 ]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/processes.unittest.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/processes.unittest.json
@@ -72,6 +72,12 @@
     "version" : "deadbeef-dead-beef-dead-beefdeadbeef"
   },
   {
+    "id": "98309fbf-6350-467a-a3ae-c92ed357c3fb",
+    "process_type_id" : 1,
+    "lock_expiry_date" : "2023-03-01 00:00:00.000000 +00:00",
+    "version" : "deadbeef-dead-beef-dead-beefdeadbeef"
+  },
+  {
     "id": "70f0f368-5058-4aca-808b-cece869bcef2",
     "process_type_id" : 6,
     "lock_expiry_date" : "2023-03-01 00:00:00.000000 +00:00",


### PR DESCRIPTION
…id document to be updated (#165)

## Description

Updating DID document requires manual DB manipulation currently. Desired outcome is to have DID document updates without manual intervention
## Why

Currently, Portal Backend does not allow Wallet Integration Layer component to update existing DID Documents. This leads to manual intervention in case of DID document has any kind of change.

With this feature, we want to enable DID document update without manual intervention.

## Issue

[Link to Github issue #1500.](https://github.com/eclipse-tractusx/sig-release/issues/1500)

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
