### PR TITLE
fix(techUser): Deleting wallet tech user via callback from SAP

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/TechnicalUserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/TechnicalUserBusinessLogic.cs
@@ -410,7 +410,7 @@ public class TechnicalUserBusinessLogic(
     {
         var processData = await portalRepositories.GetInstance<ITechnicalUserRepository>()
             .GetProcessDataForTechnicalUserDeletionCallback(processId,
-                [ProcessStepTypeId.AWAIT_CREATE_DIM_TECHNICAL_USER_RESPONSE])
+                [ProcessStepTypeId.AWAIT_DELETE_DIM_TECHNICAL_USER_RESPONSE])
             .ConfigureAwait(ConfigureAwaitOptions.None);
 
         var context = processData.ProcessData.CreateManualProcessData(ProcessStepTypeId.AWAIT_DELETE_DIM_TECHNICAL_USER_RESPONSE,


### PR DESCRIPTION
## Description

Deleted Technical User (Wallet) remain in pending state.

## Why

Currently, Technical User of Identity wallet type remain in pending state forever post deletion.

<img width="1621" height="89" alt="image" src="https://github.com/user-attachments/assets/3e113815-574b-462a-9032-877e7a6d35cf" />

## Issue

Ref: #1471 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that existing tests pass locally with my changes
