### PR TITLE
fix(appAccessManagement): Show user list as per the subscription

### DIFF
--- a/docs/api/administration-service.yaml
+++ b/docs/api/administration-service.yaml
@@ -6146,7 +6146,7 @@ paths:
           description: Internal Server Error
         '401':
           description: The User is unauthorized
-  '/api/administration/user/owncompany/apps/{appId}/users':
+  '/api/administration/user/owncompany/apps/{appId}/subscription/{subscriptionId}/users':
     get:
       tags:
         - User
@@ -6156,6 +6156,13 @@ paths:
         - name: appId
           in: path
           description: Get company app users by appId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: subscriptionId
+          in: path
+          description: Get company app users by appId and subscriptionId
           required: true
           schema:
             type: string

--- a/src/administration/Administration.Service/BusinessLogic/IUserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IUserBusinessLogic.cs
@@ -45,6 +45,6 @@ public interface IUserBusinessLogic
     Task<int> DeleteOwnUserAsync(Guid companyUserId);
     IAsyncEnumerable<Guid> DeleteOwnCompanyUsersAsync(IEnumerable<Guid> userIds);
     Task<bool> ExecuteOwnCompanyUserPasswordReset(Guid companyUserId);
-    Task<Pagination.Response<CompanyAppUserDetails>> GetOwnCompanyAppUsersAsync(Guid appId, int page, int size, CompanyUserFilter filter);
+    Task<Pagination.Response<CompanyAppUserDetails>> GetOwnCompanyAppUsersAsync(Guid appId, Guid subscriptionId, int page, int size, CompanyUserFilter filter);
     Task<int> DeleteOwnUserBusinessPartnerNumbersAsync(Guid userId, string businessPartnerNumber);
 }

--- a/src/administration/Administration.Service/BusinessLogic/UserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserBusinessLogic.cs
@@ -564,13 +564,14 @@ public class UserBusinessLogic(
         throw new NotFoundException($"Cannot identify companyId or shared idp : userId {companyUserId} is not associated with admin users company {_identityData.CompanyId}");
     }
 
-    public Task<Pagination.Response<CompanyAppUserDetails>> GetOwnCompanyAppUsersAsync(Guid appId, int page, int size, CompanyUserFilter filter) =>
+    public Task<Pagination.Response<CompanyAppUserDetails>> GetOwnCompanyAppUsersAsync(Guid appId, Guid subscriptionId, int page, int size, CompanyUserFilter filter) =>
         Pagination.CreateResponseAsync(
             page,
             size,
             15,
             portalRepositories.GetInstance<IUserRepository>().GetOwnCompanyAppUsersPaginationSourceAsync(
                 appId,
+                subscriptionId,
                 _identityData.IdentityId,
                 new[] { OfferSubscriptionStatusId.ACTIVE },
                 new[] { UserStatusId.ACTIVE, UserStatusId.INACTIVE },

--- a/src/administration/Administration.Service/Controllers/UserController.cs
+++ b/src/administration/Administration.Service/Controllers/UserController.cs
@@ -430,6 +430,7 @@ public class UserController : ControllerBase
     /// Get for given app id all the company assigned users
     /// </summary>
     /// <param name="appId">Get company app users by appId</param>
+    /// <param name="subscriptionId">Get company app users by appId and subscriptionId</param>
     /// <param name="page">page index start from 0</param>
     /// <param name="size">size to get number of records</param>
     /// <param name="firstName">First Name of User</param>
@@ -443,10 +444,11 @@ public class UserController : ControllerBase
     [HttpGet]
     [Authorize(Roles = "view_user_management")]
     [Authorize(Policy = PolicyTypes.ValidIdentity)]
-    [Route("owncompany/apps/{appId}/users")]
+    [Route("owncompany/apps/{appId}/subscription/{subscriptionId}/users")]
     [ProducesResponseType(typeof(Pagination.Response<CompanyAppUserDetails>), StatusCodes.Status200OK)]
     public Task<Pagination.Response<CompanyAppUserDetails>> GetCompanyAppUsersAsync(
         [FromRoute] Guid appId,
+        [FromRoute] Guid subscriptionId,
         [FromQuery] int page = 0,
         [FromQuery] int size = 15,
         [FromQuery] string? firstName = null,
@@ -456,6 +458,7 @@ public class UserController : ControllerBase
         [FromQuery] bool? hasRole = null) =>
         _logic.GetOwnCompanyAppUsersAsync(
             appId,
+            subscriptionId,
             page,
             size,
             new CompanyUserFilter(

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
@@ -81,7 +81,7 @@ public interface IUserRepository
 
     IAsyncEnumerable<Guid> GetServiceProviderCompanyUserWithRoleIdAsync(Guid offerId, IEnumerable<Guid> userRoleIds);
 
-    Func<int, int, Task<Pagination.Source<CompanyAppUserDetails>?>> GetOwnCompanyAppUsersPaginationSourceAsync(Guid appId, Guid companyUserId, IEnumerable<OfferSubscriptionStatusId> subscriptionStatusIds, IEnumerable<UserStatusId> companyUserStatusIds, CompanyUserFilter filter);
+    Func<int, int, Task<Pagination.Source<CompanyAppUserDetails>?>> GetOwnCompanyAppUsersPaginationSourceAsync(Guid appId, Guid subscriptionId, Guid companyUserId, IEnumerable<OfferSubscriptionStatusId> subscriptionStatusIds, IEnumerable<UserStatusId> companyUserStatusIds, CompanyUserFilter filter);
 
     /// <summary>
     /// User account data for deletion of own userId

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -354,6 +354,7 @@ public class UserRepository : IUserRepository
 
     public Func<int, int, Task<Pagination.Source<CompanyAppUserDetails>?>> GetOwnCompanyAppUsersPaginationSourceAsync(
         Guid appId,
+        Guid subscriptionId,
         Guid companyUserId,
         IEnumerable<OfferSubscriptionStatusId> subscriptionStatusIds,
         IEnumerable<UserStatusId> companyUserStatusIds,
@@ -373,8 +374,8 @@ public class UserRepository : IUserRepository
                     (lastName == null || EF.Functions.ILike(companyUser.Lastname!, $"%{lastName.EscapeForILike()}%")) &&
                     (email == null || EF.Functions.ILike(companyUser.Email!, $"%{email.EscapeForILike()}%")) &&
                     (roleName == null || companyUser.Identity!.IdentityAssignedRoles.Any(userRole => userRole.UserRole!.OfferId == appId && EF.Functions.ILike(userRole.UserRole!.UserRoleText, $"%{roleName.EscapeForILike()}%"))) &&
-                    (!hasRole.HasValue || !hasRole.Value || companyUser.Identity!.IdentityAssignedRoles.Any(userRole => userRole.UserRole!.OfferId == appId)) &&
-                    (!hasRole.HasValue || hasRole.Value || companyUser.Identity!.IdentityAssignedRoles.All(userRole => userRole.UserRole!.OfferId != appId)) &&
+                    (!hasRole.HasValue || !hasRole.Value || companyUser.Identity!.IdentityAssignedRoles.Any(userRole => userRole.OfferSubscriptionId == subscriptionId)) &&
+                    (!hasRole.HasValue || hasRole.Value || companyUser.Identity!.IdentityAssignedRoles.All(userRole => userRole.OfferSubscriptionId != subscriptionId)) &&
                     companyUserStatusIds.Contains(companyUser.Identity!.UserStatusId))
                 .GroupBy(companyUser => companyUser.Identity!.CompanyId),
             null,

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/UserBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/UserBusinessLogicTests.cs
@@ -1188,17 +1188,19 @@ public class UserBusinessLogicTests
     {
         // Arrange
         var appId = _fixture.Create<Guid>();
+        var subscriptionId = _fixture.Create<Guid>();
         var userId = Guid.NewGuid();
         var companyUsers = _fixture.CreateMany<CompanyAppUserDetails>(5);
         A.CallTo(() => _identity.IdentityId).Returns(userId);
 
-        A.CallTo(() => _userRepository.GetOwnCompanyAppUsersPaginationSourceAsync(A<Guid>._, A<Guid>._, A<IEnumerable<OfferSubscriptionStatusId>>._, A<IEnumerable<UserStatusId>>._, A<CompanyUserFilter>._))
+        A.CallTo(() => _userRepository.GetOwnCompanyAppUsersPaginationSourceAsync(A<Guid>._, A<Guid>._, A<Guid>._, A<IEnumerable<OfferSubscriptionStatusId>>._, A<IEnumerable<UserStatusId>>._, A<CompanyUserFilter>._))
             .Returns((skip, take) => Task.FromResult<Pagination.Source<CompanyAppUserDetails>?>(new Pagination.Source<CompanyAppUserDetails>(companyUsers.Count(), companyUsers.Skip(skip).Take(take))));
         var sut = new UserBusinessLogic(null!, null!, null!, null!, _portalRepositories, _identityService, null!, null!, null!, A.Fake<IOptions<UserSettings>>());
 
         // Act
         var results = await sut.GetOwnCompanyAppUsersAsync(
             appId,
+            subscriptionId,
             0,
             10,
             new CompanyUserFilter(null, null, null, null, null));
@@ -1213,17 +1215,19 @@ public class UserBusinessLogicTests
     {
         // Arrange
         var appId = _fixture.Create<Guid>();
+        var subscriptionId = _fixture.Create<Guid>();
         var userId = Guid.NewGuid();
         var companyUsers = _fixture.CreateMany<CompanyAppUserDetails>(5);
         A.CallTo(() => _identity.IdentityId).Returns(userId);
 
-        A.CallTo(() => _userRepository.GetOwnCompanyAppUsersPaginationSourceAsync(A<Guid>._, A<Guid>._, A<IEnumerable<OfferSubscriptionStatusId>>._, A<IEnumerable<UserStatusId>>._, A<CompanyUserFilter>._))
+        A.CallTo(() => _userRepository.GetOwnCompanyAppUsersPaginationSourceAsync(A<Guid>._, A<Guid>._, A<Guid>._, A<IEnumerable<OfferSubscriptionStatusId>>._, A<IEnumerable<UserStatusId>>._, A<CompanyUserFilter>._))
             .Returns((skip, take) => Task.FromResult<Pagination.Source<CompanyAppUserDetails>?>(new Pagination.Source<CompanyAppUserDetails>(companyUsers.Count(), companyUsers.Skip(skip).Take(take))));
         var sut = new UserBusinessLogic(null!, null!, null!, null!, _portalRepositories, _identityService, null!, null!, null!, A.Fake<IOptions<UserSettings>>());
 
         // Act
         var results = await sut.GetOwnCompanyAppUsersAsync(
             appId,
+            subscriptionId,
             1,
             3,
             new CompanyUserFilter(null, null, null, null, null));

--- a/tests/administration/Administration.Service.Tests/Controllers/UserControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/UserControllerTest.cs
@@ -284,14 +284,15 @@ public class UserControllerTest
         //Arrange
         var paginationResponse = new Pagination.Response<CompanyAppUserDetails>(new Pagination.Metadata(15, 1, 1, 15), _fixture.CreateMany<CompanyAppUserDetails>(5));
         var appId = Guid.NewGuid();
-        A.CallTo(() => _logic.GetOwnCompanyAppUsersAsync(appId, 0, 15, new(null, null, null, null, null)))
+        var subscriptionId = Guid.NewGuid();
+        A.CallTo(() => _logic.GetOwnCompanyAppUsersAsync(appId, subscriptionId, 0, 15, new(null, null, null, null, null)))
             .Returns(paginationResponse);
 
         // Act
-        var result = await _controller.GetCompanyAppUsersAsync(appId, 0, 15);
+        var result = await _controller.GetCompanyAppUsersAsync(appId, subscriptionId, 0, 15);
 
         // Assert
-        A.CallTo(() => _logic.GetOwnCompanyAppUsersAsync(appId, 0, 15, new(null, null, null, null, null))).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _logic.GetOwnCompanyAppUsersAsync(appId, subscriptionId, 0, 15, new(null, null, null, null, null))).MustHaveHappenedOnceExactly();
         result.Content.Should().HaveCount(5);
     }
 

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryTests.cs
@@ -37,6 +37,7 @@ public class UserRepositoryTests : IAssemblyFixture<TestDbFixture>
     private const string ValidUserCompanyId = "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87";
     private readonly Guid _validCompanyUser = new(ValidCompanyUserTxt);
     private readonly Guid _validOfferId = new("ac1cf001-7fbc-1f2f-817f-bce0572c0007");
+    private readonly Guid _validOfferSubscriptionId = new("ed4de48d-fd4b-4384-a72f-ecae3c6cc5ba");
 
     public UserRepositoryTests(TestDbFixture testDbFixture)
     {
@@ -59,6 +60,7 @@ public class UserRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Act
         var result = await sut.GetOwnCompanyAppUsersPaginationSourceAsync(
             _validOfferId,
+            _validOfferSubscriptionId,
             _validCompanyUser,
             new[] { OfferSubscriptionStatusId.ACTIVE },
             new[] { UserStatusId.ACTIVE, UserStatusId.INACTIVE },
@@ -78,6 +80,7 @@ public class UserRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Act
         var result = await sut.GetOwnCompanyAppUsersPaginationSourceAsync(
             _validOfferId,
+            _validOfferSubscriptionId,
             _validCompanyUser,
             new[] { OfferSubscriptionStatusId.ACTIVE },
             new[] { UserStatusId.INACTIVE },
@@ -97,6 +100,7 @@ public class UserRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Act
         var result = await sut.GetOwnCompanyAppUsersPaginationSourceAsync(
             _validOfferId,
+            _validOfferSubscriptionId,
             _validCompanyUser,
             new[] { OfferSubscriptionStatusId.ACTIVE },
             new[] { UserStatusId.ACTIVE, UserStatusId.INACTIVE, UserStatusId.DELETED },
@@ -116,6 +120,7 @@ public class UserRepositoryTests : IAssemblyFixture<TestDbFixture>
         // Act
         var result = await sut.GetOwnCompanyAppUsersPaginationSourceAsync(
             _validOfferId,
+            _validOfferSubscriptionId,
             Guid.NewGuid(),
             new[] { OfferSubscriptionStatusId.ACTIVE },
             new[] { UserStatusId.ACTIVE, UserStatusId.INACTIVE },


### PR DESCRIPTION
## Description

Show user list as per the subscription

## Why

User is not available to assign more roles via another subscription

## Issue

Ref: #1497

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
